### PR TITLE
Added non-zero time test print and fixed comparison in -V test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -54,7 +54,11 @@ ifeq (${MAKECMDGOALS},.coverage)
 else
 	@export KM_BIN=$(KM_BIN); export TIME_INFO=${TIME_INFO};  ${BATS} -p -f "${MATCH}" ${TEST_FILES}
 endif
-	@echo -e "${GREEN}Detailed time info is in $(abspath ${TIME_INFO}) ${NOCOLOR}"
+	@echo -e "${GREEN}Non-zero time tests:${NOCOLOR}"
+	@grep elapsed ${TIME_INFO} | grep -v "elapsed 0:00.00" | sort -r
+	@echo ""
+	@rm -f ${TIME_INFO}
+
 
 %.km: %.o
 	${CC} ${LDFLAGS} $< -o $@ ${KM_LDFLAGS}

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -36,7 +36,7 @@ timeout=60s
 
 # this is how we invoke KM - with a timeout
 function km_with_timeout () {
-   /usr/bin/time -f="elapsed %E user %U system %S mem %M KiB (km $*) " \
+   /usr/bin/time -f "elapsed %E user %U system %S mem %M KiB (km $*) " \
       -a -o $TIME_INFO timeout --foreground $timeout ${KM_BIN} $*
 }
 
@@ -102,37 +102,37 @@ teardown() {
 
 @test "km_main: optargs (hello_test)" {
    # -v flag prints version and branch
-   run ${KM_BIN} -v  hello_test.km
+   run km_with_timeout -v  hello_test.km
    [ $status -eq 0 ]
    branch=$(git rev-parse --abbrev-ref  HEAD)
    [ $(echo -e "$output" | grep -F -cw "$branch") == 1 ]
 
-   run ${KM_BIN} -Vkvm  hello_test.km
+   run km_with_timeout -Vkvm  hello_test.km
    # -V<regex> turns on tracing for a subsystem. Check it for kvm
    [ $status -eq 0 ]
-   [ $(echo -e "$output" | grep -F -cw "KVM_EXIT_IO") > 1 ]
+   [ $(echo -e "$output" | grep -F -cw "KVM_EXIT_IO") -gt 1 ]
 
    # -g[port] turns on gdb and tested in gdb coverage. Let's validate a failure case
-   run ${KM_BIN} -gfoobar  hello_test.km
+   run km_with_timeout -gfoobar  hello_test.km
    [ $status -eq 1 ]
    [ $(echo -e "$output" | grep -F -cw "Wrong gdb port number") == 1 ]
 
    # -C sets coredump file name
    corefile=/tmp/km$$
-   run ${KM_BIN} -Vcoredump -C $corefile hello_test.km
+   run km_with_timeout -Vcoredump -C $corefile hello_test.km
    [ $status -eq 0 ]
    [ $(echo -e "$output" | grep -F -cw "Setting coredump path to $corefile") == 1 ]
 
    # -P sets Physical memory bus width
-   run ${KM_BIN} -P 31   hello_test.km
+   run km_with_timeout -P 31   hello_test.km
    [ $status -eq 1 ]
    [ $(echo -e "$output" | grep -F -cw "Guest memory bus width must be between 32 and 63") == 1 ]
 
-   run ${KM_BIN} -P32 hello_test.km
+   run km_with_timeout -P32 hello_test.km
    [ $status -eq 0 ]
 
    # invalid option
-   run ${KM_BIN} -X
+   run km_with_timeout -X
    [ $status -eq 1 ]
       [ $(echo -e "$output" | grep -F -cw "invalid option") == 1 ]
 


### PR DESCRIPTION
Now after successful test pass prints something like this 
```
real    1m22.140s
user    0m8.723s
sys     1m15.179s
Non-zero time tests:
elapsed 0:42.85 user 0.00 system 42.54 mem 2020 KiB (km --overcommit-memory brk_test.km) 
elapsed 0:20.87 user 0.13 system 20.73 mem 2108 KiB (km mem_test.km) 
elapsed 0:08.21 user 0.86 system 7.30 mem 3153932 KiB (km mmap_test.km) 
elapsed 0:03.93 user 4.73 system 2.98 mem 2216 KiB (km mutex_test.km) 
elapsed 0:00.57 user 0.00 system 0.00 mem 2104 KiB (km -g gdb_test.km) 
elapsed 0:00.51 user 0.00 system 0.00 mem 2112 KiB (km hello_html_test.km) 
elapsed 0:00.44 user 1.19 system 0.00 mem 2076 KiB (km exit_grp_test.km) 
elapsed 0:00.07 user 0.04 system 0.12 mem 2112 KiB (km hello_2_loops_test.km) 
elapsed 0:00.07 user 0.03 system 0.12 mem 2024 KiB (km hello_2_loops_tls_test.km) 
elapsed 0:00.04 user 0.00 system 0.02 mem 52712 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km stray) 
elapsed 0:00.04 user 0.00 system 0.02 mem 52712 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km div0) 
elapsed 0:00.03 user 0.00 system 0.02 mem 52720 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km ud) 
elapsed 0:00.03 user 0.00 system 0.02 mem 52720 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km hc) 
elapsed 0:00.03 user 0.00 system 0.02 mem 52648 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km prot) 
elapsed 0:00.03 user 0.00 system 0.02 mem 52648 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km abort) 
elapsed 0:00.02 user 0.00 system 0.02 mem 52652 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km signal) 
elapsed 0:00.02 user 0.00 system 0.02 mem 52652 KiB (km --coredump=/tmp/kmcore.16453 stray_test.km quit) 
```
