### PR TITLE
aligned mmap/munmap

### DIFF
--- a/km/km_mmap.c
+++ b/km/km_mmap.c
@@ -73,6 +73,9 @@ mmap_check_params(km_gva_t addr, size_t size, int prot, int flags, int fd, off_t
    if (addr != 0 || fd != -1 || offset != 0 || flags & MAP_FIXED) {
       return -EINVAL;
    }
+   if (size % KM_PAGE_SIZE != 0) {
+      return -EINVAL;
+   }
    return 0;
 }
 
@@ -263,6 +266,7 @@ int km_guest_munmap(km_gva_t addr, size_t size)
    km_gva_t head_start, tail_start;
    size_t head_size, tail_size;
 
+   size = roundup(size, KM_PAGE_SIZE);
    mmaps_lock();
    if (size == 0 || (reg = km_mmap_find_busy(addr)) == NULL || (addr + size > reg->start + reg->size)) {
       mmaps_unlock();

--- a/tests/mmap_test.c
+++ b/tests/mmap_test.c
@@ -68,10 +68,11 @@ static mmap_test_t _36_tests[] = {
     {"Basic-munmap2", TYPE_MUNMAP, 0, 1020 * MIB, 0, 0},
     {"Swiss cheese-mmap", TYPE_MMAP, 0, 760 * MIB, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS},
     {"Swiss cheese-munmap1", TYPE_MUNMAP, 500 * MIB, 260 * MIB, 0, 0},
-    {"Swiss cheese-munmap2", TYPE_MUNMAP, 0, 300 * MIB, 0, 0},
+    {"Swiss cheese-unaligned-munmap2", TYPE_MUNMAP, 0, 300 * MIB - 256, 0, 0},
     {"Swiss cheese-munmap3", TYPE_MUNMAP, 300 * MIB, 200 * MIB, 0, 0},
 
     {"Wrong-args-mmap", TYPE_MMAP, 0x20000ul, 8 * MIB, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, EINVAL},
+    {"Wrong-args-mmap", TYPE_MMAP, 0, 8 * MIB + 256, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, EINVAL},
     {"Wrong-args-munmap", TYPE_MUNMAP, 0x20000ul, 1 * MIB, 0, 0, EINVAL},
     {"Basic-munmap-dup1", TYPE_MUNMAP, 0, 8 * MIB, 0, 0, EINVAL},
     {"Basic-munmap-dup2", TYPE_MUNMAP, 0, 6 * MIB, 0, 0, EINVAL},


### PR DESCRIPTION
check and reject mmap requests for unaligned sizes. roundup size on munmap