### PR TITLE
__syscall_cp return ;long' not 'int'

### DIFF
--- a/runtime/syscall_cp_km.c
+++ b/runtime/syscall_cp_km.c
@@ -1,6 +1,6 @@
 #include "km_hcalls.h"
 
-int __syscall_cp(long n, long a1, long a2, long a3, long a4, long a5, long a6)
+long __syscall_cp(long n, long a1, long a2, long a3, long a4, long a5, long a6)
 {
    km_hc_args_t arg;
 


### PR DESCRIPTION
Fix a test failure seen by myself and Eric.