### PR TITLE
Fix malformed commands in the `make distroclean`

### DIFF
--- a/make/distro.mk
+++ b/make/distro.mk
@@ -56,7 +56,7 @@ distro: all
 	@echo -e "Docker image(s) created: \n$(GREEN)`docker image ls $(PAYLOAD_IMAGE_NAME) --format '{{.Repository}}:{{.Tag}} Size: {{.Size}} sha: {{.ID}}'`$(NOCOLOR)"
 
 distroclean:
-	docker rmi -f ${PAYLOAD_BRANCH} ${PAYLOAD_LATEST}
+	-docker rmi -f ${PAYLOAD_BRANCH} ${PAYLOAD_LATEST}
 
 publish:
 	@echo Tagging and pushing to Docker registry as ${PUBLISH_TAG}.


### PR DESCRIPTION
`make distroclean` commands is malformed. PAYLOAD_VARIABLE did not have a closing "}"