### PR TITLE
pthread tid fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -195,14 +195,54 @@
          ]
       },
       {
-         "name": "KM Node.js Hello.js",
+         "name": "Direct debugging of node.km micro-srv.js",
+         "type": "cppdbg",
+         "request": "launch",
+         "cwd": "${workspaceFolder}/payloads/node",
+         "program": "${workspaceFolder}/payloads/node/node/out/Debug/node.km",
+         "args": [
+            "set debug remote 0"
+         ],
+         "stopAtEntry": true,
+         "miDebuggerServerAddress": "localhost:2159",
+         "miDebuggerArgs": "--silent",
+         "debugServerPath": "${workspaceFolder}/build/km/km",
+         "debugServerArgs": "-g ${workspaceFolder}/payloads/node/node/out/Debug/node.km ${workspaceFolder}/payloads/node/scripts/micro-srv.js",
+         "serverLaunchTimeout": 60000,
+         "filterStderr": true,
+         "filterStdout": false,
+         "serverStarted": "GdbServerStubStarted",
+         "logging": {
+            "moduleLoad": false,
+            "trace": false,
+            "engineLogging": false,
+            "programOutput": true,
+            "exceptions": true,
+            "traceResponse": false
+         },
+         "environment": [],
+         "externalConsole": false,
+         "setupCommands": [
+            {
+               "description": "Enable pretty-printing for gdb",
+               "text": "-enable-pretty-printing",
+               "ignoreFailures": true
+            },
+            {
+               "description": "Make sure we stop somewhere",
+               "text": "b printf",
+               "ignoreFailures": false
+            }
+         ]
+      },
+      {
+         "name": "KM Node.km micro-srv.js",
          "type": "cppdbg",
          "request": "launch",
          "program": "${workspaceFolder}/build/km/km",
          "args": [
-            "-Vmmap",
-            "payloads/node/node/out/Release/node.km",
-            "payloads/node/scripts/hello.js"
+            "payloads/node/node/out/Debug/node.km",
+            "payloads/node/scripts/micro-srv.js"
          ],
          "stopAtEntry": true,
          "cwd": "${workspaceFolder}",

--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -123,7 +123,7 @@ static inline int km_make_dump_prstatus(km_vcpu_t* vcpu, char* buf, size_t lengt
    cur += km_add_note_header(cur, remain, "CORE", sizeof(struct elf_prstatus));
 
    // TODO: Fill in the rest of elf_prstatus.
-   pr.pr_pid = vcpu->tid;
+   pr.pr_pid = km_vcpu_get_tid(vcpu);
    // Found these assignments in Linux source arch/x86/include/asm/elf.h
    pr.pr_reg[0] = vcpu->regs.r15;
    pr.pr_reg[1] = vcpu->regs.r14;

--- a/km/km_gdb.h
+++ b/km/km_gdb.h
@@ -72,7 +72,7 @@ typedef struct gdbstub_info {
    km_vcpu_t* gdb_vcpu;     // VCPU which GDB is asking us to work on.
    int exit_reason;         // last KVM exit reason
    int signo;               // signal number
-   // Note: we use vcpu->tid as gdb payload thread id. It also matches linux LWP
+   // Note: we use km_vcpu_get_tid() as gdb payload thread id
 } gdbstub_info_t;
 
 extern gdbstub_info_t gdbstub;

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -367,9 +367,9 @@ static void send_response(char code, int signum, bool wait_for_ack)
    }
 }
 
-static inline int km_gdb_thread_id(km_vcpu_t* vcpu)   // we use vcpu->tid as thread id for GDB
+static inline int km_gdb_thread_id(km_vcpu_t* vcpu)   // we use km_vcpu_get_tid as thread id for GDB
 {
-   return vcpu->tid;
+   return km_vcpu_get_tid(vcpu);
 }
 
 // Add hex gdb_tid to the list of thread_ids for communication to gdb

--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -499,20 +499,15 @@ uint64_t km_kill(km_vcpu_t* vcpu, pid_t pid, int signo)
 
 uint64_t km_tkill(km_vcpu_t* vcpu, pid_t tid, int signo)
 {
-   /*
-    * KM tid is the index into the machine.vm_vcpus array.
-    */
-   if (tid < 0 || tid > KVM_MAX_VCPUS || machine.vm_vcpus[tid] == NULL ||
-       machine.vm_vcpus[tid]->is_used == 0) {
-      return -EINVAL;
-   }
-   if (signo < 1 || signo >= NSIG) {
+   km_vcpu_t* target_vcpu = km_vcpu_fetch_by_tid(tid);
+
+   if (target_vcpu == NULL || signo < 1 || signo >= NSIG) {
       return -EINVAL;
    }
 
    // Thread-targeted signal.
    siginfo_t info = {.si_signo = signo, .si_code = SI_USER};
-   km_post_signal(machine.vm_vcpus[tid], &info);
+   km_post_signal(target_vcpu, &info);
    return 0;
 }
 

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -597,7 +597,6 @@ static int km_vcpu_one_kvm_run(km_vcpu_t* vcpu)
 void* km_vcpu_run(km_vcpu_t* vcpu)
 {
    int status, hc;
-   vcpu->tid = gettid();
    vcpu->is_paused = 1;
 
    while (1) {
@@ -695,8 +694,6 @@ void* km_vcpu_run(km_vcpu_t* vcpu)
 void* km_vcpu_run_main(void* unused)
 {
    km_vcpu_t* vcpu = km_main_vcpu();
-
-   vcpu->tid = gettid();
 
    km_install_sighandler(KM_SIGVCPUSTOP, km_vcpu_pause_sighandler);
    km_install_sighandler(SIGPIPE, km_forward_fd_signal);

--- a/runtime/pthread_create_km.c
+++ b/runtime/pthread_create_km.c
@@ -85,8 +85,6 @@ _Noreturn void __pthread_exit(void* result)
    }
    /*
     * At this point we are committed to thread termination. Unlink the thread from the list.
-    * This change will not be visible until the lock is released, which only happens after
-    * SYS_exit has been called, via the exit futex address pointing at the lock.
     */
    libc.threads_minus_1--;
    self->next->prev = self->prev;

--- a/tests/signal_test.c
+++ b/tests/signal_test.c
@@ -220,8 +220,8 @@ TEST test_tkill()
    // too large for KM vcpu
    ASSERT_EQ(-1, syscall(SYS_tkill, 1024, SIGUSR1));
    ASSERT_EQ(EINVAL, errno);
-   // unused KM vcpu
-   ASSERT_EQ(-1, syscall(SYS_tkill, 1, SIGUSR1));
+   // unused KM vcpu. We are single threaded, tid is 1, so we use 2
+   ASSERT_EQ(-1, syscall(SYS_tkill, 2, SIGUSR1));
    ASSERT_EQ(EINVAL, errno);
 
    // bad signal numbers


### PR DESCRIPTION
set tid in pthread in a manner consistent with assumptions in mutex code and other places

tid is now vcpu_id + 1 always, instead of vcpu field we use km_vcpu_get_tid() function,
and km_vcpu_fetch_by_tid(). gdb stub, signal code, and the rest use that now.