### PR TITLE
[trivial] added statfs stub, and added hcall  name to error message

### DIFF
--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -424,7 +424,7 @@ static int hypercall(km_vcpu_t* vcpu, int* hc)
       return -1;
    }
    if (km_hcalls_table[*hc] == NULL) {
-      warnx("Unimplemented hypercall %d", *hc);
+      warnx("Unimplemented hypercall %d (%s)", *hc, km_hc_name_get(*hc));
       siginfo_t info = {.si_signo = SIGSYS, .si_code = SI_KERNEL};
       km_post_signal(vcpu, &info);
       return -1;

--- a/runtime/runtime_stub_km.c
+++ b/runtime/runtime_stub_km.c
@@ -43,6 +43,7 @@ __stub__(setcontext);
 __stub__(makecontext);
 __stub__(swapcontext);
 __stub__(sigaltstack);
+__stub__(statfs);
 __stub_core__(execve);
 __stub_core__(execvp);
 __stub_core__(execv);


### PR DESCRIPTION
statfs needed for python.ctypes;