### PR TITLE
Do not pass --device=/dev/kvm to docker build unless testing [TRIVIAL]

### DIFF
--- a/make/actions.mk
+++ b/make/actions.mk
@@ -176,9 +176,13 @@ DFILE := Dockerfile.$(DTYPE)
 # 'chmod' in the last line is needed to enable 'make clean' to work without docker
 #    (since docker-produced files are owned by the container user, which is root by default)
 #
+__testing := $(strip $(findstring test,$(TARGET)) $(findstring coverage,$(TARGET)))
+ifneq ($(__testing),)  # only add --device=/dev/kvm is we are testing
+ DEVICE_KVM := --device=/dev/kvm
+endif
 withdocker: ## Build in docker. 'make withdocker [TARGET=clean] [DTYPE=ubuntu]'
 	docker build --build-arg=UID=$(shell id -u) --build-arg=GID=$(shell id -g) -t ${DIMG} ${DLOC} -f ${DLOC}/${DFILE}
-	docker run --device=/dev/kvm --rm -v $(realpath ${TOP}):/src:Z -w /src/${FROMTOP} $(DIMG) $(MAKE) MAKEFLAGS="$(MAKEFLAGS)" $(TARGET)
+	docker run $(DEVICE_KVM) --rm -v $(realpath ${TOP}):/src:Z -w /src/${FROMTOP} $(DIMG) $(MAKE) MAKEFLAGS="$(MAKEFLAGS)" $(TARGET)
 
 #
 # 'Help' target - based on '##' comments in targets


### PR DESCRIPTION
This should simplify build withdocker on CI/CD, and macs, and the like

Tested: manually:
```
[msterin@dacha km]$ make -n withdocker TARGET=test | grep /dev/kvm
docker run --device=/dev/kvm --rm -v /home/msterin/workspace/km:/src:Z -w /src/ km-buildenv-fedora make MAKEFLAGS="n -- TARGET=test" test
[msterin@dacha km]$ make -n withdocker TARGET=test-all | grep /dev/kvm
docker run --device=/dev/kvm --rm -v /home/msterin/workspace/km:/src:Z -w /src/ km-buildenv-fedora make MAKEFLAGS="n -- TARGET=test-all" test-all
[msterin@dacha km]$ make -n withdocker TARGET=coverage | grep /dev/kvm
docker run --device=/dev/kvm --rm -v /home/msterin/workspace/km:/src:Z -w /src/ km-buildenv-fedora make MAKEFLAGS="n -- TARGET=coverage" coverage
[msterin@dacha km]$ make -n withdocker TARGET=all | grep /dev/kvm
[msterin@dacha km]$ make -n withdocker  | grep /dev/kvm
[msterin@dacha km]$ 
```
