### PR TITLE
fix submodules for azure pipelines

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git://git.musl-libc.org/musl
 [submodule "tests/bats"]
 	path = tests/bats
-	url = git@github.com:kontainapp/bats.git
+	url = https://github.com/kontainapp/bats
 [submodule "tests/greatest"]
 	path = tests/greatest
-	url = git@github.com:kontainapp/ctest_greatest.git
+	url = https://github.com/kontainapp/ctest_greatest


### PR DESCRIPTION
tested  on my desktop workspace, i.e. git init  sync and update.
verified it works in azure too:

```
019-07-27T01:58:04.3095193Z ##[section]Starting: Checkout
2019-07-27T01:58:04.3398141Z ==============================================================================
2019-07-27T01:58:04.3398396Z Task         : Get sources
2019-07-27T01:58:04.3398579Z Description  : Get sources from a repository. Supports Git, TfsVC, and SVN repositories.
2019-07-27T01:58:04.3398745Z Version      : 1.0.0
2019-07-27T01:58:04.3398841Z Author       : Microsoft
2019-07-27T01:58:04.3399069Z Help         : [More Information](https://go.microsoft.com/fwlink/?LinkId=798199)
2019-07-27T01:58:04.3399214Z ==============================================================================
2019-07-27T01:58:05.0817799Z Syncing repository: kontainapp/km (GitHub)
2019-07-27T01:58:06.0664359Z ##[command]git version
2019-07-27T01:58:06.0670336Z git version 2.22.0
2019-07-27T01:58:06.0671186Z ##[command]git lfs version
2019-07-27T01:58:06.8865661Z git-lfs/2.7.2 (GitHub; linux amd64; go 1.12.4)
2019-07-27T01:58:06.9267714Z ##[command]git init "/home/vsts/work/1/s"
2019-07-27T01:58:06.9775277Z Initialized empty Git repository in /home/vsts/work/1/s/.git/
2019-07-27T01:58:06.9831668Z ##[command]git remote add origin https://github.com/kontainapp/km
2019-07-27T01:58:07.0032618Z ##[command]git config gc.auto 0
2019-07-27T01:58:07.0107036Z ##[command]git config --get-all http.https://github.com/kontainapp/km.extraheader
2019-07-27T01:58:07.0170480Z ##[command]git config --get-all http.proxy
2019-07-27T01:58:07.0350554Z ##[command]git -c http.extraheader="AUTHORIZATION: basic ***" fetch --force --tags --prune --progress --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/pull/131/merge:refs/remotes/pull/
```