### PR TITLE
Move identity map page out of the way

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -119,9 +119,9 @@ typedef enum {
 typedef struct km_machine_init_params {
    uint64_t guest_physmem;         // Requested size of guest physical memory in bytes
    km_flag_force_t force_pdpe1g;   // force on/off 1g pages support regardless of VM CPUID support
-                                   // TODO: check if there is a KVM config for force-enable
-   int overcommit_memory;   // 1 if we want to allow memory overcommit (i.e. MAP_NORESERVE in mmap)
-                            // Note: if too much of it is accessed, we expect Linux OOM killer to kick in
+   km_flag_force_t overcommit_memory;   // memory overcommit (i.e. MAP_NORESERVE in mmap)
+                                        // Note: if too much of it is accessed, we expect Linux OOM
+                                        // killer to kick in
 } km_machine_init_params_t;
 
 void km_machine_init(km_machine_init_params_t* params);

--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -492,7 +492,7 @@ void km_machine_init(km_machine_init_params_t* params)
             break;
          case 0x80000001:
             machine.pdpe1g = ((entry->edx & 1ul << 26) != 0);
-            if (machine.pdpe1g == 0 && params->force_pdpe1g == KM_FLAG_FORCE_ENABLE) {
+            if (machine.pdpe1g == 0 && params->force_pdpe1g != KM_FLAG_FORCE_DISABLE) {
                // The actual hardware should support it, otherwise expect payload to EXIT_SHUTDOWN
                km_infox(KM_TRACE_KVM, "PATCHING pdpe1g to 1");
                entry->edx |= (1ul << 26);

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -55,8 +55,8 @@ static inline void usage()
         "\n\tOverride auto detection:\n"
         "\t--membus-width=size (-Psize)        - Set guest physical memory bus size in bits, i.e. "
         "32 means 4GiB, 33 8GiB, 34 16GiB, etc. \n"
-        "\t--enable-1g-pages  - Force enable 1G pages support (assumes hardware support)\n"
-        "\t--disable-1g-pages - Force disable 1G pages support.");
+        "\t--enable-1g-pages  - Force enable 1G pages support (default). Assumes hardware support\n"
+        "\t--disable-1g-pages - Force disable 1G pages support");
 }
 
 // Version info. SCM_* is supposed to be set by the build
@@ -83,7 +83,10 @@ static inline void show_version(void)
         BUILD_TIME);
 }
 
-static km_machine_init_params_t km_machine_init_params = {};
+static km_machine_init_params_t km_machine_init_params = {
+   .force_pdpe1g = KM_FLAG_FORCE_ENABLE,
+   .overcommit_memory = KM_FLAG_FORCE_DISABLE,
+};
 static int wait_for_signal = 0;
 int debug_dump_on_err = 0;   // if 1, will abort() instead of err()
 static struct option long_options[] = {
@@ -91,7 +94,7 @@ static struct option long_options[] = {
     {"dump-shutdown", no_argument, 0, 'D'},
     {"enable-1g-pages", no_argument, &(km_machine_init_params.force_pdpe1g), KM_FLAG_FORCE_ENABLE},
     {"disable-1g-pages", no_argument, &(km_machine_init_params.force_pdpe1g), KM_FLAG_FORCE_DISABLE},
-    {"overcommit-memory", no_argument, &(km_machine_init_params.overcommit_memory), 1},
+    {"overcommit-memory", no_argument, &(km_machine_init_params.overcommit_memory), KM_FLAG_FORCE_ENABLE},
     {"coredump", required_argument, 0, 'C'},
     {"membus-width", required_argument, 0, 'P'},
     {"log-to", required_argument, 0, 'l'},

--- a/km/km_mem.h
+++ b/km/km_mem.h
@@ -35,16 +35,14 @@ static const int RSV_PDPT_OFFSET = 1 * KM_PAGE_SIZE;
 static const int RSV_PDPT2_OFFSET = 2 * KM_PAGE_SIZE;
 static const int RSV_PD_OFFSET = 3 * KM_PAGE_SIZE;
 static const int RSV_PD2_OFFSET = 4 * KM_PAGE_SIZE;
+static const int RSV_IDMAP_OFFSET = RSV_MEM_SIZE;   // next page after reserved area
 /*
  * convert the above to guest physical offsets
  */
 #define RSV_GUEST_PA(x) ((x) + RSV_MEM_START)
 
 static const int KM_RSRV_MEMSLOT = 0;
-static const int KM_TEXT_DATA_MEMSLOT = 1;
-// other text and data memslots follow
 
-// memreg_base(KM_TEXT_DATA_MEMSLOT)
 static const km_gva_t GUEST_MEM_START_VA = 2 * MIB;
 // ceiling for guest virt. address. 2MB shift down to make it aligned on GB with physical address
 static const km_gva_t GUEST_MEM_TOP_VA = 128 * 1024 * GIB - 2 * MIB;


### PR DESCRIPTION
move identity map page out of the way so it doesn't overlap with our memory regions.
Change 1g pages default to enable
Some cleanup

Fix #184 
Fix #185 