### PR TITLE
Change tests/Makefile to use kontain-gcc wrapper

### DIFF
--- a/gcc-km.spec
+++ b/gcc-km.spec
@@ -13,4 +13,4 @@ crtbeginT.o%s
 crtend.o%s
 
 *link:
-%(old_link) -static -Ttext-segment=0x1FF000 -u__km_sigreturn -u__km_handle_interrupt -e__start_c__ --gc-sections -zseparate-code -znorelro -zmax-page-size=0x1000 --build-id=none
+%(old_link) -static -Ttext-segment=0x1FF000 -umain -u__km_sigreturn -u__km_handle_interrupt -e__start_c__ --gc-sections -zseparate-code -znorelro -zmax-page-size=0x1000 --build-id=none

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -17,6 +17,8 @@ FROMTOP := $(shell git rev-parse --show-prefix)
 # use 'SRC_BRANCH=branch make <target>' for building target (e.g clean :-)) for other branches, if needed
 SRC_BRANCH ?= $(shell git rev-parse --abbrev-ref  HEAD)
 
+PATH := $(realpath ${TOP}tools):${PATH}
+
 # sha and build time for further reporting
 SRC_VERSION := $(shell git rev-parse HEAD)
 BUILD_TIME := $(shell date -Iminutes)

--- a/payloads/busybox/Makefile
+++ b/payloads/busybox/Makefile
@@ -13,7 +13,7 @@
 TOP := $(shell git rev-parse --show-cdup)
 
 SHELL :=/bin/bash
-PATH  := $(realpath ${TOP}tools):${PATH}
+PATH := $(realpath ${TOP}tools):${PATH}
 
 # KM monitor path
 KM_BIN=${TOP}/build/km/km

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,17 +24,17 @@ SRC_CPP = var_storage_test.cpp throw_basic_test.cpp
 
 COPTS ?= -ggdb -O2
 CFLAGS = -Wall $(COPTS) -fno-stack-protector -pthread -I$(TOP)include -I$(TOP)km
-LDFLAGS = -static -no-pie -ggdb -pthread
-KM_LDFLAGS = -specs=${TOP}gcc-km.spec $(patsubst %,-L %,${LDDIRS})
-LDDIRS := ${TOP}build/runtime
+LDFLAGS = -ggdb -pthread
+KCC := kontain-gcc
 DEPS = ${SRC:%.c=%.d} ${SRC_CPP:%.cpp=%.d}
 KM_PAYLOADS := ${SRC:%.c=%.km} ${SRC_CPP:%.cpp=%.km}
 EXECS := ${KM_PAYLOADS} ${KM_PAYLOADS:%.km=%}
 
-${KM_PAYLOADS}: ${LDDIRS}
+${KM_PAYLOADS}: ${TOP}build/runtime
 
 CXXFLAGS=${CFLAGS}
-${SRC_CPP:%.cpp=%} ${SRC_CPP:%.cpp=%.km}: CC=g++
+${SRC_CPP:%.cpp=%.km}: KCC=kontain-g++
+${SRC_CPP:%.cpp=%}: CC=g++
 
 # Test: run by BATS, definition in TEST_FILES, test name has to MATCH
 BATS := time bats/bin/bats
@@ -55,15 +55,14 @@ ifeq (${MAKECMDGOALS},.coverage)
 else
 	@export KM_BIN=$(KM_BIN); export TIME_INFO=${TIME_INFO};  ${BATS} -p -f "${MATCH}" ${TEST_FILES}
 endif
-	@echo -e "${GREEN}Tests slower that 0.01 sec:${NOCOLOR}"
-	@grep elapsed ${TIME_INFO} | grep -v "elapsed 0:00.0[01]" | sort -r
+	@echo -e "${GREEN}Tests slower than 0.1 sec:${NOCOLOR}"
+	@grep elapsed ${TIME_INFO} | grep -v "elapsed 0:00.[01]" | sort -r
 	@echo ""
 	@rm -f ${TIME_INFO}
 
 
 %.km: %.o
-	${CC} ${LDFLAGS} $< -o $@ ${KM_LDFLAGS}
-	@chmod a-x $@
+	${KCC} ${LDFLAGS} $< -o $@ ${KM_LDFLAGS}
 
 .PHONY: load_expected_size
 load_expected_size: load_test.km

--- a/tools/kontain-g++
+++ b/tools/kontain-g++
@@ -1,0 +1,1 @@
+kontain-gcc

--- a/tools/kontain-gcc
+++ b/tools/kontain-gcc
@@ -1,12 +1,14 @@
 #!/bin/bash
-if [ $# -eq 0 ] ; then exec "${REALGCC:-gcc}" ; fi
-
+# invoke gcc with extra params for Kontain link
+#
+cmd=`basename ${BASH_SOURCE[0]}`
 dir=`dirname ${BASH_SOURCE[0]}`
+if [[ $cmd == *g++ ]] ; then REALGCC=g++ ; else REALGCC=gcc; fi
+if [ $# -eq 0 ] ; then exec "${REALGCC}" ; fi
+
 KM_TOP=`realpath $dir/../../km`
-# invoke gcc with extra params for Kontain link;
-# note: some tools (e.g. busybox) have 'main' defined in .a file, so we need to force linking it in
-# set -x
-exec "${REALGCC:-gcc}" \
-   -static -no-pie -specs=${KM_TOP}/gcc-km.spec -Wl,--undefined=main \
+# note: some tools (e.g. busybox) have 'main' defined in .a file, thus we force linking it in with -u=main
+exec "${REALGCC}" \
+   -static -no-pie -specs=${KM_TOP}/gcc-km.spec \
     "$@" \
    -L/usr/lib64 -lz -L ${KM_TOP}/build/runtime


### PR DESCRIPTION
makes it a bit easier to assemble .km file. Note that the tests .o files are still compiled with regular gcc/g++,  and kontain-gcc/g++ is only used on  the link step: 
```
[msterin@ryzen tests]$ touch hello_test.c throw_basic_test.cpp 
[msterin@ryzen tests]$ make
cc -E -MT throw_basic_test.o -MT throw_basic_test.d -MM -Wall -ggdb -O2 -fno-stack-protector -pthread -I../include -I../km throw_basic_test.cpp -o throw_basic_test.d
cc -MT hello_test.o -MT hello_test.d -MM -Wall -ggdb -O2 -fno-stack-protector -pthread -I../include -I../km hello_test.c -o hello_test.d
cc -Wall -ggdb -O2 -fno-stack-protector -pthread -I../include -I../km   -c -o hello_test.o hello_test.c
kontain-gcc -ggdb -pthread hello_test.o -o hello_test.km 
g++ -Wall -ggdb -O2 -fno-stack-protector -pthread -I../include -I../km   -c -o throw_basic_test.o throw_basic_test.cpp
kontain-g++ -ggdb -pthread throw_basic_test.o -o throw_basic_test.km 
cc -ggdb -pthread  hello_test.o   -o hello_test
g++ -ggdb -pthread  throw_basic_test.o   -o throw_basic_test
```

kontain-gcc can also be used as a replacement for gcc if we want a simple way to build stuff internaly,  e.g.

```
msterin@ryzen tests]$ ../tools/kontain-gcc hello_test.c
[msterin@ryzen tests]$ ../build/km/km a.out 
Hello, world
Hello, argv[0] = 'a.out'
```
same for g++
```
[msterin@ryzen tests]$ ../tools/kontain-g++ throw_basic_test.cpp 
[msterin@ryzen tests]$ ../build/km/km a.out 
throw test: Before exception
throw test: Ready to throw
throw test: Exception Caught !
```
