### PR TITLE
Update demo-script.md

### DIFF
--- a/payloads/demo-dweb/demo-script.md
+++ b/payloads/demo-dweb/demo-script.md
@@ -142,7 +142,7 @@ kubectl delete deploy kontain-pykm-deployment-azure-demo
 ## (optional) Local docker with our payloads
 
 ```bash
-docker run -p 8080:8080 -t --rm --device /dev/kvm kontain/python-km /cpython/python.km "/scripts/micro_srv.py"
+docker run -p 8080:8080 -t --rm --device /dev/kvm kontain/python-km /cpython/python.km -S "/scripts/micro_srv.py"
 docker run -p 8080:8080 -t --rm --device /dev/kvm kontain/dweb-km dweb.km 8080
 ```
 


### PR DESCRIPTION
   Use python -S flag (See issue #156)
    
    This is to circumvent 'import the site module' issue i
    observed when running /cpython/python.km "/scripts/micro_srv.py"
    in kontain/python-km container.
    
  

   Update dweb file path
    
    dweb file is no longer copied to /tmp/dweb
    
    Tested with:
    
    [jesnault@s510 demo-dweb]$ docker run --rm  dweb  /dweb/dweb -x
    I am DWEB. Exiting as requeste
