### PR TITLE
Fix clone hcall wrapper to set ctid correctly

### DIFF
--- a/runtime/clone_km.c
+++ b/runtime/clone_km.c
@@ -48,10 +48,5 @@ int __clone(int (*fn)(void*), void* child_stack, int flags, void* args, pid_t* p
                          .arg5 = (uintptr_t)newtls,
                          .arg6 = (uintptr_t)cargs};
    km_hcall(SYS_clone, &args1);
-   if (args1.hc_ret != 0) {
-      if (ctid != NULL && args1.hc_ret != -1) {
-         *ctid = (pid_t)args1.hc_ret;
-      }
-   }
    return args1.hc_ret;
 }


### PR DESCRIPTION
Should fix recent occasional CI failures. The wrapper code would set ctid unconditionally, which would break the locking logic in thread list lock in musl.

Testing done by multiple runs of our CI tests. The crash seems to be gone. However there is is still #338