### PR TITLE
Issue #9 - avoid loading non-km elfs to KM

### DIFF
--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -180,9 +180,7 @@ void km_init_libc_main(km_vcpu_t* vcpu, int argc, char* const argv[])
    km_gva_t dtv;
    km_gva_t map_base;
 
-   if (km_guest.km_handlers == 0) {
-      errx(1, "Bad binary - cannot find interrupt handler");
-   }
+   assert(km_guest.km_handlers != 0);
    km_init_guest_idt(km_guest.km_handlers);
    if ((map_base = km_guest_mmap_simple(GUEST_STACK_SIZE)) < 0) {
       err(1, "Failed to allocate memory for main stack");
@@ -312,9 +310,7 @@ km_pthread_init(const km_pthread_attr_t* restrict g_attr, km_vcpu_t* vcpu, km_gv
    uintptr_t* dtv_kma;
    km_gva_t dtv;
 
-   if (km_guest.km_tsd_size == 0) {
-      errx(1, "Bad binary - cannot find __pthread_tsd_size");
-   }
+   assert(km_guest.km_tsd_size != 0);
    tsd_size = *(size_t*)km_gva_to_kma(km_guest.km_tsd_size);
    assert(tsd_size <= sizeof(void*) * PTHREAD_KEYS_MAX &&
           tsd_size == rounddown(tsd_size, sizeof(void*)));

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -182,18 +182,15 @@ int km_load_elf(const char* file)
             if (sym.st_info == ELF64_ST_INFO(STB_GLOBAL, STT_OBJECT) &&
                 strcmp(elf_strptr(e, shdr.sh_link, sym.st_name), KM_LIBC_SYM_NAME) == 0) {
                km_guest.km_libc = sym.st_value;
-            }
-            if (sym.st_info == ELF64_ST_INFO(STB_GLOBAL, STT_FUNC) &&
-                strcmp(elf_strptr(e, shdr.sh_link, sym.st_name), KM_INT_HNDL_SYM_NAME) == 0) {
+            } else if (sym.st_info == ELF64_ST_INFO(STB_GLOBAL, STT_FUNC) &&
+                       strcmp(elf_strptr(e, shdr.sh_link, sym.st_name), KM_INT_HNDL_SYM_NAME) == 0) {
                km_guest.km_handlers = sym.st_value;
-            }
-            if ((sym.st_info == ELF64_ST_INFO(STB_GLOBAL, STT_OBJECT) ||
-                 sym.st_info == ELF64_ST_INFO(STB_WEAK, STT_OBJECT)) &&
-                strcmp(elf_strptr(e, shdr.sh_link, sym.st_name), KM_TSD_SIZE_SYM_NAME) == 0) {
+            } else if ((sym.st_info == ELF64_ST_INFO(STB_GLOBAL, STT_OBJECT) ||
+                        sym.st_info == ELF64_ST_INFO(STB_WEAK, STT_OBJECT)) &&
+                       strcmp(elf_strptr(e, shdr.sh_link, sym.st_name), KM_TSD_SIZE_SYM_NAME) == 0) {
                km_guest.km_tsd_size = sym.st_value;
-            }
-            if (sym.st_info == ELF64_ST_INFO(STB_GLOBAL, STT_FUNC) &&
-                strcmp(elf_strptr(e, shdr.sh_link, sym.st_name), KM_SIG_RTRN_SYM_NAME) == 0) {
+            } else if (sym.st_info == ELF64_ST_INFO(STB_GLOBAL, STT_FUNC) &&
+                       strcmp(elf_strptr(e, shdr.sh_link, sym.st_name), KM_SIG_RTRN_SYM_NAME) == 0) {
                km_guest.km_sigreturn = sym.st_value;
             }
             if (km_guest.km_libc != 0 && km_guest.km_handlers != 0 && km_guest.km_tsd_size != 0 &&
@@ -203,6 +200,14 @@ int km_load_elf(const char* file)
          }
          break;
       }
+   }
+   if (km_guest.km_handlers == 0 || km_guest.km_tsd_size == 0 || km_guest.km_sigreturn == 0) {
+      errx(1,
+           "Non-KM binary: cannot find interrupt handler%s, tsd size%s, or sigreturn%s. Trying to "
+           "run regular Linux executable in KM?",
+           km_guest.km_handlers == 0 ? "(*)" : "",
+           km_guest.km_tsd_size == 0 ? "(*)" : "",
+           km_guest.km_sigreturn == 0 ? "(*)" : "");
    }
    (void)elf_end(e);
    (void)close(fd);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -102,18 +102,18 @@ teardown() {
 
 @test "km_main: optargs (hello_test)" {
    # -v flag prints version and branch
-   run km_with_timeout -v  hello_test.km
+   run km_with_timeout -v hello_test.km
    [ $status -eq 0 ]
    branch=$(git rev-parse --abbrev-ref  HEAD)
    [ $(echo -e "$output" | grep -F -cw "$branch") == 1 ]
 
-   run km_with_timeout -Vkvm  hello_test.km
+   run km_with_timeout -Vkvm hello_test.km
    # -V<regex> turns on tracing for a subsystem. Check it for kvm
    [ $status -eq 0 ]
    [ $(echo -e "$output" | grep -F -cw "KVM_EXIT_IO") -gt 1 ]
 
    # -g[port] turns on gdb and tested in gdb coverage. Let's validate a failure case
-   run km_with_timeout -gfoobar  hello_test.km
+   run km_with_timeout -gfoobar hello_test.km
    [ $status -eq 1 ]
    [ $(echo -e "$output" | grep -F -cw "Wrong gdb port number") == 1 ]
 
@@ -124,7 +124,7 @@ teardown() {
    [ $(echo -e "$output" | grep -F -cw "Setting coredump path to $corefile") == 1 ]
 
    # -P sets Physical memory bus width
-   run km_with_timeout -P 31   hello_test.km
+   run km_with_timeout -P 31 hello_test.km
    [ $status -eq 1 ]
    [ $(echo -e "$output" | grep -F -cw "Guest memory bus width must be between 32 and 63") == 1 ]
 
@@ -136,6 +136,10 @@ teardown() {
    [ $status -eq 1 ]
       [ $(echo -e "$output" | grep -F -cw "invalid option") == 1 ]
 
+   # Linux executable instead of .km
+   run km_with_timeout hello_test
+   [ $status -eq 0 ]
+      [ $(echo -e "$output" | grep -F -cw "regular Linux executable in KM") == 1 ]
 }
 
 @test "mem_slots: KVM memslot / phys mem sizes (memslot_test)" {
@@ -223,7 +227,7 @@ teardown() {
    [ $(echo "$output" | grep -F -cw 'received signal SIGUSR1') == 1 ]
    [ $(echo "$output" | grep -F -cw 'received signal SIGABRT') == 1 ]
    # check that KM exited normally
-   run wait $gdb_pid 
+   run wait $gdb_pid
    [ $status -eq 6 ]
 }
 


### PR DESCRIPTION
load_elf to check for KM specific parts of .km executable and error out. Fixes issue #9