### PR TITLE
small cleanup - moved mmaps under machine plus a couple small cosmetic fixes. 

### DIFF
--- a/km/gdb/list.gdb
+++ b/km/gdb/list.gdb
@@ -22,7 +22,7 @@ document print_list
    Prints LIST info. Assumes LIST entry name is 'link'
      Syntax: print_list &LIST
    Examples:
-     print_list &mmaps.free
+     print_list &machine.mmaps.free
 end
 
 define print_tailq
@@ -51,13 +51,13 @@ document print_tailq
    Prints TAILQ info. Assumes TAILQ entry name is 'link'
      Syntax: print_tailq &LIST
    Examples:
-     print_tailq &mmaps.free
+     print_tailq &machine.mmaps.free
 end
 
 define km_mmaps
    print "mmaps FREE list:"
-   print_tailq &mmaps.free
+   print_tailq &machine.mmaps.free
    print "mmaps BUSY list:"
-   print_tailq &mmaps.busy "Busy list"
+   print_tailq &machine.mmaps.busy "Busy list"
    printf ".tbrk= 0x%lx\n", machine.tbrk
 end

--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -41,6 +41,9 @@ km_machine_t machine = {
     .signal_mutex = PTHREAD_MUTEX_INITIALIZER,
     .sigpending.head = TAILQ_HEAD_INITIALIZER(machine.sigpending.head),
     .sigfree.head = TAILQ_HEAD_INITIALIZER(machine.sigfree.head),
+    .mmaps.free = TAILQ_HEAD_INITIALIZER(machine.mmaps.free),
+    .mmaps.busy = TAILQ_HEAD_INITIALIZER(machine.mmaps.busy),
+    .mmaps.mutex = PTHREAD_MUTEX_INITIALIZER,
 };
 
 /*

--- a/tests/cpuid_print_details_test.c
+++ b/tests/cpuid_print_details_test.c
@@ -186,6 +186,7 @@ int main(void)
       print_feature(ecx & (1 << 7), "MISALIGNSSE   (Misaligned SSE mode)");
       print_feature(ecx & (1 << 2), "SVM           (Secure Virtual Machine)");
       print_feature(ecx & (1 << 0), "LAHFSAHF      (LAHF and SAHF instruction support in 64-bit mode)");
+      print_feature(edx & (1 << 26), "pdpe1g        (1G pages support)");
    }
    return 0;
 }

--- a/tests/gdb/mprotect.gdb
+++ b/tests/gdb/mprotect.gdb
@@ -7,7 +7,7 @@ source ../km/gdb/list.gdb
 break km_hcalls.c:dummy_hcall
 command
 print "Busy list"
-print_tailq &mmaps.busy
+print_tailq &machine.mmaps.busy
 print "Free list"
-print_tailq &mmaps.free
+print_tailq &machine.mmaps.free
 end

--- a/tests/mprotect_test.c
+++ b/tests/mprotect_test.c
@@ -267,7 +267,7 @@ TEST concat_test()
        {"11.mprotect", TYPE_MPROTECT, 6 * MIB, 1 * MIB, PROT_READ, flags, OK},
 
        // TODO: automate checking for the mmaps concatenation. For now check with `print_tailq
-       // &mmaps.busy ` in gdb
+       // &machine.mmaps.busy ` in gdb
        {"12.cleanup unmap", TYPE_MUNMAP, 0, 15 * MIB, PROT_NONE, flags, OK},
 
        {NULL},


### PR DESCRIPTION
No impact to functionality (other that timeout is added to gdb run so it will not hang on errors)

* move mmaps from static under machine to be consistent with other machine vars
* replaced 'jobs -p' with '$!' in .bats, and added timeout to gdb runs
* added a check for 1gpages in cpuid_print_details_test (manual helper)