### PR TITLE
simplified gva_to_kma using contiguos guest memory allocation

### DIFF
--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -161,12 +161,13 @@ typedef struct km_builtin_tls {
  * For the main thread, going from the top of the allocated stack area down, we place Thread Control
  * Block (TCB, km_pthread_t), then TLS, then dtv. All with the appropriate alignment derived either
  * from structure packing (MIN_TLS_ALIGN) or coming from TLS extend in ELF. Below dtv for main
- * thread we put the argv built from the args, and then goes the initial top of the stack.
+ * thread we put dummy (empty) AUXV and environ, the argv built from the args, and then goes the
+ * initial top of the stack.
  *
  * For the subsequent threads on the very top goes fixed size TSD area. Below that goes TCB, then
  * TLS, then dtv, and the initial top of the stack, again all appropriately alligned.
  *
- * TODO: There are other guest structures, such as __environ, __hwcap, __sysinfo, __progname and so
+ * TODO: There are other guest structures, such as __hwcap, __sysinfo, __progname and so
  * on, we will need to process them as well most likely.
  */
 void km_init_libc_main(km_vcpu_t* vcpu, int argc, char* const argv[])

--- a/km/km_mem.c
+++ b/km/km_mem.c
@@ -152,14 +152,6 @@ static const uint64_t PDPTE_REGION = GIB;
 static const uint64_t PDE_REGION = 2 * MIB;
 
 /*
- * Memory readions that become guest physical memory are allocated using mmap() with specified
- * address, so that contiguous guest physical memory becomes contiguos in KM space as well. We
- * randomly choose to start guest memory allocation from 0x100000000000, which happens to be 16TB.
- * It has an advantage of being numerically the guest physical addresses with bit 0x100000000000 set.
- */
-static km_kma_t KM_USER_MEM_BASE = (void*)0x100000000000ul;   // 16TiB
-
-/*
  * Slot number in PDE table for gva '_addr'.
  * Logically: (__addr % PDPTE_REGION) / PDE_REGION
  */
@@ -509,7 +501,7 @@ km_gva_t km_mem_brk(km_gva_t brk)
    }
    km_mem_lock();
 
-   // Keep brk and tbrk out if the same 1 GIB region.
+   // Keep brk and tbrk out of the same 1 GIB region.
    if (rounddown(gva_to_gpa(brk), PDPTE_REGION) >= rounddown(gva_to_gpa(machine.tbrk), PDPTE_REGION)) {
       km_mem_unlock();
       return -ENOMEM;

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -53,7 +53,7 @@ static void load_extent(int fd, const GElf_Phdr* phdr)
     * ``. = SEGMENT_START("text-segment", 0x400000) + SIZEOF_HEADERS;'' and later
     * ``. = ALIGN(CONSTANT (MAXPAGESIZE));''
     * which adds that page. Normally that page contains program headers and build-if. The former
-    * doesn't apply to us as we are statically linked, so the space is just waisted. --build-id=none
+    * doesn't apply to us as we are statically linked, so the space is just wasted. --build-id=none
     * removes the latter, so the page simply stay empty, and first loadable segment starts at 2MB as
     * we want.
     *
@@ -61,7 +61,7 @@ static void load_extent(int fd, const GElf_Phdr* phdr)
     */
    assert(top >= GUEST_MEM_START_VA);
 
-   /* Extent memory if neccesary */
+   /* Extent memory if necessary */
    if (top >= km_mem_brk(0)) {
       if (km_mem_brk(top) != top) {
          err(2, "No memory to load elf");


### PR DESCRIPTION
No need to look into region structures any more - gva and kma simply differ by constant.