### PR TITLE
Almost trivial - send guest pthread pointer to gdb instead of vcpu_id

### DIFF
--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -422,7 +422,7 @@ static void km_gdb_general_query(char* packet, char* obuf)
          send_error_msg();
          return;
       }
-      sprintf(label, "vcpu %d", vcpu->vcpu_id);   // gdb allow free form labels, so we send VCPU ID
+      sprintf(label, "Guest 0x%lx", vcpu->guest_thr);   // guest pthread pointer in free form label
       mem2hex((unsigned char*)label, obuf, strlen(label));
       send_packet(obuf);
    } else {


### PR DESCRIPTION
tell gdb guest pthread pointer in free label.
as TID now is vcpu_id + 1, sending vcpu_id is pointless