### PR TITLE
Fix BUILD variable not override.

### DIFF
--- a/payloads/node/Makefile
+++ b/payloads/node/Makefile
@@ -11,7 +11,7 @@
 # Makefile for building and packing Node.js payload runtime for KM
 
 TOP := $(shell git rev-parse --show-cdup)
-BUILD=Debug
+BUILD ?= Debug
 
 # KM monitor path
 KM_BIN=${TOP}/build/km/km


### PR DESCRIPTION
BUILD variable are expected to be overriden through cmd line.
Use ?= to correctly set the variable. Without it, `make distro` at the km root will not override the variable correctly.