### PR TITLE
downgrade init time memory messages

### DIFF
--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -513,7 +513,7 @@ void km_machine_init(km_machine_init_params_t* params)
       }
    }
    if (machine.guest_max_physmem > GUEST_MAX_PHYSMEM_SUPPORTED) {
-      warnx("Scaling down guest max phys mem to %#lx from %#lx",
+      km_infox(KM_TRACE_MEM, "Scaling down guest max phys mem to %#lx from %#lx",
             GUEST_MAX_PHYSMEM_SUPPORTED,
             machine.guest_max_physmem);
       machine.guest_max_physmem = GUEST_MAX_PHYSMEM_SUPPORTED;
@@ -524,7 +524,7 @@ void km_machine_init(km_machine_init_params_t* params)
        * text+data, and the second for the stack. See assert() in
        * set_pml4_hierarchy()
        */
-      warnx("KVM: 1gb pages are not supported (pdpe1g=0), setting VM max mem to 2 GiB");
+      km_infox(KM_TRACE_MEM, "KVM: 1gb pages are not supported (pdpe1g=0), setting VM max mem to 2 GiB");
       machine.guest_max_physmem = MIN(2 * GIB, machine.guest_max_physmem);
    }
    if (params->guest_physmem != 0) {


### PR DESCRIPTION
These adjustments 'just work'. No need to pollute output.