### PR TITLE
last items to make Java print Hello, World!

### DIFF
--- a/include/km_hcalls.h
+++ b/include/km_hcalls.h
@@ -65,6 +65,7 @@ enum km_internal_hypercalls {
    HC_guest_interrupt = KM_MAX_HCALL - 3,
    HC_km_unittest = KM_MAX_HCALL - 4,
    HC_procfdname = KM_MAX_HCALL - 5,
+   HC_unmapself = KM_MAX_HCALL - 6,
 };
 
 extern const char* const km_hc_name_get(int hc);

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1147,6 +1147,15 @@ static km_hc_ret_t set_tid_address_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
+static km_hc_ret_t unmapself_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   // pthread_exit() does this at the end to unmap the stack and exit:
+   // _Noreturn void__unmapself(void* base, size_t size);
+   (void) km_guest_munmap(arg->arg1, arg->arg2);
+   km_exit(vcpu, 0);
+   return HC_STOP;
+}
+
 /*
  * Maximum hypercall number, defines the size of the km_hcalls_table
  */
@@ -1272,6 +1281,7 @@ void km_hcalls_init(void)
    km_hcalls_table[HC_guest_interrupt] = guest_interrupt_hcall;
    km_hcalls_table[HC_km_unittest] = km_unittest_hcall;
    km_hcalls_table[HC_procfdname] = procfdname_hcall;
+   km_hcalls_table[HC_unmapself] = unmapself_hcall;
 }
 
 void km_hcalls_fini(void)

--- a/payloads/demo-dweb/demo-script.md
+++ b/payloads/demo-dweb/demo-script.md
@@ -98,7 +98,7 @@ curl -s -d "type=demo&subject=Kontain"  localhost:8080 | jq . # shows simple APi
 # While we are here, let's compare container sizes for another payload, Python:
 make -C ~/workspace/km/payloads/python distro
 docker pull python
-docker images | grep python| grep latest
+docker images | grep python | grep latest
 
 ```
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -22,8 +22,8 @@ ARCH := x86_64
 SKIP_SRC_DIR := $(addprefix $(SRCDIR)src/, ipc mq process sched)
 SRC_DIRS := $(filter-out $(addsuffix /,${SKIP_SRC_DIR}), $(wildcard $(addprefix $(SRCDIR),src/*/ crt/ ldso/)))
 
-KM_REPLACED_SRCS := __set_thread_area.s syscall.s syscall_cp.s getenv.c uname.c preadv.c pwritev.c fcntl.c \
-                    procfdname.c sigaltstack.c clone.s getpagesize.c fcntl/open.c
+KM_REPLACED_SRCS := __set_thread_area.s __unmapself.s syscall.s syscall_cp.s getenv.c uname.c preadv.c pwritev.c \
+						  fcntl.c procfdname.c sigaltstack.c clone.s getpagesize.c fcntl/open.c
 KM_EXTRA_SRCS := $(wildcard *_km.c) $(wildcard *.s)
 
 PTHREAD_CFLS := pthread_cond_broadcast.c pthread_cond_destroy.c pthread_cond_signal.c pthread_cond_wait.c \

--- a/runtime/runtime_stub_km.c
+++ b/runtime/runtime_stub_km.c
@@ -66,7 +66,7 @@ __stub_core__(sched_getscheduler);
 __stub_core__(sched_rr_get_interval);
 __stub_core__(sched_setparam);
 __stub_core__(sched_setscheduler);
-__stub_core__(sched_yield);
+__stub__(sched_yield);
 __stub_core__(system);
 __stub__(fork);
 __stub__(vfork);

--- a/runtime/unmapself_km.c
+++ b/runtime/unmapself_km.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include "km_hcalls.h"
+#include "syscall.h"
+
+_Noreturn void __unmapself(void* base, size_t size)
+{
+   km_hc_args_t args = {0};
+
+   args.arg1 = base;
+   args.arg2 = size;
+   km_hcall(SYS_exit, &args);
+}


### PR DESCRIPTION
Implemented unmapself() as hcall, basically unmap and exit. This is needed in pthread_exit() for detached threads.
Made sched_yield dummy call that simply succeeds instead of core dump. 

These two happened to be the last drops Java really wanted.

Added test for detached threads, confirmed it would fail without unmapself()

