### PR TITLE
kontain specific libstdc++ 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,6 @@ TOP := $(shell git rev-parse --show-cdup)
 
 # On mac $(MAKE) evaluates to '/Applications/Xcode.app/Contents/Developer/usr/bin/make'
 ifeq ($(shell uname), Darwin)
-  MAKE := make
+MAKE := make
 endif
 include ${TOP}make/actions.mk

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
 
 pool:
     vmImage: $(vmImage)
-    
+
 steps:
 - checkout: self
   submodules: true
@@ -29,19 +29,19 @@ steps:
 - bash: echo "##vso[task.setvariable variable=git_rev]$(git rev-parse --short HEAD)"
 
 - script: |
-    set -e
+    set -e -x
     docker pull $(registry)/km-buildenv-fedora
-    docker tag $(registry)/km-buildenv-fedora  km-buildenv-fedora
+    docker tag $(registry)/km-buildenv-fedora km-buildenv-fedora
     make withdocker DTYPE=fedora
     echo "short head: $git_rev"
-    sed  -i "s:BRANCH_NAME:$(git_rev):"        tests/bats-job.yaml
-    sed  -i "s:BUILD_ID:$(Build.BuildId):"     tests/bats-job.yaml
-    sed  -i "s:REGISTRY:$(azureContainerRegistry):"     tests/bats-job.yaml
+    sed -i "s:BRANCH_NAME:$(git_rev):"        tests/bats-job.yaml
+    sed -i "s:BUILD_ID:$(Build.BuildId):"     tests/bats-job.yaml
+    sed -i "s:REGISTRY:$(azureContainerRegistry):"     tests/bats-job.yaml
     cat tests/bats-job.yaml
-  displayName: build 
+  displayName: build
 
 - script: |
-    set -e
+    set -e -x
     cp -v build/km/km tests/
     make mk-bats TAG=$(Build.BuildId)
     docker tag test-bats:$(Build.BuildId)  $(registry)/test-bats:$(Build.BuildId)

--- a/docker/build/Dockerfile.fedora
+++ b/docker/build/Dockerfile.fedora
@@ -8,27 +8,52 @@
 #   information is strictly prohibited without the express written permission of
 #   Kontain Inc.
 #
-# Dockerfile for builds.
+# Dockerfile for build image. There are three stages:
+#
+# buildenv-base - basic from OS image with the necessary packages installed
+# build-libstdcpp - clone gcc source, then build and install libstdc++
+# buildenv - based on buildenv-base and just copy the installed part from the previous
+#
 # Usage will be 'docker run <container> make TARGET=<target> - see ../../Makefile
 
-FROM fedora
-
-LABEL version="1.0" maintainer="Mark Sterin <msterin@kontain.app>"
-
-# uid=1001(vsts) gid=117(docker) groups=117(docker)
+FROM fedora AS buildenv-base
 ARG USER=appuser
-ARG UID
-ARG GID
+ARG UID=1000
+ARG GID=1000
 
-RUN dnf install -y gcc glibc-static \
-   elfutils-libelf-devel elfutils-libelf-devel-static glibc-devel zlib-static gdb \
-   gcc-c++ libstdc++-static make git gcovr time patch openssl-devel findutils python expat-static \
-   && dnf clean all
+RUN groupadd -f -g $GID $USER && useradd -r -u $UID -g $GID $USER && mkdir /home/$USER && chown $UID.$GID /home/$USER
 
-
-RUN groupadd -f -g $GID $USER
-RUN useradd -r -u $UID -g $GID $USER
-
-USER $USER
-WORKDIR /home/$USER
 ENV TERM=xterm
+ENV USER=$USER
+ENV PREFIX=/opt/kontain
+WORKDIR /home/$USER
+
+RUN dnf install -y gcc gcc-c++ make gdb git gcovr time patch file findutils python \
+   glibc-devel glibc-static elfutils-libelf-devel elfutils-libelf-devel-static zlib-static openssl-devel expat-static \
+   && dnf upgrade -y && dnf clean all
+
+FROM buildenv-base AS buildenv-gcc-base
+RUN dnf install -y gmp-devel mpfr-devel libmpc-devel isl-devel flex m4
+
+FROM buildenv-gcc-base AS build-libstdcpp
+ARG LIBSTDCPPVER=gcc-9_2_0-release
+USER $USER
+
+RUN git clone https://github.com/gcc-mirror/gcc.git -b $LIBSTDCPPVER
+RUN mkdir -p build_gcc && cd build_gcc \
+   && ../gcc/configure --prefix=$PREFIX --enable-clocale=generic --disable-bootstrap --enable-languages=c,c++,fortran,lto \
+   --disable-shared --enable-threads=posix --enable-checking=release --disable-multilib --with-system-zlib \
+   --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object \
+   --enable-linker-build-id --with-gcc-major-version-only --with-linker-hash-style=gnu \
+   --enable-plugin --enable-initfini-array --with-isl --without-cuda-driver \
+   --enable-gnu-indirect-function --enable-cet --with-tune=generic \
+   && make -j16
+
+USER root
+RUN mkdir -p $PREFIX && make -C build_gcc/x86_64-pc-linux-gnu/libstdc++-v3 install
+
+FROM buildenv-base AS buildenv
+LABEL version="1.0" maintainer="Mark Sterin <msterin@kontain.app>"
+USER $USER
+
+COPY --from=build-libstdcpp $PREFIX/ $PREFIX

--- a/payloads/node/build.sh
+++ b/payloads/node/build.sh
@@ -5,6 +5,9 @@ set -x
 if [ $# -ne 0 ] ; then BUILD=$1 ; else BUILD=Release ; fi
 if [ $BUILD == 'Debug' ] ; then CONFIG_DEBUG=--debug ; fi
 
+NODE=node/out/$BUILD/node
+KM=`realpath ../../build/km/km`
+
 if [ ! -d node ]; then
     git clone https://github.com/nodejs/node.git -b v12.4.0
     pushd node
@@ -14,11 +17,16 @@ else
     pushd node
 fi
 
-make -j8
+make -j16
 popd
 
 ./link-km.sh $BUILD
+mv $NODE ${NODE}.static
+
+echo "#!$KM --copyenv" > ${NODE}.sh
+chmod +x ${NODE}.sh
+ln -s node.sh ${NODE}
 
 echo ""
-echo "now you can run ``../../build/km/km ./node/out/${BUILD}/node.km''"
+echo "now you can run ``$KM ${NODE}.km''"
 

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -39,7 +39,7 @@ link:
 
 TEST_CMD ?= ${KM_BIN} ${PAYLOAD_KM}
 test-all:
-	-${TEST_CMD} ./test_unittest.py
+	${TEST_CMD} ./test_unittest.py
 	${TEST_CMD} ./cpython/Lib/unittest/test/
 
 include ${TOP}make/distro.mk

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@ SRC = hello_test.c hello_html_test.c brk_test.c mmap_test.c gdb_test.c exit_valu
 		getline_test.c mem_test.c exit_grp_test.c intr_test.c brk_map_test.c crash_test.c cpuid_test.c \
 		longjmp_test.c cpuid_print_details_test.c stray_test.c signal_test.c hello_2_loops_tls_test.c \
 		regions_test.c mprotect_test.c pthread_cancel_test.c filesys_test.c filepath_test.c socket_test.c \
-		dl_iterate_phdr_test.c env_test.c
+		dl_iterate_phdr_test.c env_test.c locale_test.c
 
 SRC_CPP = var_storage_test.cpp throw_basic_test.cpp
 

--- a/tests/locale_test.c
+++ b/tests/locale_test.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2019 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ *
+ * Test helper to print out misc. info about memory slots in different memory sizes
+ *
+ * Print date in using four different locales
+ */
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+void print_time(void)
+{
+   static char outstr[4096];
+   time_t t;
+   struct tm* tmp;
+
+   t = time(NULL);
+   tmp = localtime(&t);
+   if (tmp == NULL) {
+      perror("localtime");
+      exit(1);
+   }
+
+   if (strftime(outstr, sizeof(outstr), "%A, %d %B %Y %T %P %z %Z", tmp) < 0) {
+      perror("strftime");
+      exit(1);
+   }
+   printf("%s: ", outstr);
+}
+
+int main(int argc, char** argv)
+{
+   locale_t loc;
+
+   if ((loc = uselocale((locale_t)0)) == NULL) {
+      perror("uselocale(0)");
+      exit(1);
+   }
+   print_time();
+   printf("after 0: %p\n", loc);
+   if ((loc = uselocale(LC_GLOBAL_LOCALE)) == NULL) {
+      perror("uselocale(LC_GLOBAL_LOCALE)");
+      exit(1);
+   }
+   print_time();
+   printf("after LC_GLOBAL_LOCALE: %p\n", loc);
+   if ((loc = newlocale(LC_ALL, "ru_RU.utf8", (locale_t)0)) == (locale_t)0) {
+      perror("newlocale()");
+      exit(1);
+   }
+   if (uselocale(loc) == NULL) {
+      perror("uselocale(loc)");
+      exit(1);
+   }
+   print_time();
+   printf("after loc: %p\n", loc);
+   if ((loc = newlocale(LC_ALL, "de_BE.utf8", (locale_t)0)) == (locale_t)0) {
+      perror("newlocale()");
+      exit(1);
+   }
+   if (uselocale(loc) == NULL) {
+      perror("uselocale(loc)");
+      exit(1);
+   }
+   print_time();
+   printf("after loc: %p\n", loc);
+}

--- a/tests/var_storage_test.cpp
+++ b/tests/var_storage_test.cpp
@@ -84,10 +84,20 @@ class check_tls
    }
 };
 
+double toDouble(const char* buffer, size_t length) {
+  std::istringstream stream(std::string(buffer, length));
+  stream.imbue(std::locale("C"));  // Ignore locale
+  double d;
+  stream >> d;
+  return d;
+}
+
 int main()
 {
    StorageType t_main("Local main");
    static StorageType t_LocalStatic("local Static");
+
+   cout << "======> " << toDouble("1", 1) << endl;
 
    thread t1(thread_entry, "1");
    thread t2(thread_entry, "2");

--- a/tools/kontain-gcc
+++ b/tools/kontain-gcc
@@ -1,13 +1,20 @@
 #!/bin/bash
 # invoke gcc with extra params for Kontain link
-#
+
 cmd=`basename ${BASH_SOURCE[0]}`
 dir=`dirname ${BASH_SOURCE[0]}`
 KM_TOP=`realpath $dir/..`
-if [[ $cmd == *g++ ]] ; then REALGCC=g++ ; else REALGCC=gcc; fi
-if [ $# -eq 0 ] ; then exec "${REALGCC}" ; fi
+PREFIX=/opt/kontain
+# check if this is run in local build tree and use the local libs then
+if [[ x${KM_TOP} == x${PREFIX}/* ]] ; then
+   LIB="-L ${PREFIX}/lib64"
+   SPEC="${PREFIX}/lib64"
+else
+   LIB="-L ${PREFIX}/lib64 -L ${KM_TOP}/build/runtime"
+   SPEC="${KM_TOP}"
+fi
 
-exec "${REALGCC}" \
-   -static -no-pie -specs=${KM_TOP}/gcc-km.spec \
-    "$@" \
-   -L ${KM_TOP}/build/runtime
+if [[ $cmd == *g++ ]] ; then REALGCC=g++; else REALGCC=gcc; fi
+if [[ $# -eq 0 ]] ; then exec "${REALGCC}" ; fi
+
+exec "${REALGCC}" -static -no-pie -specs=${SPEC}/gcc-km.spec "$@" ${LIB}


### PR DESCRIPTION
build and use our own libstdc++ instead of system standard, due to conflict with musl locale
staged fedora dockerfile for build image with libstdc++

For this to work you need to make a couple of steps
1. need to make new `km-buildenv-fedora` image - `run make mk-image`. Once this completes (a while) you can run `make withdocker ...` and everything should work.
1. However local builds will not work still. Need to copy the kontain specific libstdc++ to the local system to work. Run this three commands:
`docker create -n tmp_env kontainkubecr.azurecr.io/km-buildenv-fedora`
`sudo docker cp tmp_env:/opt /opt`
`docker rm tmp_env`
This will place libstc++ library in /opt/kontain/lib64, kontain-g++ will pick it up for linking, and everything will work.

Please make sure you follow the steps before you approve, to make sure the merge will not screw you.