### PR TITLE
move update-build-image make target to cloud/azure

### DIFF
--- a/cloud/azure/Makefile
+++ b/cloud/azure/Makefile
@@ -45,6 +45,10 @@ login:  ## Interactive login to Azure, Acure Container Registry and Kubernetes c
 dashboard: login # Interactive login, and then forward port/open Kubernetes Dashboard
 	az aks browse --resource-group $(CLOUD_RESOURCE_GROUP) --name $(K8S_CLUSTER)
 
+DTYPE ?= fedora
+buildenv:  ## Build km-buildenv image for Azure
+	./buildenv.sh ${DTYPE}
+
 # Support for simple debug print (make debugvars)
 VARS_TO_PRINT ?= CLOUD_RESOURCE_GROUP CLOUD_SUBSCRIPTION CLOUD_LOCATION \
 					K8_SERVICE_PRINCIPAL K8S_CLUSTER K8S_NODE_INSTANCE_SIZE \

--- a/cloud/azure/buildenv.sh
+++ b/cloud/azure/buildenv.sh
@@ -1,0 +1,28 @@
+# Copyright © 2019 Kontain Inc. All rights reserved.
+#
+# Kontain Inc CONFIDENTIAL
+#
+#  This file includes unpublished proprietary source code of Kontain Inc. The
+#  copyright notice above does not evidence any actual or intended publication of
+#  such source code. Disclosure of this source code or any related proprietary
+#  information is strictly prohibited without the express written permission of
+#  Kontain Inc.
+#
+# create buildenv images and push them to Azure regitry
+
+TOP=$(git rev-parse --show-cdup)
+source `dirname $0`/cloud_config.mk
+
+DTYPE=$1
+DLOC=${TOP}docker/build
+DIMG=km-buildenv-${DTYPE}
+DFILE=Dockerfile.${DTYPE}
+DIMG=${REGISTRY}/${DIMG}
+
+# DEBUG=echo
+
+$DEBUG az acr login -n ${REGISTRY_NAME}
+$DEBUG docker build --build-arg=USER=appuser  \
+	--build-arg=UID=1001 --build-arg=GID=117 \
+	-t ${DIMG} ${DLOC} -f ${DLOC}/${DFILE}
+	docker push ${DIMG}

--- a/docs/azure_pipeline.md
+++ b/docs/azure_pipeline.md
@@ -75,3 +75,7 @@ If you want changes to CI, you can edit script in your private branch and go thr
 
 CI source is under source control if you have questions/confusion - please ask @ slack **build\_and\_test** channel, and PLEASE do not not hesitate to update this file with the info :-)
 
+### Update buildenv images
+
+    make -C ./cloud/azure buildenv      # default to fedora
+    make -C ./cloud/azure buildenv DTYPE=ubuntu|fedora|alpine

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -194,17 +194,9 @@ endif
 UID := $(shell id -u)
 GID := $(shell id -g)
 
-.PHONY: mk-image update-build-image
+.PHONY: mk-image
 mk-image: ## build fedora image
 	docker build --build-arg=USER=$(USER)  --build-arg=UID=$(UID) --build-arg=GID=$(GID) -t ${DIMG} ${DLOC} -f ${DLOC}/${DFILE}
-
-# This target assumes we are building for kontainkubecr registry.
-update-build-image:
-	az acr login -n kontainkubecr
-	docker build --build-arg=USER=appuser  \
-         --build-arg=UID=1001 --build-arg=GID=117 \
-         -t ${DIMG} ${DLOC} -f ${DLOC}/${DFILE}
-	docker push ${DIMG}
 
 # Default is to tag test-bats image with uid.
 # Allows for Azure CI to set tag with build id.


### PR DESCRIPTION
- remove update-build-image target from generic make
- add buildenv target to clould/azure makefile
- update azure_pipeline.md

tested:

```
   make -C ./cloud/azure buildenv
   make -C ./cloud/azure buildenv DTYPE=ubuntu
   make -C ./cloud/azure buildenv DTYPE=alpine
```
fix #213