### PR TITLE
ensure make mk-image artifacts can't be pushed to azure

### DIFF
--- a/make/locations.mk
+++ b/make/locations.mk
@@ -39,6 +39,12 @@ KM_BIN := ${KM_BLDDIR}km
 # name of the cloud, as well as subdir of $(TOP)/cloud where the proper scripts hide. Use CLOUD='' to build with no cloud
 # All cloud stuff can be turned off by passing CLOUD=''
 CLOUD ?= azure
+ifeq ($(MAKECMDGOALS),mk-image)
+undefine CLOUD
+endif
+ifeq ($(MAKECMDGOALS),withdocker)
+undefine CLOUD
+endif
 
 ifneq ($(CLOUD),)
 # now bring all cloud-specific stuff needed in forms on 'key = value'


### PR DESCRIPTION
Unless built like so: **CLOUD= make mk-image**
buildenv image names include registry name

An image built using mk-image won't work on azure CI.
Likewise an image build for azure CI won't work locally.

Fix ensures mk-image and withdocker targets can only use images built locally by
not including the registry in the image name.

**Tests:**

- [x] make mk-image -> km-buildenv-fedora:latest
- [x] make mk-image DTYPE=ubuntu  -> km-buildenv-ubuntu:latest
- [x] make withdocker  uses km-buildenv-fedora:latest
- [x] make withdocker DTYPE=ubuntu uses km-buildenv-ubuntu:latest
- [ ] CI passes
