### PR TITLE
add missing files for new musl, needed for python

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -23,9 +23,10 @@ SKIP_SRC_DIR := $(addprefix $(SRCDIR)src/, ipc ldso mq process sched)
 SRC_DIRS := $(filter-out $(addsuffix /,${SKIP_SRC_DIR}), $(wildcard $(addprefix $(SRCDIR),src/*/)))
 
 KM_REPLACED_SRCS := syscall.s __libc_start_main.c __init_tls.c pthread_create.c pthread_join.c uname.c getenv.c \
-					__reset_tls.c
+					__reset_tls.c preadv.c pwritev.c fcntl.c
 KM_EXTRA_SRCS := start_c_km.c syscall_km.c pthread_create_km.c pthread_exit_km.c pthread_join_km.c \
-					uname_km.c runtime_stub_km.c chk_stub_km.c cxa_thread_atexit_km.c getenv_km.c x86_sigaction.s
+					uname_km.c runtime_stub_km.c chk_stub_km.c cxa_thread_atexit_km.c getenv_km.c x86_sigaction.s \
+					preadv_km.c pwritev_km.c fcntl_km.c
 
 KM_PTHREAD_OBJS := pthread_cond_broadcast.o pthread_cond_destroy.o pthread_cond_signal.o pthread_cond_wait.o \
 						 pthread_create_km.o pthread_detach.o pthread_getspecific.o pthread_join_km.o pthread_key_create.o \

--- a/runtime/fcntl_km.c
+++ b/runtime/fcntl_km.c
@@ -1,0 +1,3 @@
+#include "musl/src/fcntl/fcntl.c"
+
+weak_alias(fcntl, fcntl64);

--- a/runtime/preadv_km.c
+++ b/runtime/preadv_km.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <sys/uio.h>
+#include "syscall.h"
+
+ssize_t preadv(int fd, const struct iovec* iov, int count, off_t ofs)
+{
+   return syscall_cp(SYS_preadv, fd, iov, count, (long)(ofs), (long)(ofs >> 32));
+}
+
+weak_alias(preadv, preadv64);
+weak_alias(preadv, preadv64v2);

--- a/runtime/pwritev_km.c
+++ b/runtime/pwritev_km.c
@@ -1,0 +1,12 @@
+#define _BSD_SOURCE
+#include <unistd.h>
+#include <sys/uio.h>
+#include "syscall.h"
+
+ssize_t pwritev(int fd, const struct iovec* iov, int count, off_t ofs)
+{
+   return syscall_cp(SYS_pwritev, fd, iov, count, (long)(ofs), (long)(ofs >> 32));
+}
+
+weak_alias(pwritev, pwritev64);
+weak_alias(pwritev, pwritev64v2);


### PR DESCRIPTION
Python links with this, but when I run unittests.py it gives a bunch of
`km: Guest Fault: type:14 (Page Fault) --> signal:11 (Segmentation fault)`
`km: Guest Fault: type:14 (Page Fault) --> signal:11 (Segmentation fault)`
`...`

I assume this is because of mprotect, but we need to check