### PR TITLE
specify explicit rlimit for nfiles under docker

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -53,7 +53,7 @@ Run `sudo service docker start` to start the Docker service.
 
 #### Configuring Docker
 
-By default Docker require root permission to run. Read the instructions at https://docs.docker.com/install/linux/linux-postinstall/ to run docker without being root. 
+By default Docker require root permission to run. Read the instructions at https://docs.docker.com/install/linux/linux-postinstall/ to run docker without being root.
 
 
 ### Building directly on the box
@@ -109,7 +109,7 @@ Note that we do not tag any image as `latest` since I am not sure which oneto ta
 
 ### Run under Docker
 
-`docker run --device=/dev/kvm kontain/python-km:latest <payload.py>` - see a few .py files in payloads/python
+`docker run --ulimit nofile=1024:1024 --device=/dev/kvm kontain/python-km:latest <payload.py>` - see a few .py files in payloads/python
 
 ### Run under Kubernetes
 

--- a/km/Makefile
+++ b/km/Makefile
@@ -41,10 +41,6 @@ distro: ${BLDEXEC}
 	@$(TOP)make/check-docker.sh
 	@echo "Creating docker image '$(KM_IMAGE_FULL_NAME)'..." ; docker rmi -f $(KM_IMAGE_FULL_NAME) 2>/dev/null
 	tar -C $(dir $(BLDEXEC)) -c $(notdir $(BLDEXEC)) | docker import -m '$(KM_IMAGE_MESSAGE)' -c '$(KM_IMAGE_LABEL)' - $(KM_IMAGE_FULL_NAME)
-	@# Quick validation of the image; it will fail if load_test.km fails
-	docker run --rm --device /dev/kvm \
-		-v $(abspath ${TOP}/tests):/payloads:Z $(KM_IMAGE_FULL_NAME) \
-		/km /payloads/hello_test.km > /dev/null
 	@echo -e "Docker image created: $(GREEN)`docker image ls $(KM_IMAGE_FULL_NAME) --format '{{.Repository}}:{{.Tag}} Size: {{.Size}} sha: {{.ID}}'`$(NOCOLOR)"
 
 distroclean:

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -135,7 +135,7 @@ int hostfd_to_guestfd(km_vcpu_t* vcpu, int hostfd)
    return guest_fd;
 }
 
-int km_fs_init()
+int km_fs_init(void)
 {
    struct rlimit lim;
 
@@ -159,7 +159,7 @@ int km_fs_init()
    return 0;
 }
 
-void km_fs_fini()
+void km_fs_fini(void)
 {
    if (machine.filesys.guestfd_to_hostfd_map != NULL) {
       free(machine.filesys.guestfd_to_hostfd_map);

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -45,8 +45,8 @@
  * Note: vcpu is NULL if called from km signal handler.
  */
 int hostfd_to_guestfd(km_vcpu_t* vcpu, int hostfd);
-int km_fs_init();
-void km_fs_fini();
+int km_fs_init(void);
+void km_fs_fini(void);
 // int open(char *pathname, int flags, mode_t mode)
 uint64_t km_fs_open(km_vcpu_t* vcpu, char* pathname, int flags, mode_t mode);
 // int close(fd)

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -210,7 +210,7 @@ mk-bats: ## build bats image with tests
 withdocker: ## Build in docker. 'make withdocker [TARGET=clean] [DTYPE=ubuntu]'
 	@if ! docker image ls --format "{{.Repository}}:{{.Tag}}" |  grep -q ${DIMG} ; then \
 		echo -e "$(CYAN)${DIMG} is missing locally, will try to pull from registry. Use 'make mk-image' to build$(NOCOLOR)" ; fi
-	docker run $(DEVICE_KVM) --rm -v $(realpath ${TOP}):/src:Z -w /src/${FROMTOP} $(DIMG) $(MAKE) MAKEFLAGS="$(MAKEFLAGS)" $(TARGET)
+	docker run --ulimit nofile=`ulimit -n`:`ulimit -n -H` $(DEVICE_KVM) --rm -v $(realpath ${TOP}):/src:Z -w /src/${FROMTOP} $(DIMG) $(MAKE) MAKEFLAGS="$(MAKEFLAGS)" $(TARGET)
 
 #
 # 'Help' target - based on '##' comments in targets


### PR DESCRIPTION
km_filesys.c km_fs_init() allocates two tables base on RLIMIT_NOFILE rlimit. Under docker 18.06 we see that number being 1 billion, so arrays are 4GB, which takes about a second each to allocate. 
Run docker with explicit ulimit to make the number reasonable.