### PR TITLE
add coverage as ignored target under payloads

### DIFF
--- a/payloads/Makefile
+++ b/payloads/Makefile
@@ -16,7 +16,7 @@ SUBDIRS := python demo-dweb node busybox
 
 # Filter out 'make test' requests' to assure that 'make test' only builds/tests KM. If payload needs to be tested, uses 'make test-all'
 # Also, just 'make' will not cause building payloads , so it is reserved for building KM only. Use 'make all' or 'make build' to request payloads build
-default test:
+default test coverage:
 	@echo "Info: ignoring target '$@' in payloads"
 
 # use this target to force payloads build

--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -16,7 +16,7 @@
 #
 # Usage will be 'docker run <container> make TARGET=<target> - see ../../Makefile
 
-FROM fedora AS buildenv-base
+FROM fedora:30 AS buildenv-base
 ARG USER=appuser
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
use fedora 30 when making docker image
remove buildenv-image from buildenv-local-fedora's dependency list