### PR TITLE
Set thread name to 'vcpu-N'  - helps in gdb -[trivial]

### DIFF
--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -10,6 +10,7 @@
  * permission of Kontain Inc.
  */
 
+#define _GNU_SOURCE
 #include <assert.h>
 #include <err.h>
 #include <errno.h>
@@ -593,6 +594,10 @@ void* km_vcpu_run(km_vcpu_t* vcpu)
 {
    int hc;
    vcpu->is_paused = 1;
+
+   char thread_name[16];   // see 'man pthread_getname_np'
+   sprintf(thread_name, "vcpu-%d", vcpu->vcpu_id);
+   pthread_setname_np(vcpu->vcpu_thread, thread_name);
 
    while (1) {
       int reason;

--- a/runtime/syscall_cp_km.c
+++ b/runtime/syscall_cp_km.c
@@ -34,6 +34,7 @@ long __syscall_cp_asm(int* c, long n, long a1, long a2, long a3, long a4, long a
       __asm__("__cp_end:");
       return arg.hc_ret;
    }
+   _Pragma("GCC diagnostic ignored \"-Wreturn-type\"");   // shut up gcc about lack of 'return'
    __asm__("__cp_cancel:"
            "jmp __cancel");
 }


### PR DESCRIPTION
`info thread` in gdb now tells vcpu-id for each thread: 
```
(gdb) info thr
  Id   Target Id                                 Frame 
  1    Thread 0x53e8c0 (LWP 1610) "km"           0x000000000042ceac in read ()
  2    Thread 0x7ffff7ff7700 (LWP 1621) "vcpu-0" 0x0000000000429a45 in pthread_cond_wait ()
* 3    Thread 0x7ffff77f3700 (LWP 1623) "vcpu-1" km_pthread_create (current_vcpu=0x7ffff0000b20, pid=0x107fffbfdaa0, attr=0x107fffbfdab0, start=2100128, args=2121728)
    at km_init_guest.c:424
  4    Thread 0x7ffff77df700 (LWP 1624) "vcpu-2" futex_hcall (vcpu=<optimized out>, hc=<optimized out>, arg=0x107fffbdd950) at km_syscall.h:111
  5    Thread 0x7ffff77cb700 (LWP 1625) "vcpu-3" 0x0000000000429a45 in pthread_cond_wait ()
  6    Thread 0x7ffff77b7700 (LWP 1627) "vcpu-4" 0x0000000000429a45 in pthread_cond_wait ()

```
