### PR TITLE
fix python link-km.sh rot

### DIFF
--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -2,11 +2,11 @@
 
 set -x
 
-KM_TOP=../$(git rev-parse --show-cdup)
+KM_TOP=$(git rev-parse --show-cdup)
 PATH=${KM_TOP}/tools:$PATH
 
-BUILD=${1:cpython}
-OUT=${2:cpython}
+BUILD=${1:-cpython}
+OUT=${2:-cpython}
 
 kontain-gcc -ggdb ${BUILD}/Programs/python.o ${BUILD}/libpython3*.a -lz -lssl -lcrypto -o ${OUT}/python.km && chmod a-x ${OUT}/python.km
 


### PR DESCRIPTION
Somehow python link-km.sh script doesn't work any more. I suspect I screwed this up doing the new way to build python, although it looks like it shouldn't have worked. 