### PR TITLE
don't leak thread id into the guest

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -231,8 +231,6 @@ extern int km_vcpu_print(km_vcpu_t* vcpu, uint64_t unused);
 extern km_vcpu_t* km_vcpu_fetch(pthread_tid_t);
 extern km_vcpu_t* km_vcpu_fetch_by_tid(int tid);
 
-extern pid_t gettid(void);
-
 // Interrupt handling.
 void km_init_guest_idt(km_gva_t handlers);
 void km_handle_interrupt(km_vcpu_t* vcpu);


### PR DESCRIPTION
vcpu_id + 1 is numerical thread id used in pthread_t->tid. This is **not** what pthread_create() returns, this is what **gettid()** returns.

gdb output looks like this:
```
(gdb) info thre
  Id   Target Id         Frame 
* 1    Thread 1 (vcpu 0) __syscall6 (a6=0, a5=0, a4=0, a3=-1, a2=128, a1=46299840, n=202) at ./syscall_arch.h:103
  2    Thread 2 (vcpu 1) __syscall6 (a6=8, a5=0, a4=-1, a3=1024, a2=140737484138960, a1=18, n=281) at ./syscall_arch.h:103
  3    Thread 3 (vcpu 2) __syscall6 (a6=0, a5=0, a4=0, a3=2, a2=128, a1=140737475758444, n=202) at ./syscall_arch.h:103
  4    Thread 4 (vcpu 3) __syscall6 (a6=0, a5=0, a4=0, a3=2, a2=128, a1=140737467365740, n=202) at ./syscall_arch.h:103
  5    Thread 5 (vcpu 4) __syscall6 (a6=0, a5=0, a4=0, a3=2, a2=128, a1=140737458973036, n=202) at ./syscall_arch.h:103
  6    Thread 6 (vcpu 5) __syscall6 (a6=0, a5=0, a4=0, a3=2, a2=128, a1=140737450580332, n=202) at ./syscall_arch.h:103
  7    Thread 7 (vcpu 6) __syscall6 (a6=0, a5=0, a4=0, a3=-1, a2=128, a1=46299840, n=202) at ./syscall_arch.h:103
```