### PR TITLE
make km memory private to enable Linux to collapse contiguous areas

### DIFF
--- a/km/km_mem.c
+++ b/km/km_mem.c
@@ -207,7 +207,7 @@ static int overcommit_memory;   // controls how we request memory for payload fr
 static void* km_guest_page_malloc(km_gva_t gpa_hint, size_t size, int prot)
 {
    km_kma_t addr;
-   int flags = MAP_SHARED | MAP_ANONYMOUS | (overcommit_memory == 1 ? MAP_NORESERVE : 0);
+   int flags = MAP_PRIVATE | MAP_ANONYMOUS | (overcommit_memory == 1 ? MAP_NORESERVE : 0);
 
    if ((size & (KM_PAGE_SIZE - 1)) != 0 || (gpa_hint & (KM_PAGE_SIZE - 1)) != 0) {
       errno = EINVAL;
@@ -231,7 +231,7 @@ void km_guest_page_free(km_gva_t addr, size_t size)
 km_gva_t km_guest_mmap_simple(size_t size)
 {
    return km_syscall_ok(
-       km_guest_mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+       km_guest_mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
 }
 
 /*


### PR DESCRIPTION
It turns out Linux mmap of contiguous (back to back) memory ares is very different for PRIVATE and SHARED mmaps. The latter keeps each mmaped area separate even though they logically contiguous, however the former does collapse them into a single area. We used to use SHARED for no particular reason - we are not sharing that memory between processes, and I don't think we have plans to do so. Changing the flag to PRIVATE makes Linux collapse the memory areas.

I don't know how much difference does it make, but in general fewer data structures should be better.