### PR TITLE
load_elf to add .km to file if not there

### DIFF
--- a/km/km_main.c
+++ b/km/km_main.c
@@ -36,7 +36,7 @@ static inline void usage()
 {
    errx(1,
         "Kontain Monitor - runs 'payload-file [payload args]' in Kontain VM\n"
-        "Usage: km [options] <payload-file> [-- <payload args>]\n"
+        "Usage: km [options] payload-file.[km] [payload_args ... ]\n"
 
         "\nOptions:\n"
         "\t--verbose[=regexp] (-V[regexp])     - Verbose print where internal info tag matches "
@@ -84,8 +84,8 @@ static inline void show_version(void)
 }
 
 static km_machine_init_params_t km_machine_init_params = {
-   .force_pdpe1g = KM_FLAG_FORCE_ENABLE,
-   .overcommit_memory = KM_FLAG_FORCE_DISABLE,
+    .force_pdpe1g = KM_FLAG_FORCE_ENABLE,
+    .overcommit_memory = KM_FLAG_FORCE_DISABLE,
 };
 static int wait_for_signal = 0;
 int debug_dump_on_err = 0;   // if 1, will abort() instead of err()

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -127,12 +127,17 @@ static void tls_extent(int fd, GElf_Phdr* phdr)
  */
 int km_load_elf(const char* file)
 {
+   char fn[strlen(file + 3)];
    int fd;
    Elf* e;
    GElf_Ehdr* ehdr = &km_guest.km_ehdr;
 
    if (elf_version(EV_CURRENT) == EV_NONE) {
       errx(2, "ELF library initialization failed: %s", elf_errmsg(-1));
+   }
+   if (strcmp(".km", file + strlen(file) - 3) != 0) {
+      sprintf(fn, "%s.km", file);
+      file = fn;
    }
    if ((fd = open(file, O_RDONLY, 0)) < 0) {
       err(2, "open %s failed", file);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -151,9 +151,12 @@ function in_docker() {
    assert_failure
    assert_line --partial "invalid option"
 
-   run km_with_timeout hello_test # Linux executable instead of .km
+   # KM will auto-add '.km' to file name, so create a .km file with Linux executable
+   tmp=/tmp/hello$$ ; cp hello_test $tmp.km
+   run km_with_timeout $tmp # Linux executable instead of .km
    assert_failure
    assert_line "km: Non-KM binary: cannot find interrupt handler(*), tsd size(*), or sigreturn(*). Trying to run regular Linux executable in KM?"
+   rm $tmp.km # may leave dirt if the tests above fail
 
    log=`mktemp`
    echo Log location: $log


### PR DESCRIPTION
This way I can make shell script like this:

`#!_path_to_km_/km`

and name it _path_to_node_/node. It allows other tools, like node test framework, work with no changes.

It's the next best thing to encoding interpreter in ELF, which I'm still not sure how to do.