### PR TITLE
dependencies for dynamically linked python

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -23,7 +23,8 @@ SKIP_SRC_DIR := $(addprefix $(SRCDIR)src/, ipc mq process sched)
 SRC_DIRS := $(filter-out $(addsuffix /,${SKIP_SRC_DIR}), $(wildcard $(addprefix $(SRCDIR),src/*/)))
 
 KM_REPLACED_SRCS := syscall.s syscall_cp.s __libc_start_main.c __init_tls.c __reset_tls.c getenv.c uname.c \
-					pthread_create.c pthread_join.c pthread_setcancelstate.c preadv.c pwritev.c fcntl.c procfdname.c sigaltstack.c getpagesize.c
+					pthread_create.c pthread_join.c pthread_setcancelstate.c preadv.c pwritev.c fcntl.c procfdname.c \
+					sigaltstack.c getpagesize.c fcntl/open.c
 
 KM_EXTRA_SRCS := $(wildcard *_km.c) $(wildcard *.s)
 

--- a/runtime/open_km.c
+++ b/runtime/open_km.c
@@ -1,0 +1,3 @@
+#include "musl/src/fcntl/open.c"
+
+weak_alias(open, __open64_2);


### PR DESCRIPTION
Needed to add these to satisfy dynamically linked python. No tests, but dynlinked python does work, and loads modules like math. Not the dynamic linking is **not** part of this PR, only dependencies.