### PR TITLE
Added --log-to KM flag, to stream stdout/stderr to the file.

### DIFF
--- a/km/km_main.c
+++ b/km/km_main.c
@@ -44,6 +44,7 @@ static inline void usage()
         "\t--gdb-server-port[=port] (-g[port]) - Listen for gbd on <port> (default 2159) "
         "before running payload\n"
         "\t--version (-v)                      - Print version info and exit\n"
+        "\t--log-to=file_name                  - Stream stdout and stderr to file_name\n"
         "\t--wait-for-signal                   - Wait for SIGUSR1 before running payload\n"
         "\t--dump-shutdown                     - Produce register dump on VCPU error\n"
         "\t--core-on-err                       - generate KM core dump when exiting on err, "
@@ -93,6 +94,7 @@ static struct option long_options[] = {
     {"overcommit-memory", no_argument, &(km_machine_init_params.overcommit_memory), 1},
     {"coredump", required_argument, 0, 'C'},
     {"membus-width", required_argument, 0, 'P'},
+    {"log-to", required_argument, 0, 'l'},
     {"gdb-server-port", optional_argument, 0, 'g'},
     {"verbose", optional_argument, 0, 'V'},
     {"core-on-err", no_argument, &debug_dump_on_err, 1},
@@ -129,6 +131,11 @@ int main(int argc, char* const argv[])
                usage();
             }
             km_gdb_port_set(port);
+            break;
+         case 'l':
+            if (freopen(optarg, "a", stdout) == NULL || freopen(optarg, "a", stderr) == NULL) {
+               err(1, optarg);
+            }
             break;
          case 'C':
             km_set_coredump_path(optarg);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -137,6 +137,17 @@ teardown() {
    run km_with_timeout hello_test # Linux executable instead of .km
    assert_failure
    assert_line "km: Non-KM binary: cannot find interrupt handler(*), tsd size(*), or sigreturn(*). Trying to run regular Linux executable in KM?"
+
+   log=`mktemp`
+   echo Log location: $log
+   run km_with_timeout -V --log-to=$log hello_test.km # check --log-to option
+   assert_success
+   assert [ -e $log ]
+   assert grep -q 'Hello, world' $log       # stdout
+   assert grep -q 'Setting VendorId ' $log  # stderr
+   rm $log
+   run km_with_timeout -V --log-to=/very/bad/place hello_test.km
+   assert_failure
 }
 
 @test "mem_slots: KVM memslot / phys mem sizes (memslot_test)" {


### PR DESCRIPTION
Helpful in places like runk (so they can pass the flag instead of messing with fds)
Fixes #167