### PR TITLE
forward SIGPIPE to guest

### DIFF
--- a/km/km_gdb.h
+++ b/km/km_gdb.h
@@ -107,6 +107,11 @@ static inline void km_gdb_vcpu_set(km_vcpu_t* vcpu)
    gdbstub.gdb_vcpu = vcpu;
 }
 
+static inline int km_fd_is_gdb(int fd)
+{
+   return (fd == gdbstub.sock_fd);
+}
+
 extern int km_gdb_wait_for_connect(const char* image_name);
 extern void km_gdb_main_loop(km_vcpu_t* main_vcpu);
 extern void km_gdb_fini(int ret);

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -58,9 +58,9 @@
 #include "km_mem.h"
 #include "km_signal.h"
 
-gdbstub_info_t gdbstub;          // GDB global info
-#define BUFMAX (16 * 1024)       // buffer for gdb protocol
-static char in_buffer[BUFMAX];   // TODO: malloc/free these two
+gdbstub_info_t gdbstub = {.sock_fd = -1};   // GDB global info
+#define BUFMAX (16 * 1024)                  // buffer for gdb protocol
+static char in_buffer[BUFMAX];              // TODO: malloc/free these two
 static unsigned char registers[BUFMAX];
 
 #define GDB_ERROR_MSG "E01"   // The actual error code is ignored by GDB, so any number will do

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -660,6 +660,13 @@ static km_hc_ret_t epoll_pwait_hcall(void* vcpu, int hc, km_hc_args_t* arg, int*
    return HC_CONTINUE;
 }
 
+static km_hc_ret_t pipe_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
+{
+   // int pipe2(int pipefd[2], int flags);
+   arg->hc_ret = __syscall_1(hc, km_gva_to_kml(arg->arg1));
+   return HC_CONTINUE;
+}
+
 static km_hc_ret_t pipe2_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int pipe2(int pipefd[2], int flags);
@@ -744,6 +751,7 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_epoll_pwait] = epoll_pwait_hcall;
    km_hcalls_table[SYS_dup] = dup_hcall;
    km_hcalls_table[SYS_dup3] = dup3_hcall;
+   km_hcalls_table[SYS_pipe] = pipe_hcall;
    km_hcalls_table[SYS_pipe2] = pipe2_hcall;
    km_hcalls_table[SYS_eventfd2] = eventfd2_hcall;
    km_hcalls_table[SYS_prlimit64] = prlimit64_hcall;

--- a/km/km_signal.h
+++ b/km/km_signal.h
@@ -13,6 +13,7 @@
 #ifndef __KM_SIGNAL_H__
 #define __KM_SIGNAL_H__
 
+#include <signal.h>
 #include <sys/signalfd.h>
 #include "km.h"
 
@@ -32,8 +33,8 @@ uint64_t km_tkill(km_vcpu_t* vcpu, pid_t tid, int signo);
 uint64_t km_rt_sigpending(km_vcpu_t* vcpu, km_sigset_t* set, size_t sigsetsize);
 
 extern void km_wait_for_signal(int sig);
-typedef void (*sa_handler_t)(int);
-extern void km_install_sighandler(int signum, sa_handler_t hander_func);
+typedef void (*sa_action_t)(int, siginfo_t*, void*);
+extern void km_install_sighandler(int signum, sa_action_t hander_func);
 
 static inline int km_sigindex(int signo)
 {

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -415,6 +415,12 @@ teardown() {
    [  -f ${CORE} ]
    gdb --ex=bt --ex=q stray_test.km ${CORE} | grep -F 'stray_reference ('
    rm -f ${CORE}
+
+   # ensure that the guest can ignore a SIGPIPE.
+   [ ! -f ${CORE} ]
+   run km_with_timeout --coredump=${CORE} stray_test.km sigpipe
+   [ $status -eq 0 ]  # should succeed
+   [ ! -f ${CORE} ]
 }
 
 @test "signals: signals in the guest (signals)" {


### PR DESCRIPTION
New test case generates a SIGPIPE and ensures it can be ignored by the guest.

It is safe to unconditionally forward SIGPIPE (IMO). Other signals will take more thought,