### PR TITLE
python version - make test-all works with 3.7.4 and 3.8.0 b3

### DIFF
--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -395,13 +395,14 @@ km_fs_setsockopt(km_vcpu_t* vcpu, int sockfd, int level, int optname, void* optv
 }
 
 // int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+// int getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 static inline uint64_t
-km_fs_getsockname(km_vcpu_t* vcpu, int sockfd, struct sockaddr* addr, socklen_t* addrlen)
+km_fs_get_sock_peer_name(km_vcpu_t* vcpu, int hc, int sockfd, struct sockaddr* addr, socklen_t* addrlen)
 {
    if (check_guest_fd(vcpu, sockfd) == -1) {
       return -EBADF;
    }
-   int ret = __syscall_3(SYS_getsockname, sockfd, (uintptr_t)addr, (uintptr_t)addrlen);
+   int ret = __syscall_3(hc, sockfd, (uintptr_t)addr, (uintptr_t)addrlen);
    return ret;
 }
 

--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -498,7 +498,7 @@ km_rt_sigaction(km_vcpu_t* vcpu, int signo, km_sigaction_t* act, km_sigaction_t*
 
 uint64_t km_kill(km_vcpu_t* vcpu, pid_t pid, int signo)
 {
-   if (pid != 0) {
+   if (pid != 0 && pid != 1) {
       return -EINVAL;
    }
    if (signo < 1 || signo >= NSIG) {

--- a/payloads/python/Setup.local
+++ b/payloads/python/Setup.local
@@ -21,7 +21,7 @@ math mathmodule.c _math.c # -lm # math library functions, e.g. sin()
 _contextvars _contextvarsmodule.c  # Context Variables
 _struct _struct.c      # binary structure packing/unpacking
 #_weakref _weakref.c    # basic weak reference support
-_testcapi _testcapimodule.c    # Python C API test module
+#_testcapi _testcapimodule.c    # Python C API test module
 _random _randommodule.c        # Random number generator
 _elementtree -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DUSE_PYEXPAT_CAPI _elementtree.c # elementtree accelerator
 _pickle _pickle.c      # pickle accelerator

--- a/payloads/python/build.sh
+++ b/payloads/python/build.sh
@@ -2,33 +2,20 @@
 
 set -x
 
-# list cpython unittest we do not want to run.
-TEST_PATH="./Lib/unittest/test"
-TEST_NAMES=(\
-  test_case.py \
-  test_discovery.py \
-  test_program.py \
-  test_result.py \
-  test_runner.py \
-)
-
 if [ ! -d cpython ]; then
-    git clone https://github.com/python/cpython.git -b v3.7.1
+    git clone https://github.com/python/cpython.git -b v3.7.4
     pushd cpython
     set -e
     ./configure CFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0" LDFLAGS="-static" --disable-shared
-    patch < ../pyconfig.h-patch
+    patch < ../pyconfig.h-patch || true
     cp ../Setup.local Modules/Setup.local
-    # Prefix tests differently to ensure that they are not run.
-    for tname in "${TEST_NAMES[@]}"; do
-        mv -v $TEST_PATH/$tname $TEST_PATH/__km_disable__$tname
-    done
+    patch -p1 < ../unittest.patch
     set +e
 else
     pushd cpython
 fi
 
-make -j8 LDFLAGS="-static" LINKFORSHARED=" " DYNLOADFILE="dynload_stub.o"
+make -j16 LDFLAGS="-static" LINKFORSHARED=" " DYNLOADFILE="dynload_stub.o"
 popd
 
 ./link-km.sh

--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -5,5 +5,5 @@ set -x
 KM_TOP=../$(git rev-parse --show-cdup)
 
 cd cpython
-cc -static -no-pie -ggdb -pthread Programs/python.o libpython3.7m.a -o python.km -L/usr/lib64 -lz  -specs=${KM_TOP}/gcc-km.spec -L ${KM_TOP}/build/runtime && chmod a-x python.km
+cc -static -no-pie -ggdb -pthread Programs/python.o libpython3*.a -o python.km -L/usr/lib64 -lz  -specs=${KM_TOP}/gcc-km.spec -L ${KM_TOP}/build/runtime && chmod a-x python.km
 

--- a/payloads/python/pyconfig.h-patch
+++ b/payloads/python/pyconfig.h-patch
@@ -1,6 +1,16 @@
---- pyconfig.h	2019-03-06 17:15:52.951436513 -0800
-+++ /home/serge/workspace/cpython/pyconfig.h	2019-03-06 16:01:36.654704447 -0800
-@@ -263,7 +263,7 @@
+--- pyconfig.h.orig	2019-08-05 22:36:12.022514663 -0700
++++ pyconfig.h	2019-08-05 22:38:31.674660581 -0700
+@@ -150,7 +150,8 @@
+ #define HAVE_COPYSIGN 1
+
+ /* Define to 1 if you have the `copy_file_range' function. */
+-#define HAVE_COPY_FILE_RANGE 1
++// #define HAVE_COPY_FILE_RANGE 1
++#undef HAVE_COPY_FILE_RANGE
+
+ /* Define to 1 if you have the <crypt.h> header file. */
+ #define HAVE_CRYPT_H 1
+@@ -274,7 +275,7 @@
  #define HAVE_DLFCN_H 1
 
  /* Define to 1 if you have the `dlopen' function. */
@@ -9,7 +19,7 @@
 
  /* Define to 1 if you have the `dup2' function. */
  #define HAVE_DUP2 1
-@@ -272,7 +272,7 @@
+@@ -283,7 +284,7 @@
  #define HAVE_DUP3 1
 
  /* Defined when any dynamic module loading is enabled. */
@@ -18,7 +28,22 @@
 
  /* Define to 1 if you have the <endian.h> header file. */
  #define HAVE_ENDIAN_H 1
-@@ -817,7 +817,7 @@
+@@ -753,10 +754,12 @@
+ #define HAVE_POSIX_FALLOCATE 1
+
+ /* Define to 1 if you have the `posix_spawn' function. */
+-#define HAVE_POSIX_SPAWN 1
++// #define HAVE_POSIX_SPAWN 1
++#undef HAVE_POSIX_SPAWN
+
+ /* Define to 1 if you have the `posix_spawnp' function. */
+-#define HAVE_POSIX_SPAWNP 1
++// #define HAVE_POSIX_SPAWNP 1
++#undef HAVE_POSIX_SPAWNP
+
+ /* Define to 1 if you have the `pread' function. */
+ #define HAVE_PREAD 1
+@@ -867,7 +870,7 @@
  #define HAVE_SCHED_RR_GET_INTERVAL 1
 
  /* Define to 1 if you have the `sched_setaffinity' function. */
@@ -27,12 +52,22 @@
 
  /* Define to 1 if you have the `sched_setparam' function. */
  #define HAVE_SCHED_SETPARAM 1
-@@ -898,7 +898,7 @@
+@@ -954,7 +957,7 @@
  #define HAVE_SIGACTION 1
 
  /* Define to 1 if you have the `sigaltstack' function. */
 -#define HAVE_SIGALTSTACK 1
 +// #define HAVE_SIGALTSTACK 1
 
- /* Define to 1 if `si_band' is a member of `siginfo_t'. */
- #define HAVE_SIGINFO_T_SI_BAND 1
+ /* Define to 1 if you have the `sigfillset' function. */
+ #define HAVE_SIGFILLSET 1
+@@ -999,7 +1002,8 @@
+ #define HAVE_SOCKETPAIR 1
+
+ /* Define to 1 if you have the <spawn.h> header file. */
+-#define HAVE_SPAWN_H 1
++// #define HAVE_SPAWN_H 1
++#undef HAVE_SPAWN_H
+
+ /* Define if your compiler provides ssize_t */
+ #define HAVE_SSIZE_T 1

--- a/payloads/python/test_unittest.py
+++ b/payloads/python/test_unittest.py
@@ -17,12 +17,16 @@ We should find a list of 50 modules.
 
 """
 import unittest
+import platform
 
 
 class TestModules(unittest.TestCase):
 
     def test_import_modules(self):
-        NUMBER_OF_MODULES = 50
+        if platform.python_version().split('.')[1] == '7':
+            NUMBER_OF_MODULES = 55
+        else:
+            NUMBER_OF_MODULES = 67
 
         with self.assertRaises(ModuleNotFoundError):
             import foo

--- a/payloads/python/unittest.patch
+++ b/payloads/python/unittest.patch
@@ -1,0 +1,25 @@
+diff --git a/Lib/unittest/test/test_program.py b/Lib/unittest/test/test_program.py
+index 4a62ae1b11..98cf922586 100644
+--- a/Lib/unittest/test/test_program.py
++++ b/Lib/unittest/test/test_program.py
+@@ -419,6 +419,7 @@ class TestCommandLineArgs(unittest.TestCase):
+ 
+         self.assertEqual(program.testNamePatterns, ['*foo*', '*bar*', '*pat*'])
+ 
++    @unittest.expectedFailure
+     def testSelectedTestNamesFunctionalTest(self):
+         def run_unittest(args):
+             p = subprocess.Popen([sys.executable, '-m', 'unittest'] + args,
+diff --git a/Lib/unittest/test/test_runner.py b/Lib/unittest/test/test_runner.py
+index 7d36340741..088c20c8cd 100644
+--- a/Lib/unittest/test/test_runner.py
++++ b/Lib/unittest/test/test_runner.py
+@@ -935,6 +935,7 @@ class Test_TextTestRunner(unittest.TestCase):
+         expectedresult = (runner.stream, DESCRIPTIONS, VERBOSITY)
+         self.assertEqual(runner._makeResult(), expectedresult)
+ 
++    @unittest.expectedFailure
+     def test_warnings(self):
+         """
+         Check that warnings argument of TextTestRunner correctly affects the
+

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -19,7 +19,7 @@ LIB := runtime_unused
 # arch specific ones based on ARCH.
 SRCDIR := musl/
 ARCH := x86_64
-SKIP_SRC_DIR := $(addprefix $(SRCDIR)src/, ipc ldso mq process sched)
+SKIP_SRC_DIR := $(addprefix $(SRCDIR)src/, ipc mq process sched)
 SRC_DIRS := $(filter-out $(addsuffix /,${SKIP_SRC_DIR}), $(wildcard $(addprefix $(SRCDIR),src/*/)))
 
 KM_REPLACED_SRCS := syscall.s syscall_cp.s __libc_start_main.c __init_tls.c __reset_tls.c  getenv.c uname.c \

--- a/runtime/runtime_stub_km.c
+++ b/runtime/runtime_stub_km.c
@@ -17,7 +17,7 @@
 
 int __dummy_stub(void)
 {
-   return 0;
+   return -ENOSYS;
 }
 
 static void dump_core_stub(const char* syscall_name)
@@ -39,8 +39,8 @@ static void dump_core_stub(const char* syscall_name)
  */
 __stub_core__(execve);
 __stub_core__(execvp);
-__stub_core__(fork);
-__stub_core__(waitpid);
+__stub__(fork);
+__stub__(waitpid);
 __stub_core__(execv);
 __stub_core__(fexecve);
 __stub_core__(sched_getparam);
@@ -54,13 +54,6 @@ __stub_core__(sched_yield);
 __stub_core__(system);
 __stub_core__(wait);
 __stub_core__(waitid);
-
-__stub_core__(dl_iterate_phdr);
-__stub_core__(dladdr);
-__stub_core__(dlclose);
-__stub_core__(dlerror);
-__stub_core__(dlopen);
-__stub_core__(dlsym);
 
 /*
  * executable stubs, returning simple canned value

--- a/tests/signal_test.c
+++ b/tests/signal_test.c
@@ -200,8 +200,8 @@ TEST test_sigaction()
 
 TEST test_kill()
 {
-   // Another process
-   ASSERT_EQ(-1, kill(1, SIGUSR1));
+   // Another process - we are 1, hence we use 2
+   ASSERT_EQ(-1, kill(2, SIGUSR1));
    ASSERT_EQ(EINVAL, errno);
 
    // test bad signal numbers


### PR DESCRIPTION
make python 3.8.0 (beta 3) work, as well as 3.7.4
add the tests that were removed, make two of them skipped