### PR TITLE
Refactor KM guest filesystem calls (version 2)

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -135,6 +135,12 @@ void km_hcalls_init(void);
 void km_hcalls_fini(void);
 
 /*
+ * Guest file descriptor entry.
+ */
+typedef struct km_guest_file {
+   int used;
+} km_guest_file_t;
+/*
  * kernel include/linux/kvm_host.h
  */
 static const int CPUID_ENTRIES = 100;   // A little padding, kernel says 80
@@ -177,6 +183,9 @@ typedef struct km_machine {
    km_signal_list_t sigpending;    // List of signals pending for guest
    km_signal_list_t sigfree;       // Freelist of signal entries.
    km_sigaction_t sigactions[_NSIG];
+
+   km_guest_file_t* files;   // file descriptor table
+   int nfiles;               // number of file descriptor table entries
 } km_machine_t;
 
 extern km_machine_t machine;

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -1,0 +1,569 @@
+/*
+ * Copyright © 2019 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ */
+
+#ifndef KM_FILESYS_H_
+#define KM_FILESYS_H_
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <sys/epoll.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+
+#include "km.h"
+#include "km_mem.h"
+#include "km_syscall.h"
+
+static int check_guest_fd(km_vcpu_t* vcpu, int fd)
+{
+   if (fd < 0 || fd >= machine.nfiles) {
+      return -EBADF;
+   }
+   if (__atomic_load_n(&machine.files[fd].used, __ATOMIC_SEQ_CST) != 0) {
+      return fd;
+   }
+   return -1;
+}
+
+/*
+ * Note: dup3 will silently close a fd, so if the fd is already in the table, assume
+ *       that is what happened.
+ */
+static void add_guest_fd(km_vcpu_t* vcpu, int fd)
+{
+   if (fd < 0 || fd > machine.nfiles) {
+      errx(1, "%s bad file descriptor %d", __FUNCTION__, fd);
+   }
+   __atomic_store_n(&machine.files[fd].used, 1, __ATOMIC_SEQ_CST);
+   return;
+}
+
+static void del_guest_fd(km_vcpu_t* vcpu, int fd)
+{
+   if (fd < 0 || fd > machine.nfiles) {
+      errx(1, "%s bad file descriptor %d", __FUNCTION__, fd);
+   }
+   __atomic_store_n(&machine.files[fd].used, 0, __ATOMIC_SEQ_CST);
+}
+
+static inline int km_init_guest_files()
+{
+   struct rlimit lim;
+
+   if (getrlimit(RLIMIT_NOFILE, &lim) < 0) {
+      return -1;
+   }
+   machine.files = calloc(lim.rlim_cur, sizeof(km_guest_file_t));
+   machine.nfiles = lim.rlim_cur;
+   // stdin, stdout, and stderr are open.
+   machine.files[0].used = 1;
+   machine.files[1].used = 1;
+   machine.files[2].used = 1;
+   return 0;
+}
+
+// int open(char *pathname, int flags, mode_t mode)
+static inline uint64_t km_fs_open(km_vcpu_t* vcpu, char* pathname, int flags, mode_t mode)
+{
+   int fd = __syscall_3(SYS_open, (uintptr_t)pathname, flags, mode);
+   if (fd >= 0) {
+      add_guest_fd(vcpu, fd);
+   }
+   return fd;
+}
+
+// int close(fd)
+static inline uint64_t km_fs_close(km_vcpu_t* vcpu, int fd)
+{
+   if (check_guest_fd(vcpu, fd) == -1) {
+      return -EBADF;
+   }
+   int ret = __syscall_1(SYS_close, fd);
+   if (ret == 0) {
+      del_guest_fd(vcpu, fd);
+   }
+   return ret;
+}
+
+// ssize_t read(int fd, void *buf, size_t count);
+// ssize_t write(int fd, const void *buf, size_t count);
+// ssize_t pread(int fd, void *buf, size_t count, off_t offset);
+// ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset);
+static inline uint64_t
+km_fs_prw(km_vcpu_t* vcpu, int scall, int fd, const void* buf, size_t count, off_t offset)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_4(scall, fd, (uintptr_t)buf, count, offset);
+   return ret;
+}
+
+// ssize_t readv(int fd, const struct iovec *iov, int iovcnt);
+// ssize_t writev(int fd, const struct iovec *iov, int iovcnt);
+// ssize_t preadv(int fd, const struct iovec* iov, int iovcnt, off_t offset);
+// ssize_t pwritev(int fd, const struct iovec* iov, int iovcnt, off_t offset);
+static inline uint64_t
+km_fs_prwv(km_vcpu_t* vcpu, int scall, int fd, const struct iovec* guest_iov, size_t iovcnt, off_t offset)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   struct iovec iov[iovcnt];
+
+   if (guest_iov == NULL) {
+      return -EFAULT;
+   }
+
+   // ssize_t readv(int fd, const struct iovec *iov, int iovcnt);
+   // ssize_t writev(int fd, const struct iovec *iov, int iovcnt);
+   // ssize_t preadv(int fd, const struct iovec* iov, int iovcnt, off_t offset);
+   // ssize_t pwritev(int fd, const struct iovec* iov, int iovcnt, off_t offset);
+   //
+   // need to convert not only the address of iov,
+   // but also pointers to individual buffers in it
+   for (int i = 0; i < iovcnt; i++) {
+      iov[i].iov_base = km_gva_to_kma((long)guest_iov[i].iov_base);
+      iov[i].iov_len = guest_iov[i].iov_len;
+   }
+   int ret = __syscall_4(scall, fd, (uintptr_t)iov, iovcnt, offset);
+
+   return ret;
+}
+
+// int ioctl(int fd, unsigned long request, void *arg);
+static inline uint64_t km_fs_ioctl(km_vcpu_t* vcpu, int fd, unsigned long request, void* arg)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_3(SYS_ioctl, fd, request, (uintptr_t)arg);
+   return ret;
+}
+
+// int fcntl(int fd, int cmd, ... /* arg */ );
+static inline uint64_t km_fs_fcntl(km_vcpu_t* vcpu, int fd, int cmd, uint64_t arg)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   uint64_t farg = arg;
+   if (cmd == F_SETLK || cmd == F_SETLKW || cmd == F_GETLK) {
+      farg = (uint64_t)km_gva_to_kma(arg);
+   }
+   int ret = __syscall_3(SYS_fcntl, fd, cmd, farg);
+   return ret;
+}
+
+// off_t lseek(int fd, off_t offset, int whence);
+static inline uint64_t km_fs_lseek(km_vcpu_t* vcpu, int fd, off_t offset, int whence)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_3(SYS_lseek, fd, offset, whence);
+   return ret;
+}
+
+// int getdents64(unsigned int fd, struct linux_dirent64 *dirp, unsigned int count);
+static inline uint64_t km_fs_getdents64(km_vcpu_t* vcpu, int fd, void* dirp, unsigned int count)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_3(SYS_getdents64, fd, (uintptr_t)dirp, count);
+   return ret;
+}
+
+// int symlink(const char *target, const char *linkpath);
+static inline uint64_t km_fs_symlink(km_vcpu_t* vcpu, char* target, char* linkpath)
+{
+   int ret = __syscall_2(SYS_symlink, (uintptr_t)target, (uintptr_t)linkpath);
+   return ret;
+}
+
+// ssize_t readlink(const char *pathname, char *buf, size_t bufsiz);
+static inline uint64_t km_fs_readlink(km_vcpu_t* vcpu, char* pathname, char* buf, size_t bufsz)
+{
+   int ret = __syscall_3(SYS_readlink, (uintptr_t)pathname, (uintptr_t)buf, bufsz);
+   return ret;
+}
+
+// int getcwd(char *buf, size_t size);
+static inline uint64_t km_fs_getcwd(km_vcpu_t* vcpu, char* buf, size_t bufsz)
+{
+   int ret = __syscall_2(SYS_getcwd, (uintptr_t)buf, bufsz);
+   return ret;
+}
+
+// int chdir(const char *path);
+static inline uint64_t km_fs_chdir(km_vcpu_t* vcpu, char* pathname)
+{
+   int ret = __syscall_1(SYS_chdir, (uintptr_t)pathname);
+   return ret;
+}
+
+// int mkdir(const char *path, mode_t mode);
+static inline uint64_t km_fs_mkdir(km_vcpu_t* vcpu, char* pathname, mode_t mode)
+{
+   int ret = __syscall_2(SYS_getcwd, (uintptr_t)pathname, mode);
+   return ret;
+}
+
+// int rename(const char *oldpath, const char *newpath);
+static inline uint64_t km_fs_rename(km_vcpu_t* vcpu, char* oldpath, char* newpath)
+{
+   int ret = __syscall_2(SYS_rename, (uintptr_t)oldpath, (uintptr_t)newpath);
+   return ret;
+}
+
+// int stat(const char *pathname, struct stat *statbuf);
+static inline uint64_t km_fs_stat(km_vcpu_t* vcpu, char* pathname, struct stat* statbuf)
+{
+   int ret = __syscall_2(SYS_stat, (uintptr_t)pathname, (uintptr_t)statbuf);
+   return ret;
+}
+
+// int lstat(const char *pathname, struct stat *statbuf);
+static inline uint64_t km_fs_lstat(km_vcpu_t* vcpu, char* pathname, struct stat* statbuf)
+{
+   int ret = __syscall_2(SYS_lstat, (uintptr_t)pathname, (uintptr_t)statbuf);
+   return ret;
+}
+
+// int statx(int dirfd, const char *pathname, int flags, unsigned int mask, struct statx *statxbuf)
+static inline uint64_t
+km_fs_statx(km_vcpu_t* vcpu, int dirfd, char* pathname, int flags, unsigned int mask, void* statxbuf)
+{
+   int ret = __syscall_5(SYS_statx, dirfd, (uintptr_t)pathname, flags, mask, (uintptr_t)statxbuf);
+   return ret;
+}
+
+// int fstat(int fd, struct stat *statbuf);
+static inline uint64_t km_fs_fstat(km_vcpu_t* vcpu, int fd, struct stat* statbuf)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_2(SYS_fstat, fd, (uintptr_t)statbuf);
+   return ret;
+}
+
+// int dup(int oldfd);
+static inline uint64_t km_fs_dup(km_vcpu_t* vcpu, int fd)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_1(SYS_dup, fd);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// int dup2(int oldfd, int newfd);
+static inline uint64_t km_fs_dup2(km_vcpu_t* vcpu, int fd, int newfd)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   // Don't allow dup to newfd open by KM and not guest.
+   struct stat st;
+   if (check_guest_fd(vcpu, newfd) == 0 && fstat(newfd, &st) == 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_2(SYS_dup2, fd, newfd);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// int dup3(int oldfd, int newfd, int flags);
+static inline uint64_t km_fs_dup3(km_vcpu_t* vcpu, int fd, int newfd, int flags)
+{
+   if (check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   // Don't allow dup to newfd open by KM and not guest.
+   struct stat st;
+   if (check_guest_fd(vcpu, newfd) == 0 && fstat(newfd, &st) == 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_3(SYS_dup2, fd, newfd, flags);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// int pipe(int pipefd[2]);
+static inline uint64_t km_fs_pipe(km_vcpu_t* vcpu, int pipefd[2])
+{
+   int ret = __syscall_1(SYS_pipe, (uintptr_t)pipefd);
+   if (ret == 0) {
+      add_guest_fd(vcpu, pipefd[0]);
+      add_guest_fd(vcpu, pipefd[1]);
+   }
+   return ret;
+}
+
+// int pipe2(int pipefd[2], int flags);
+static inline uint64_t km_fs_pipe2(km_vcpu_t* vcpu, int pipefd[2], int flags)
+{
+   int ret = __syscall_2(SYS_pipe, (uintptr_t)pipefd, flags);
+   if (ret == 0) {
+      add_guest_fd(vcpu, pipefd[0]);
+      add_guest_fd(vcpu, pipefd[1]);
+   }
+   return ret;
+}
+
+// int eventfd2(unsigned int initval, int flags);
+static inline uint64_t km_fs_eventfd2(km_vcpu_t* vcpu, int initval, int flags)
+{
+   int ret = __syscall_2(SYS_eventfd2, initval, flags);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// int socket(int domain, int type, int protocol);
+static inline uint64_t km_fs_socket(km_vcpu_t* vcpu, int domain, int type, int protocol)
+{
+   int ret = __syscall_3(SYS_socket, domain, type, protocol);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// int getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *optlen);
+static inline uint64_t
+km_fs_getsockopt(km_vcpu_t* vcpu, int sockfd, int level, int optname, void* optval, socklen_t* optlen)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_5(SYS_getsockopt, sockfd, level, optname, (uintptr_t)optval, (uintptr_t)optlen);
+   return ret;
+}
+
+// int setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen);
+static inline uint64_t
+km_fs_setsockopt(km_vcpu_t* vcpu, int sockfd, int level, int optname, void* optval, socklen_t optlen)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_5(SYS_setsockopt, sockfd, level, optname, (uintptr_t)optval, optlen);
+   return ret;
+}
+
+// int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+static inline uint64_t
+km_fs_getsockname(km_vcpu_t* vcpu, int sockfd, struct sockaddr* addr, socklen_t* addrlen)
+{
+   if (check_guest_fd(vcpu, sockfd) == -1) {
+      return -EBADF;
+   }
+   int ret = __syscall_3(SYS_getsockname, sockfd, (uintptr_t)addr, (uintptr_t)addrlen);
+   return ret;
+}
+
+// int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+static inline uint64_t km_fs_bind(km_vcpu_t* vcpu, int sockfd, struct sockaddr* addr, socklen_t addrlen)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_3(SYS_bind, sockfd, (uintptr_t)addr, addrlen);
+   return ret;
+}
+
+// int listen(int sockfd, int backlog)
+static inline uint64_t km_fs_listen(km_vcpu_t* vcpu, int sockfd, int backlog)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_2(SYS_listen, sockfd, backlog);
+   return ret;
+}
+
+// int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+static inline uint64_t
+km_fs_accept(km_vcpu_t* vcpu, int sockfd, struct sockaddr* addr, socklen_t* addrlen)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_3(SYS_accept, sockfd, (uintptr_t)addr, (uintptr_t)addrlen);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags);
+static inline uint64_t
+km_fs_accept4(km_vcpu_t* vcpu, int sockfd, struct sockaddr* addr, socklen_t* addrlen, int flags)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_4(SYS_accept4, sockfd, (uintptr_t)addr, (uintptr_t)addrlen, flags);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
+//                const struct sockaddr *dest_addr, socklen_t addrlen);
+static inline uint64_t km_fs_sendto(km_vcpu_t* vcpu,
+                                    int sockfd,
+                                    const void* buf,
+                                    size_t len,
+                                    int flags,
+                                    const struct sockaddr* addr,
+                                    socklen_t addrlen)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_6(SYS_sendto, sockfd, (uintptr_t)buf, len, flags, (uintptr_t)addr, addrlen);
+   return ret;
+}
+
+// ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
+//                  struct sockaddr *src_addr, socklen_t *addrlen);
+static inline uint64_t km_fs_recvfrom(
+    km_vcpu_t* vcpu, int sockfd, void* buf, size_t len, int flags, struct sockaddr* addr, socklen_t* addrlen)
+{
+   if (check_guest_fd(vcpu, sockfd) < 0) {
+      return -EBADF;
+   }
+   int ret =
+       __syscall_6(SYS_recvfrom, sockfd, (uintptr_t)buf, len, flags, (uintptr_t)addr, (uintptr_t)addrlen);
+   return ret;
+}
+
+//  int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
+static inline uint64_t km_fs_select(km_vcpu_t* vcpu,
+                                    int nfds,
+                                    fd_set* readfds,
+                                    fd_set* writefds,
+                                    fd_set* exceptfds,
+                                    struct timeval* timeout)
+{
+   for (int i = 0; i < nfds; i++) {
+      if (FD_ISSET(i, readfds) && check_guest_fd(vcpu, i) == -1) {
+         return -EBADF;
+      }
+      if (FD_ISSET(i, writefds) && check_guest_fd(vcpu, i) == -1) {
+         return -EBADF;
+      }
+      if (FD_ISSET(i, exceptfds) && check_guest_fd(vcpu, i) == -1) {
+         return -EBADF;
+      }
+   }
+   int ret = __syscall_5(SYS_select,
+                         nfds,
+                         (uintptr_t)readfds,
+                         (uintptr_t)writefds,
+                         (uintptr_t)exceptfds,
+                         (uintptr_t)timeout);
+   return ret;
+}
+
+// int poll(struct pollfd *fds, nfds_t nfds, int timeout);
+static inline uint64_t km_fs_poll(km_vcpu_t* vcpu, struct pollfd* fds, nfds_t nfds, int timeout)
+{
+   for (int i = 0; i < nfds; i++) {
+      if (check_guest_fd(vcpu, fds[i].fd) == -1) {
+         return -EBADF;
+      }
+   }
+   int ret = __syscall_3(SYS_poll, (uintptr_t)fds, nfds, timeout);
+   return ret;
+}
+
+// int epoll_create1(int flags);
+static inline uint64_t km_fs_epoll_create1(km_vcpu_t* vcpu, int flags)
+{
+   int ret = __syscall_1(SYS_epoll_create1, flags);
+   if (ret >= 0) {
+      add_guest_fd(vcpu, ret);
+   }
+   return ret;
+}
+
+// int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event);
+static inline uint64_t
+km_fs_epoll_ctl(km_vcpu_t* vcpu, int epfd, int op, int fd, struct epoll_event* event)
+{
+   if (check_guest_fd(vcpu, epfd) < 0 || check_guest_fd(vcpu, fd) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_4(SYS_epoll_ctl, epfd, op, fd, (uintptr_t)event);
+   return ret;
+}
+
+// int epoll_pwait(int epfd, struct epoll_event *events, int maxevents, int timeout,
+//  const sigset_t *sigmask);
+static inline uint64_t km_fs_epoll_pwait(km_vcpu_t* vcpu,
+                                         int epfd,
+                                         struct epoll_event* events,
+                                         int maxevents,
+                                         int timeout,
+                                         const sigset_t* sigmask)
+{
+   if (check_guest_fd(vcpu, epfd) < 0) {
+      return -EBADF;
+   }
+   int ret =
+       __syscall_5(SYS_epoll_wait, epfd, (uintptr_t)events, maxevents, timeout, (uintptr_t)sigmask);
+   return ret;
+}
+
+// int prlimit(pid_t pid, int resource, const struct rlimit *new_limit, struct rlimit *old_limit);
+static inline uint64_t km_fs_prlimit64(km_vcpu_t* vcpu,
+                                       pid_t pid,
+                                       int resource,
+                                       const struct rlimit* new_limit,
+                                       struct rlimit* old_limit)
+{
+   /*
+    * TODO: A number of rlimit values are effected by KM and we want to virtualize. For example:
+    *       RLIMIT_AS - Maximum address space size.
+    *       RLIMIT_CORE - Maximum core size.
+    *       RLIMIT_DATA - Maximum data a process can create.
+    *       RLIMIT_NOFILE - Maximum number of files
+    *       RLIMIT_NPROC - Maximum number of processes (should set to 1).
+    *       RLIMIT_SIGPENDING - Maximum number of pending signals.
+    *       RLIMIT_STACK - maximum size of process stack.
+    */
+   if (resource == RLIMIT_NOFILE && new_limit != NULL && new_limit->rlim_cur > machine.nfiles) {
+      return -EPERM;
+   }
+   int ret = __syscall_4(SYS_prlimit64, pid, resource, (uintptr_t)new_limit, (uintptr_t)old_limit);
+   return ret;
+}
+#endif

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -19,9 +19,11 @@
 #include <linux/futex.h>
 
 #include "km.h"
+#include "km_filesys.h"
 #include "km_hcalls.h"
 #include "km_mem.h"
 #include "km_signal.h"
+#include "km_syscall.h"
 
 /*
  * User space (km) implementation of hypercalls.
@@ -51,92 +53,6 @@
  * call. We paste signature in comment to make it a bit easier. Look into each
  * XXX_hcall() for examples.
  */
-
-static inline uint64_t __syscall_0(uint64_t num)
-{
-   uint64_t res;
-
-   __asm__ __volatile__("syscall" : "=a"(res) : "a"(num) : "rcx", "r11");
-
-   return res;
-}
-
-static inline uint64_t __syscall_1(uint64_t num, uint64_t a1)
-{
-   uint64_t res;
-
-   __asm__ __volatile__("syscall" : "=a"(res) : "a"(num), "D"(a1) : "rcx", "r11", "memory");
-
-   return res;
-}
-
-static inline uint64_t __syscall_2(uint64_t num, uint64_t a1, uint64_t a2)
-{
-   uint64_t res;
-
-   __asm__ __volatile__("syscall"
-                        : "=a"(res)
-                        : "a"(num), "D"(a1), "S"(a2)
-                        : "rcx", "r11", "memory");
-
-   return res;
-}
-
-static inline uint64_t __syscall_3(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3)
-{
-   uint64_t res;
-
-   __asm__ __volatile__("syscall"
-                        : "=a"(res)
-                        : "a"(num), "D"(a1), "S"(a2), "d"(a3)
-                        : "rcx", "r11", "memory");
-
-   return res;
-}
-
-static inline uint64_t __syscall_4(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4)
-{
-   uint64_t res;
-   register uint64_t r10 __asm__("r10") = a4;
-
-   __asm__ __volatile__("syscall"
-                        : "=a"(res)
-                        : "a"(num), "D"(a1), "S"(a2), "d"(a3), "r"(r10)
-                        : "rcx", "r11", "memory");
-
-   return res;
-}
-
-static inline uint64_t
-__syscall_5(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5)
-{
-   uint64_t res;
-   register uint64_t r10 __asm__("r10") = a4;
-   register uint64_t r8 __asm__("r8") = a5;
-
-   __asm__ __volatile__("syscall"
-                        : "=a"(res)
-                        : "a"(num), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8)
-                        : "rcx", "r11", "memory");
-
-   return res;
-}
-
-static inline uint64_t
-__syscall_6(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6)
-{
-   uint64_t res;
-   register uint64_t r10 __asm__("r10") = a4;
-   register uint64_t r8 __asm__("r8") = a5;
-   register uint64_t r9 __asm__("r9") = a6;
-
-   __asm__ __volatile__("syscall"
-                        : "=a"(res)
-                        : "a"(num), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8), "r"(r9)
-                        : "rcx", "r11", "memory");
-
-   return res;
-}
 
 static inline uint64_t km_gva_to_kml(uint64_t gva)
 {
@@ -170,7 +86,8 @@ static km_hc_ret_t prw_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
    // ssize_t write(int fd, const void *buf, size_t count);
    // ssize_t pread(int fd, void *buf, size_t count, off_t offset);
    // ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset);
-   arg->hc_ret = __syscall_4(hc, arg->arg1, km_gva_to_kml(arg->arg2), arg->arg3, arg->arg4);
+   // arg->hc_ret = __syscall_4(hc, arg->arg1, km_gva_to_kml(arg->arg2), arg->arg3, arg->arg4);
+   arg->hc_ret = km_fs_prw(vcpu, hc, arg->arg1, km_gva_to_kma(arg->arg2), arg->arg3, arg->arg4);
    return HC_CONTINUE;
 }
 
@@ -179,34 +96,14 @@ static km_hc_ret_t prw_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
  */
 static km_hc_ret_t prwv_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
-   int cnt = arg->arg3;
-   struct iovec iov[cnt];
-   const struct iovec* guest_iov = km_gva_to_kma(arg->arg2);
-
-   if (guest_iov == NULL) {
-      arg->hc_ret = EFAULT;
-      return HC_CONTINUE;
-   }
-
-   // ssize_t readv(int fd, const struct iovec *iov, int iovcnt);
-   // ssize_t writev(int fd, const struct iovec *iov, int iovcnt);
-   // ssize_t preadv(int fd, const struct iovec* iov, int iovcnt, off_t offset);
-   // ssize_t pwritev(int fd, const struct iovec* iov, int iovcnt, off_t offset);
-   //
-   // need to convert not only the address of iov,
-   // but also pointers to individual buffers in it
-   for (int i = 0; i < cnt; i++) {
-      iov[i].iov_base = km_gva_to_kma((long)guest_iov[i].iov_base);
-      iov[i].iov_len = guest_iov[i].iov_len;
-   }
-   arg->hc_ret = __syscall_4(hc, arg->arg1, (long)iov, cnt, arg->arg4);
+   arg->hc_ret = km_fs_prwv(vcpu, hc, arg->arg1, km_gva_to_kma(arg->arg2), arg->arg3, arg->arg4);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t accept_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
-   arg->hc_ret = __syscall_3(hc, arg->arg1, km_gva_to_kml(arg->arg2), km_gva_to_kml(arg->arg3));
+   arg->hc_ret = km_fs_accept(vcpu, arg->arg1, km_gva_to_kma(arg->arg2), km_gva_to_kma(arg->arg3));
    return HC_CONTINUE;
 }
 
@@ -227,21 +124,21 @@ static km_hc_ret_t connect_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* sta
 static km_hc_ret_t bind_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
-   arg->hc_ret = __syscall_3(hc, arg->arg1, km_gva_to_kml(arg->arg2), arg->arg3);
+   arg->hc_ret = km_fs_bind(vcpu, arg->arg1, km_gva_to_kma(arg->arg2), arg->arg3);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t listen_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int listen(int sockfd, int backlog);
-   arg->hc_ret = __syscall_2(hc, arg->arg1, arg->arg2);
+   arg->hc_ret = km_fs_listen(vcpu, arg->arg1, arg->arg2);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t socket_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int socket(int domain, int type, int protocol);
-   arg->hc_ret = __syscall_3(hc, arg->arg1, arg->arg2, arg->arg3);
+   arg->hc_ret = km_fs_socket(vcpu, arg->arg1, arg->arg2, arg->arg3);
    return HC_CONTINUE;
 }
 
@@ -249,8 +146,12 @@ static km_hc_ret_t getsockopt_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* 
 {
    // int getsockopt(int sockfd, int level, int optname, void *optval, socklen_t
    // *optlen);
-   arg->hc_ret =
-       __syscall_5(hc, arg->arg1, arg->arg2, arg->arg3, km_gva_to_kml(arg->arg4), km_gva_to_kml(arg->arg5));
+   arg->hc_ret = km_fs_getsockopt(vcpu,
+                                  arg->arg1,
+                                  arg->arg2,
+                                  arg->arg3,
+                                  km_gva_to_kma(arg->arg4),
+                                  km_gva_to_kma(arg->arg5));
    return HC_CONTINUE;
 }
 
@@ -258,56 +159,76 @@ static km_hc_ret_t setsockopt_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* 
 {
    // int setsockopt(int sockfd, int level, int optname, const void *optval,
    // socklen_t optlen);
-   arg->hc_ret = __syscall_5(hc, arg->arg1, arg->arg2, arg->arg3, km_gva_to_kml(arg->arg4), arg->arg5);
+   arg->hc_ret =
+       km_fs_setsockopt(vcpu, arg->arg1, arg->arg2, arg->arg3, km_gva_to_kma(arg->arg4), arg->arg5);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t ioctl_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int ioctl(int fd, unsigned long request, void *arg);
-   arg->hc_ret = __syscall_3(hc, arg->arg1, arg->arg2, km_gva_to_kml(arg->arg3));
+   // arg->hc_ret = __syscall_3(hc, arg->arg1, arg->arg2, km_gva_to_kml(arg->arg3));
+   arg->hc_ret = km_fs_ioctl(vcpu, arg->arg1, arg->arg2, km_gva_to_kma(arg->arg3));
+   return HC_CONTINUE;
+}
+
+static km_hc_ret_t fcntl_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
+{
+   // int fcntl(int fd, int cmd, ...); (Only 1 optional argument)
+   arg->hc_ret = km_fs_fcntl(vcpu, arg->arg1, arg->arg2, arg->arg3);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t stat_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int stat(const char *pathname, struct stat *statbuf);
-   arg->hc_ret = __syscall_2(hc, km_gva_to_kml(arg->arg1), km_gva_to_kml(arg->arg2));
+   arg->hc_ret = km_fs_stat(vcpu, km_gva_to_kma(arg->arg1), km_gva_to_kma(arg->arg2));
+   return HC_CONTINUE;
+}
+static km_hc_ret_t lstat_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
+{
+   // int lstat(const char *pathname, struct stat *statbuf);
+   arg->hc_ret = km_fs_lstat(vcpu, km_gva_to_kma(arg->arg1), km_gva_to_kma(arg->arg2));
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t statx_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int statx(int dirfd, const char *pathname, int flags, unsigned int mask, struct statx *statxbuf);
-   arg->hc_ret =
-       __syscall_5(hc, arg->arg1, km_gva_to_kml(arg->arg2), arg->arg3, arg->arg4, km_gva_to_kml(arg->arg5));
+   arg->hc_ret = km_fs_statx(vcpu,
+                             arg->arg1,
+                             km_gva_to_kma(arg->arg2),
+                             arg->arg3,
+                             arg->arg4,
+                             km_gva_to_kma(arg->arg5));
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t fstat_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int fstat(int fd, struct stat *statbuf);
-   arg->hc_ret = __syscall_2(hc, arg->arg1, km_gva_to_kml(arg->arg2));
+   arg->hc_ret = km_fs_fstat(vcpu, arg->arg1, km_gva_to_kma(arg->arg2));
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t getdirents_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int getdents64(unsigned int fd, struct linux_dirent64 *dirp, unsigned int count);
-   arg->hc_ret = __syscall_3(hc, arg->arg1, km_gva_to_kml(arg->arg2), arg->arg3);
+   arg->hc_ret = km_fs_getdents64(vcpu, arg->arg1, km_gva_to_kma(arg->arg2), arg->arg3);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t getcwd_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int getcwd(char *buf, size_t size);
-   arg->hc_ret = __syscall_2(hc, km_gva_to_kml(arg->arg1), arg->arg2);
+   arg->hc_ret = km_fs_getcwd(vcpu, km_gva_to_kma(arg->arg1), arg->arg2);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t close_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
-   arg->hc_ret = __syscall_1(hc, arg->arg1);
+   // arg->hc_ret = __syscall_1(hc, arg->arg1);
+   arg->hc_ret = km_fs_close(vcpu, arg->arg1);
    return HC_CONTINUE;
 }
 
@@ -411,7 +332,7 @@ static km_hc_ret_t umask_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* statu
 static km_hc_ret_t readlink_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // ssize_t readlink(const char *pathname, char *buf, size_t bufsiz);
-   arg->hc_ret = __syscall_3(hc, km_gva_to_kml(arg->arg1), km_gva_to_kml(arg->arg2), arg->arg3);
+   arg->hc_ret = km_fs_readlink(vcpu, km_gva_to_kma(arg->arg1), km_gva_to_kma(arg->arg2), arg->arg3);
    return HC_CONTINUE;
 }
 
@@ -425,21 +346,28 @@ static km_hc_ret_t getrandom_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* s
 static km_hc_ret_t open_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int open(const char *pathname, int flags, mode_t mode);
-   arg->hc_ret = __syscall_3(hc, km_gva_to_kml(arg->arg1), arg->arg2, arg->arg3);
+   // arg->hc_ret = __syscall_3(hc, km_gva_to_kml(arg->arg1), arg->arg2, arg->arg3);
+   arg->hc_ret = km_fs_open(vcpu, km_gva_to_kma(arg->arg1), arg->arg2, arg->arg3);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t lseek_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // off_t lseek(int fd, off_t offset, int whence);
-   arg->hc_ret = __syscall_3(hc, arg->arg1, arg->arg2, arg->arg3);
+   arg->hc_ret = km_fs_lseek(vcpu, arg->arg1, arg->arg2, arg->arg3);
+   return HC_CONTINUE;
+}
+
+static km_hc_ret_t symlink_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
+{
+   arg->hc_ret = km_fs_symlink(vcpu, km_gva_to_kma(arg->arg1), km_gva_to_kma(arg->arg2));
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t rename_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int rename(const char *oldpath, const char *newpath);
-   arg->hc_ret = __syscall_2(hc, km_gva_to_kml(arg->arg1), km_gva_to_kml(arg->arg2));
+   arg->hc_ret = km_fs_rename(vcpu, km_gva_to_kma(arg->arg1), km_gva_to_kma(arg->arg2));
    return HC_CONTINUE;
 }
 
@@ -453,7 +381,7 @@ static km_hc_ret_t chdir_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* statu
 static km_hc_ret_t mkdir_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int mkdir(const char *path, mode_t mode);
-   arg->hc_ret = __syscall_2(hc, km_gva_to_kml(arg->arg1), arg->arg2);
+   arg->hc_ret = km_fs_mkdir(vcpu, km_gva_to_kma(arg->arg1), arg->arg2);
    return HC_CONTINUE;
 }
 
@@ -461,12 +389,12 @@ static km_hc_ret_t select_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* stat
 {
    //  int select(int nfds, fd_set *readfds, fd_set *writefds,
    //             fd_set *exceptfds, struct timeval *timeout);
-   arg->hc_ret = __syscall_5(hc,
-                             arg->arg1,
-                             km_gva_to_kml(arg->arg2),
-                             km_gva_to_kml(arg->arg3),
-                             km_gva_to_kml(arg->arg4),
-                             km_gva_to_kml(arg->arg5));
+   arg->hc_ret = km_fs_select(vcpu,
+                              arg->arg1,
+                              km_gva_to_kma(arg->arg2),
+                              km_gva_to_kma(arg->arg3),
+                              km_gva_to_kma(arg->arg4),
+                              km_gva_to_kma(arg->arg5));
    return HC_CONTINUE;
 }
 
@@ -474,13 +402,13 @@ static km_hc_ret_t sendto_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* stat
 {
    // ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
    //                const struct sockaddr *dest_addr, socklen_t addrlen);
-   arg->hc_ret = __syscall_6(hc,
-                             arg->arg1,
-                             km_gva_to_kml(arg->arg2),
-                             arg->arg3,
-                             arg->arg4,
-                             km_gva_to_kml(arg->arg5),
-                             arg->arg6);
+   arg->hc_ret = km_fs_sendto(vcpu,
+                              arg->arg1,
+                              km_gva_to_kma(arg->arg2),
+                              arg->arg3,
+                              arg->arg4,
+                              km_gva_to_kma(arg->arg5),
+                              arg->arg6);
    return HC_CONTINUE;
 }
 
@@ -494,14 +422,21 @@ static km_hc_ret_t nanosleep_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* s
 static km_hc_ret_t dup_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int dup(int oldfd);
-   arg->hc_ret = __syscall_1(hc, arg->arg1);
+   arg->hc_ret = km_fs_dup(vcpu, arg->arg1);
+   return HC_CONTINUE;
+}
+
+static km_hc_ret_t dup2_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
+{
+   // int dup(int oldfd);
+   arg->hc_ret = km_fs_dup2(vcpu, arg->arg1, arg->arg2);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t dup3_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int dup3(int oldfd, int newfd, int flags);
-   arg->hc_ret = __syscall_3(hc, arg->arg1, arg->arg2, arg->arg3);
+   arg->hc_ret = km_fs_dup3(vcpu, arg->arg1, arg->arg2, arg->arg3);
    return HC_CONTINUE;
 }
 
@@ -522,7 +457,7 @@ static km_hc_ret_t getsockname_hcall(void* vcpu, int hc, km_hc_args_t* arg, int*
 static km_hc_ret_t poll_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int poll(struct pollfd *fds, nfds_t nfds, int timeout);
-   arg->hc_ret = __syscall_3(hc, km_gva_to_kml(arg->arg1), arg->arg2, arg->arg3);
+   arg->hc_ret = km_fs_poll(vcpu, km_gva_to_kma(arg->arg1), arg->arg2, arg->arg3);
    return HC_CONTINUE;
 }
 
@@ -531,7 +466,7 @@ static km_hc_ret_t accept4_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* sta
    // int accept4(int sockfd, struct sockaddr *addr,
    //             socklen_t *addrlen, int flags);
    arg->hc_ret =
-       __syscall_4(hc, arg->arg1, km_gva_to_kml(arg->arg2), km_gva_to_kml(arg->arg3), arg->arg4);
+       km_fs_accept4(vcpu, arg->arg1, km_gva_to_kma(arg->arg2), km_gva_to_kma(arg->arg3), arg->arg4);
    return HC_CONTINUE;
 }
 
@@ -539,13 +474,13 @@ static km_hc_ret_t recvfrom_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* st
 {
    // ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
    //                  struct sockaddr *src_addr, socklen_t *addrlen);
-   arg->hc_ret = __syscall_6(hc,
-                             arg->arg1,
-                             km_gva_to_kml(arg->arg2),
-                             arg->arg3,
-                             arg->arg4,
-                             km_gva_to_kml(arg->arg5),
-                             km_gva_to_kml(arg->arg6));
+   arg->hc_ret = km_fs_recvfrom(vcpu,
+                                arg->arg1,
+                                km_gva_to_kma(arg->arg2),
+                                arg->arg3,
+                                arg->arg4,
+                                km_gva_to_kma(arg->arg5),
+                                km_gva_to_kma(arg->arg6));
    return HC_CONTINUE;
 }
 
@@ -596,7 +531,7 @@ static km_hc_ret_t pthread_join_hcall(void* vcpu, int hc, km_hc_args_t* arg, int
 
 static km_hc_ret_t guest_interrupt_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
-   km_handle_interrupt((km_vcpu_t*)vcpu);
+   km_handle_interrupt(vcpu);
    return HC_CONTINUE;
 }
 
@@ -636,10 +571,8 @@ static km_hc_ret_t rt_sigaction_hcall(void* vcpu, int hc, km_hc_args_t* arg, int
    return HC_CONTINUE;
 }
 
-static km_hc_ret_t rt_sigreturn_hcall(void* varg, int hc, km_hc_args_t* arg, int* status)
+static km_hc_ret_t rt_sigreturn_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
-   km_vcpu_t* vcpu = (km_vcpu_t*)varg;
-
    km_rt_sigreturn(vcpu);   // don't care about arg or return code.
    return HC_CONTINUE;
 }
@@ -668,14 +601,14 @@ static km_hc_ret_t rt_sigpending_hcall(void* vcpu, int hc, km_hc_args_t* arg, in
 static km_hc_ret_t epoll1_create_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int epoll_create1(int flags);
-   arg->hc_ret = __syscall_1(hc, arg->arg1);
+   arg->hc_ret = km_fs_epoll_create1(vcpu, arg->arg1);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t epoll_ctl_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event);
-   arg->hc_ret = __syscall_4(hc, arg->arg1, arg->arg2, arg->arg3, km_gva_to_kml(arg->arg4));
+   arg->hc_ret = km_fs_epoll_ctl(vcpu, arg->arg1, arg->arg2, arg->arg3, km_gva_to_kma(arg->arg4));
    return HC_CONTINUE;
 }
 
@@ -683,29 +616,33 @@ static km_hc_ret_t epoll_pwait_hcall(void* vcpu, int hc, km_hc_args_t* arg, int*
 {
    // int epoll_pwait(int epfd, struct epoll_event *events, int maxevents, int timeout, const
    // sigset_t *sigmask);
-   arg->hc_ret =
-       __syscall_5(hc, arg->arg1, km_gva_to_kml(arg->arg2), arg->arg3, arg->arg4, km_gva_to_kml(arg->arg5));
+   arg->hc_ret = km_fs_epoll_pwait(vcpu,
+                                   arg->arg1,
+                                   km_gva_to_kma(arg->arg2),
+                                   arg->arg3,
+                                   arg->arg4,
+                                   km_gva_to_kma(arg->arg5));
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t pipe_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int pipe2(int pipefd[2], int flags);
-   arg->hc_ret = __syscall_1(hc, km_gva_to_kml(arg->arg1));
+   arg->hc_ret = km_fs_pipe(vcpu, km_gva_to_kma(arg->arg1));
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t pipe2_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
    // int pipe2(int pipefd[2], int flags);
-   arg->hc_ret = __syscall_2(hc, km_gva_to_kml(arg->arg1), arg->arg2);
+   arg->hc_ret = km_fs_pipe2(vcpu, km_gva_to_kma(arg->arg1), arg->arg2);
    return HC_CONTINUE;
 }
 
 static km_hc_ret_t eventfd2_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* status)
 {
-   // int eventfd(unsigned int initval, int flags);
-   arg->hc_ret = __syscall_2(hc, arg->arg1, arg->arg2);
+   // int eventfd2(unsigned int initval, int flags);
+   arg->hc_ret = km_fs_eventfd2(vcpu, arg->arg1, arg->arg2);
    return HC_CONTINUE;
 }
 
@@ -714,7 +651,7 @@ static km_hc_ret_t prlimit64_hcall(void* vcpu, int hc, km_hc_args_t* arg, int* s
    // int prlimit(pid_t pid, int resource, const struct rlimit *new_limit, struct rlimit
    // *old_limit);
    arg->hc_ret =
-       __syscall_4(hc, arg->arg1, arg->arg2, km_gva_to_kml(arg->arg3), km_gva_to_kml(arg->arg4));
+       km_fs_prlimit64(vcpu, arg->arg1, arg->arg2, km_gva_to_kma(arg->arg3), km_gva_to_kma(arg->arg4));
    return HC_CONTINUE;
 }
 
@@ -744,9 +681,9 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_getsockopt] = getsockopt_hcall;
    km_hcalls_table[SYS_setsockopt] = setsockopt_hcall;
    km_hcalls_table[SYS_ioctl] = ioctl_hcall;
-   km_hcalls_table[SYS_fcntl] = ioctl_hcall;
+   km_hcalls_table[SYS_fcntl] = fcntl_hcall;
    km_hcalls_table[SYS_stat] = stat_hcall;
-   km_hcalls_table[SYS_lstat] = stat_hcall;
+   km_hcalls_table[SYS_lstat] = lstat_hcall;
    km_hcalls_table[SYS_statx] = statx_hcall;
    km_hcalls_table[SYS_fstat] = fstat_hcall;
    km_hcalls_table[SYS_getdents64] = getdirents_hcall;
@@ -768,6 +705,7 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_open] = open_hcall;
    km_hcalls_table[SYS_lseek] = lseek_hcall;
    km_hcalls_table[SYS_rename] = rename_hcall;
+   km_hcalls_table[SYS_symlink] = symlink_hcall;
    km_hcalls_table[SYS_mkdir] = mkdir_hcall;
    km_hcalls_table[SYS_chdir] = chdir_hcall;
    km_hcalls_table[SYS_select] = select_hcall;
@@ -782,6 +720,7 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_epoll_ctl] = epoll_ctl_hcall;
    km_hcalls_table[SYS_epoll_pwait] = epoll_pwait_hcall;
    km_hcalls_table[SYS_dup] = dup_hcall;
+   km_hcalls_table[SYS_dup2] = dup2_hcall;
    km_hcalls_table[SYS_dup3] = dup3_hcall;
    km_hcalls_table[SYS_pipe] = pipe_hcall;
    km_hcalls_table[SYS_pipe2] = pipe2_hcall;

--- a/km/km_syscall.h
+++ b/km/km_syscall.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2019 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ *
+ * __syscall_X() simply picks the values from memory into registers and do the
+ * system call on behalf of the guest.
+ *
+ * Some of the values passed in these arguments are guest addresses. There is no
+ * pattern here, each system call has its own signature. We need to translate
+ * the guest addresses to km view to make things work, using km_gva_to_kma() when
+ * appropriate. There is no machinery, need to manually interpret each system
+ * call. We paste signature in comment to make it a bit easier. Look into each
+ * XXX_hcall() for examples.
+ */
+
+#ifndef KM_SYSCALL_H_
+#define KM_SYSCALL_H_
+
+#include <stdint.h>
+
+static inline uint64_t __syscall_0(uint64_t num)
+{
+   uint64_t res;
+
+   __asm__ __volatile__("syscall" : "=a"(res) : "a"(num) : "rcx", "r11");
+
+   return res;
+}
+
+static inline uint64_t __syscall_1(uint64_t num, uint64_t a1)
+{
+   uint64_t res;
+
+   __asm__ __volatile__("syscall" : "=a"(res) : "a"(num), "D"(a1) : "rcx", "r11", "memory");
+
+   return res;
+}
+
+static inline uint64_t __syscall_2(uint64_t num, uint64_t a1, uint64_t a2)
+{
+   uint64_t res;
+
+   __asm__ __volatile__("syscall"
+                        : "=a"(res)
+                        : "a"(num), "D"(a1), "S"(a2)
+                        : "rcx", "r11", "memory");
+
+   return res;
+}
+
+static inline uint64_t __syscall_3(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+   uint64_t res;
+
+   __asm__ __volatile__("syscall"
+                        : "=a"(res)
+                        : "a"(num), "D"(a1), "S"(a2), "d"(a3)
+                        : "rcx", "r11", "memory");
+
+   return res;
+}
+
+static inline uint64_t __syscall_4(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4)
+{
+   uint64_t res;
+   register uint64_t r10 __asm__("r10") = a4;
+
+   __asm__ __volatile__("syscall"
+                        : "=a"(res)
+                        : "a"(num), "D"(a1), "S"(a2), "d"(a3), "r"(r10)
+                        : "rcx", "r11", "memory");
+
+   return res;
+}
+
+static inline uint64_t
+__syscall_5(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5)
+{
+   uint64_t res;
+   register uint64_t r10 __asm__("r10") = a4;
+   register uint64_t r8 __asm__("r8") = a5;
+
+   __asm__ __volatile__("syscall"
+                        : "=a"(res)
+                        : "a"(num), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8)
+                        : "rcx", "r11", "memory");
+
+   return res;
+}
+
+static inline uint64_t
+__syscall_6(uint64_t num, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6)
+{
+   uint64_t res;
+   register uint64_t r10 __asm__("r10") = a4;
+   register uint64_t r8 __asm__("r8") = a5;
+   register uint64_t r9 __asm__("r9") = a6;
+
+   __asm__ __volatile__("syscall"
+                        : "=a"(res)
+                        : "a"(num), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8), "r"(r9)
+                        : "rcx", "r11", "memory");
+
+   return res;
+}
+#endif

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -431,6 +431,11 @@ teardown() {
    run km_with_timeout --coredump=${CORE} stray_test.km sigpipe
    assert_success  # should succeed
    assert [ ! -f ${CORE} ]
+
+   # Try to close a KM file from the guest
+   run km_with_timeout --coredump=${CORE} stray_test.km close 5
+   assert [ $status -eq 9 ]  # EBADF
+   assert [ ! -f ${CORE} ]
 }
 
 @test "signals: signals in the guest (signals)" {

--- a/tests/stray_test.c
+++ b/tests/stray_test.c
@@ -47,6 +47,7 @@ int block_segv_test(int optind, int argc, char* argv[]);
 int sigpipe_test(int optind, int argc, char* argv[]);
 int hc_test(int optind, int argc, char* argv[]);
 int hc_badarg_test(int optind, int argc, char* argv[]);
+int close_test(int optind, int argc, char* argv[]);
 
 struct stray_op {
    char* op;                                          // Operation name on command line
@@ -73,6 +74,7 @@ struct stray_op {
     {.op = "hc-badarg",
      .func = hc_badarg_test,
      .description = "<call> - make hypercall with number <call> and a bad argument."},
+    {.op = "close", .func = close_test, .description = "<fd> - close file descriptor fd"},
     {.op = NULL, .func = NULL, .description = NULL},
 };
 
@@ -210,6 +212,21 @@ int hc_badarg_test(int optind, int optarg, char* argv[])
       return 100;
    }
    km_hcall(callid, (km_hc_args_t*)-1LL);
+   return 0;
+}
+
+int close_test(int optind, int optarg, char* argv[])
+{
+   char* ep = NULL;
+   int fd = strtol(argv[optind], &ep, 0);
+   if (ep == NULL || *ep != '\0') {
+      fprintf(stderr, "fd '%s' is not a number", argv[optind]);
+      usage();
+      return 100;
+   }
+   if (close(fd) < 0) {
+      return errno;
+   }
    return 0;
 }
 


### PR DESCRIPTION
(There was a problem with the previous version. It was easier to re-trace
my step to find the source of the problem.)

Anything using file descrptors or path names will need more processing
going forward. To support this I've refactored the system calls that
involve paths and fd into a separate file. Right now, the functionality
has moved into new functions (adding a new level of call). Next steps
are:
 - keep track of the file descriptors that the guest has open and
   ensure the guest doesn't use file descriptos it doesn't have open.
 - Support file prefixes for a poor man's chroot.