### PR TITLE
Support environment vars passing to payload via --putenv and --copyenv flags

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,7 @@
          "request": "launch",
          "program": "${workspaceFolder}/build/km/km",
          "args": [
-            "-Vmmap",
-            "tests/${input:test_payload}.km",
-            "-v"
+            "tests/${input:test_payload}.km"
          ],
          "stopAtEntry": true,
          "cwd": "${workspaceFolder}",

--- a/km/km.h
+++ b/km/km.h
@@ -208,7 +208,7 @@ typedef struct km_machine {
    km_signal_list_t sigfree;       // Freelist of signal entries.
    km_sigaction_t sigactions[_NSIG];
    km_filesys_t filesys;
-   km_mmap_cb_t mmaps;       // guest memory regions managed with mmaps/mprotect/munmap
+   km_mmap_cb_t mmaps;   // guest memory regions managed with mmaps/mprotect/munmap
 } km_machine_t;
 
 extern km_machine_t machine;
@@ -250,7 +250,7 @@ static inline int km_wait_on_eventfd(int fd)
    return value;
 }
 
-km_gva_t km_init_libc_main(km_vcpu_t* vcpu, int argc, char* const argv[]);
+km_gva_t km_init_libc_main(km_vcpu_t* vcpu, int argc, char* const argv[], int envc, char* envp[]);
 int km_pthread_create(
     km_vcpu_t* vcpu, pthread_tid_t* restrict pid, const km_kma_t attr, km_gva_t start, km_gva_t args);
 int km_pthread_join(km_vcpu_t* vcpu, pthread_tid_t pid, km_kma_t ret);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ SRC = hello_test.c hello_html_test.c brk_test.c mmap_test.c gdb_test.c exit_valu
 		getline_test.c mem_test.c exit_grp_test.c intr_test.c brk_map_test.c crash_test.c cpuid_test.c \
 		longjmp_test.c cpuid_print_details_test.c stray_test.c signal_test.c hello_2_loops_tls_test.c \
 		regions_test.c mprotect_test.c pthread_cancel_test.c filesys_test.c filepath_test.c socket_test.c \
-		dl_iterate_phdr_test.c
+		dl_iterate_phdr_test.c env_test.c
 
 SRC_CPP = var_storage_test.cpp throw_basic_test.cpp
 

--- a/tests/env_test.c
+++ b/tests/env_test.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2018-2019 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ *
+ * Simple test of env vars
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define MAX_ENV_VAR_SIZE (1024ul * 16)   // account for stuff like BASH_FUNC_
+
+int main(int argc, char* argv[])
+{
+   printf("Testing getenv/putenv,  __environ = %p\n", __environ);
+   for (int i = 0; __environ[i] != 0; i++) {
+      char name[MAX_ENV_VAR_SIZE];   // var name bufer
+      char* c = strchrnul(__environ[i], '=');
+      strncpy(name, __environ[i], c - __environ[i]);
+      name[c - __environ[i]] = 0;
+      char* v = getenv(name);
+      printf("getenv: %s=%s\n", name, v);
+   }
+   exit(0);
+}

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -170,6 +170,23 @@ function in_docker() {
    assert_failure
 }
 
+@test "environ: passing environment to payloads (env_test)" {
+   val=`pwd`/$$
+   run km_with_timeout --putenv PATH=$val env_test.km
+   assert_success
+   assert_output --partial "PATH=$val"
+
+   run km_with_timeout --copyenv env_test.km
+   assert_success
+   assert_output --partial "PATH=$PATH"
+
+   run km_with_timeout --copyenv --putenv MORE=less env_test.km
+   assert_failure
+
+   run km_with_timeout --putenv PATH=testingpath --copyenv env_test.km
+   assert_failure
+}
+
 @test "mem_slots: KVM memslot / phys mem sizes (memslot_test)" {
    run ./memslot_test
    assert_success


### PR DESCRIPTION
```
--putenv KEY=VALUE -- adds a new env to payload. Multiple --putenv can be used
--copyenv          -- copies payload host i.e. KM) environment to payload
```

`--putenv` and `--copyenv` are mutually exclusive. Also, no attempt to replace existing keys
are made during `--putenv` handling, so if multiple flags set the same KEY, only the first one
will be picked up by payload `getenv()` call

Tests included