### PR TITLE
mprotect memory according to brk/tbrk - issue #77

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -185,6 +185,7 @@
             "var_storage_test",
             "exit_value_test",
             "hello_test",
+            "mprotect_test",
             "hello_html_test",
             "hello_loop_test",
             "hello_2_loops_test",

--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -103,7 +103,7 @@ void km_machine_fini(void)
          if (ioctl(machine.mach_fd, KVM_SET_USER_MEMORY_REGION, mr) < 0) {
             warn("KVM: failed to unplug memory region %d", i);
          }
-         km_page_free((void*)mr->userspace_addr, mem_siz);
+         km_guest_page_free(mr->guest_phys_addr, mem_siz);
          mr->userspace_addr = 0;
       }
    }
@@ -513,9 +513,10 @@ void km_machine_init(km_machine_init_params_t* params)
       }
    }
    if (machine.guest_max_physmem > GUEST_MAX_PHYSMEM_SUPPORTED) {
-      km_infox(KM_TRACE_MEM, "Scaling down guest max phys mem to %#lx from %#lx",
-            GUEST_MAX_PHYSMEM_SUPPORTED,
-            machine.guest_max_physmem);
+      km_infox(KM_TRACE_MEM,
+               "Scaling down guest max phys mem to %#lx from %#lx",
+               GUEST_MAX_PHYSMEM_SUPPORTED,
+               machine.guest_max_physmem);
       machine.guest_max_physmem = GUEST_MAX_PHYSMEM_SUPPORTED;
    }
    if (machine.pdpe1g == 0) {
@@ -524,7 +525,8 @@ void km_machine_init(km_machine_init_params_t* params)
        * text+data, and the second for the stack. See assert() in
        * set_pml4_hierarchy()
        */
-      km_infox(KM_TRACE_MEM, "KVM: 1gb pages are not supported (pdpe1g=0), setting VM max mem to 2 GiB");
+      km_infox(KM_TRACE_MEM,
+               "KVM: 1gb pages are not supported (pdpe1g=0), setting VM max mem to 2 GiB");
       machine.guest_max_physmem = MIN(2 * GIB, machine.guest_max_physmem);
    }
    if (params->guest_physmem != 0) {

--- a/km/km_mem.h
+++ b/km/km_mem.h
@@ -181,17 +181,22 @@ static inline uint64_t memreg_size(int idx)
  * @param gva Guest virtual address
  * @returns Address in KM. returns NULL if guest VA is invalid.
  */
+static inline km_kma_t km_gva_to_kma_nocheck(km_gva_t gva)
+{
+   return KM_USER_MEM_BASE + gva_to_gpa(gva);
+}
+
 static inline km_kma_t km_gva_to_kma(km_gva_t gva)
 {
    if (gva < GUEST_MEM_START_VA || (machine.brk <= gva && gva < machine.tbrk) ||
        GUEST_MEM_TOP_VA < gva) {
       return NULL;
    }
-   return KM_USER_MEM_BASE + gva_to_gpa(gva);
+   return km_gva_to_kma_nocheck(gva);
 }
 
 void km_mem_init(km_machine_init_params_t* params);
-void km_page_free(void* addr, size_t size);
+void km_guest_page_free(km_gva_t addr, size_t size);
 void km_guest_mmap_init(void);
 km_gva_t km_mem_brk(km_gva_t brk);
 km_gva_t km_mem_tbrk(km_gva_t tbrk);

--- a/runtime/syscall_km.c
+++ b/runtime/syscall_km.c
@@ -1,6 +1,6 @@
 #include "km_hcalls.h"
 
-int __syscall(long n, long a1, long a2, long a3, long a4, long a5, long a6)
+unsigned long __syscall(long n, long a1, long a2, long a3, long a4, long a5, long a6)
 {
    km_hc_args_t arg;
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,7 +18,7 @@ SRC = hello_test.c hello_html_test.c brk_test.c mmap_test.c gdb_test.c exit_valu
 		load_test.c  hello_loop_test.c hello_2_loops_test.c memslot_test.c mutex_test.c futex_test.c \
 		getline_test.c mem_test.c exit_grp_test.c intr_test.c brk_map_test.c crash_test.c cpuid_test.c \
 		longjmp_test.c cpuid_print_details_test.c stray_test.c signal_test.c hello_2_loops_tls_test.c \
-		regions_test.c
+		regions_test.c mprotect_test.c
 
 SRC_CPP = var_storage_test.cpp throw_basic_test.cpp
 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -223,13 +223,18 @@ teardown() {
    [ $(echo "$output" | grep -F -cw 'received signal SIGUSR1') == 1 ]
    [ $(echo "$output" | grep -F -cw 'received signal SIGABRT') == 1 ]
    # check that KM exited normally
-   run wait $gdb_pid 
+   run wait $gdb_pid
    [ $status -eq 6 ]
 }
 
-@test "threads_basic: basic threads create, TSD, exit and join (hello_2_loops_test)" {
-   run km_with_timeout hello_2_loops_test.km
-   [ "$status" -eq 0 ]
+@test "Unused memory protection: check that unused memory is protected (mprotect_test)" {
+   core=/tmp/kmcore$$
+   run km_with_timeout -C $core mprotect_test.km
+   [ $status -eq 11 ]
+   [[  $(gdb -q mprotect_test.km $core -ex=bt -ex=q | grep -F -cw 'error: Cannot access memory at address 0x620000') == 1 ]]
+   rm $core
+   run km_with_timeout mprotect_test.km -w
+   [ $status -eq 1 ]
 }
 
 @test "threads_basic: threads with TLS, create, exit and join (hello_2_loops_tls_test)" {

--- a/tests/mprotect_test.c
+++ b/tests/mprotect_test.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2019 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ *
+ * Test reaching out above brk to see if mprotect catches it.
+ * No arg - access to memory above brk in the code
+ * -w arg - access to memory above brk using write syscall
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+
+static char pad[0x400000] = " padding";
+void inline IGUR()
+{
+} /* Ignore GCC Unused Result */
+
+int main(int argc, char** argv)
+{
+   int c;
+   int wr = 0;
+   char* ptr = (char*)0x620000;   // 2MB start + 4MB pad + a little bit (less than 1MB) for code
+
+   while ((c = getopt(argc, argv, "w")) != -1) {
+      switch (c) {
+         case 'w':
+            wr = 1;
+            break;
+      }
+   }
+
+   if (wr != 0) {
+      if (write(1, ptr, 1024) < 0 && errno == EFAULT) {
+         exit(1);
+      }
+      IGUR(write(1, pad, 1024));   // to keep pad in
+   } else {
+      printf("%s", ptr);
+   }
+   exit(0);
+}


### PR DESCRIPTION
mprotect memory according to brk/tbrk
add test for mprotect between brk and tbrk
fix syscall return

fixes  #77