### PR TITLE
Fixed stupid 'concat busy' bug - forgot to refresh 'last' pointer

### DIFF
--- a/km/gdb/list.gdb
+++ b/km/gdb/list.gdb
@@ -38,9 +38,9 @@ if $argc == 0
    set $count = 1
    while $item != 0
       set $distance = $item->start - $last_end
-      printf "%3d start= 0x%lx size = %ld MiB (%ld) prot 0x%x distance %d MiB (%ld)\n", \
+      printf "%3d start= 0x%lx size = %ld MiB (%ld) prot 0x%x flags 0x%x distance %d MiB (%ld)\n", \
                $count, $item->start, $item->size/(1024ul*1024ul), \
-               $item->size, $item->protection,$distance/ (1024ul*1024ul), $distance
+               $item->size, $item->protection, $item->flags, $distance/ (1024ul*1024ul), $distance
       set $count++
       set $last_end = $item->start + $item->size
       set $item=$item->link->tqe_next

--- a/km/km_mmap.c
+++ b/km/km_mmap.c
@@ -230,16 +230,13 @@ static inline void km_mmap_busy_collapse(void)
 {
    km_mmap_reg_t *reg, *next, *last = NULL;
    TAILQ_FOREACH_SAFE (reg, &mmaps.busy, link, next) {
-      if (last == NULL) {
-         last = reg;
-         continue;
-      }
-      if (last->start + last->size == reg->start && last->flags == reg->flags &&
+      if (last != NULL && last->start + last->size == reg->start && last->flags == reg->flags &&
           last->protection == reg->protection) {
          last->size += reg->size;
          TAILQ_REMOVE(&mmaps.busy, reg, link);
          free(reg);
       }
+      last = reg;
    }
 }
 /*

--- a/tests/mprotect_test.c
+++ b/tests/mprotect_test.c
@@ -244,6 +244,33 @@ TEST complex_test()
    PASS();
 }
 
+// helper to test glue
+TEST concat_test()
+{
+   static mmap_test_t mprotect_tests[] = {
+       {"1. mmap", TYPE_MMAP, 0, 1 * MIB, PROT_NONE, flags, OK},
+       {"2. mmap", TYPE_MMAP, 0, 2 * MIB, PROT_NONE, flags, OK},
+       {"3. mmap", TYPE_MMAP, 0, 3 * MIB, PROT_NONE, flags, OK},
+       {"4. mmap", TYPE_MMAP, 0, 4 * MIB, PROT_NONE, flags, OK},
+       {"5. mmap", TYPE_MMAP, 0, 5 * MIB, PROT_NONE, flags, OK},
+       {"6. mprotect", TYPE_MPROTECT, 1 * MIB, 1 * MIB, PROT_READ, flags, OK},
+       {"7. mprotect", TYPE_MPROTECT, 2 * MIB, 1 * MIB, PROT_READ, flags, OK},
+       {"8. mprotect", TYPE_MPROTECT, 3 * MIB, 1 * MIB, PROT_READ, flags, OK},
+       {"9. mprotect", TYPE_MPROTECT, 4 * MIB, 1 * MIB, PROT_READ, flags, OK},
+       {"10.mprotect", TYPE_MPROTECT, 5 * MIB, 1 * MIB, PROT_READ, flags, OK},
+       {"11.mprotect", TYPE_MPROTECT, 6 * MIB, 1 * MIB, PROT_READ, flags, OK},
+
+       // TODO: automate checking for the mmaps concatenation. For now check with `print_tailq
+       // &mmaps.busy ` in gdb
+       {"12.cleanup unmap", TYPE_MUNMAP, 0, 15 * MIB, PROT_NONE, flags, OK},
+
+       {NULL},
+   };
+
+   printf("Running %s\n", __FUNCTION__);
+   CHECK_CALL(mmap_test_execute(mprotect_tests));
+   PASS();
+}
 GREATEST_MAIN_DEFS();
 int main(int argc, char** argv)
 {
@@ -252,6 +279,7 @@ int main(int argc, char** argv)
 
    RUN_TEST(brk_test);
    RUN_TEST(simple_test);
+   RUN_TEST(concat_test);
    RUN_TEST(complex_test);
 
    GREATEST_PRINT_REPORT();


### PR DESCRIPTION
added a concat_test and verified that mmaps are concatenated fine on both mmap and mprotect. 
