### PR TITLE
Dropped bash -x flag and added BASH_TRACING env controlling the same [TRIVIAL]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,8 @@ variables:
   pod_test_km: "pod/test-km-$(buildenv.type)-ci-$(Build.BuildId)"
   pod_test_node: "pod/test-node-$(buildenv.type)-ci-$(Build.BuildId)"
   pod_test_python: "pod/test-python-$(buildenv.type)-ci-$(Build.BuildId)"
-  dtype: "$(buildenv.type)"
+  dtype: $(buildenv.type)
+  #bash_tracing: true # uncomment to enable '-x' in all bash scripts
 
 strategy:
   matrix:
@@ -55,8 +56,9 @@ steps:
     displayName: Login to Azure, container registry and Kubernetes
 
   - bash: |
-      set -x -e
-      make -C tests pull-buildenv-image
+      set -e
+      if [ -v BASH_TRACING ] ; then set -x ; fi
+      make -C tests pull-buildenv-image IMAGE_VERSION=latest
       make -j withdocker
       make -C tests testenv-image push-testenv-image IMAGE_VERSION=CI-$(Build.BuildId)
     displayName: KM test - set build environment, build, create test container and push it to registry
@@ -80,7 +82,7 @@ steps:
     timeoutInMinutes: 5
 
   - bash: |
-      set -x
+      if [ -v BASH_TRACING ] ; then set -x ; fi
       make -C cloud/azure ci-image-purge CI_IMAGE_DRY_RUN=""
       # TODO - if the **test** failed (especially with kmcore), we want to keep these pods for a few days
       # Setting vars doc: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables

--- a/cloud/azure/apply_openwhisk_vms.sh
+++ b/cloud/azure/apply_openwhisk_vms.sh
@@ -15,7 +15,7 @@
 source `dirname $0`/cloud_config.mk
 SUFFIX='openwhisk-kontain'
 
-# set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 op=${1:-help}
 if [[ "$op" == "help" || "$op" == "--help" ]] ; then
    cat <<EOF

--- a/cloud/azure/clear_initial_resources.sh
+++ b/cloud/azure/clear_initial_resources.sh
@@ -15,7 +15,7 @@
 source `dirname $0`/cloud_config.mk
 
 set -e
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 az account set -s ${CLOUD_SUBSCRIPTION}
 az configure --defaults location=${CLOUD_LOCATION}}
 az acr delete --resource-group ${CLOUD_RESOURCE_GROUP} --name  ${REGISTRY_NAME}

--- a/cloud/azure/clear_kube_cluster.sh
+++ b/cloud/azure/clear_kube_cluster.sh
@@ -17,7 +17,7 @@ cd `dirname $0`
 source ./cloud_config.mk
 
 #set -e  # even if some resource deletion fails, keep deleting others. Thus no need for 'set -e' here
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 sp_id=`az ad sp list  --query "[?contains(servicePrincipalNames,'$K8_SERVICE_PRINCIPAL')].{Id: objectId}"  --output tsv`
 az aks delete -y --resource-group ${CLOUD_RESOURCE_GROUP}  --name ${K8S_CLUSTER}
 az ad sp delete --id $sp_id

--- a/cloud/azure/create_initial_resources.sh
+++ b/cloud/azure/create_initial_resources.sh
@@ -14,7 +14,7 @@
 source `dirname $0`/cloud_config.mk
 
 set -e
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 az account set -s ${CLOUD_SUBSCRIPTION}
 az configure --defaults location=${CLOUD_LOCATION}
 az group create --name ${CLOUD_RESOURCE_GROUP} --output ${OUT_TYPE}

--- a/cloud/azure/create_kube_cluster.sh
+++ b/cloud/azure/create_kube_cluster.sh
@@ -23,7 +23,7 @@ set -e
 # create service principal, give it access to ACR, create cluster with the SP
 appPwd=`az ad sp create-for-rbac --name ${K8_SERVICE_PRINCIPAL} --skip-assignment --query password --output tsv`
 echo Do not lose it PWD $appPwd . TODO: switch to pre-generated PEM certs
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 acrId=`az acr show --resource-group ${CLOUD_RESOURCE_GROUP} --name ${REGISTRY_NAME} --query "id" --output tsv`
 sp_id=`az ad sp list  --query "[?contains(servicePrincipalNames,'$K8_SERVICE_PRINCIPAL')].{Id: objectId}"  --output tsv`
 appId=`az ad sp show --id ${sp_id}  --query appId --output tsv`

--- a/cloud/azure/create_openwhisk_vms.sh
+++ b/cloud/azure/create_openwhisk_vms.sh
@@ -11,7 +11,8 @@
 #
 # Deploys VMs for Openwhisk demo to Azure.
 # Also preps this VM to fetch from Kontain github
-set -ex
+set -e
+if [ -v BASH_TRACING ] ; then set -x ; fi
 
 source `dirname $0`/cloud_config.mk
 

--- a/cloud/azure/untag_image.sh
+++ b/cloud/azure/untag_image.sh
@@ -23,7 +23,7 @@ image="$1"
 version="$2"
 if [ -z "$image" -o -z "$version" ] ; then echo Usage: $0 image_short_name version; exit; fi
 
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 $DEBUG az acr login -n ${REGISTRY_NAME}
 $DEBUG az acr repository show-tags --repository ${image} -n ${REGISTRY_NAME} --output ${out_type}
 $DEBUG az acr repository untag  -n ${REGISTRY_NAME}  --image ${image}:${version}

--- a/payloads/busybox/build.sh
+++ b/payloads/busybox/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 src=busybox
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 set -e
 
 if [ ! -d $src ]; then

--- a/payloads/node/link-km.sh
+++ b/payloads/node/link-km.sh
@@ -3,7 +3,7 @@
 # Create node.km by linking the objects files from build artifacts located at $1 (like /home/appuser/node in a "blank")
 # and put the result into location at $2
 
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 
 if [[ $# -ne 0 ]] ; then NODE=$1 ; else exit 1 ; fi
 OUT=${2:-$NODE}

--- a/payloads/python/build.sh
+++ b/payloads/python/build.sh
@@ -12,10 +12,11 @@
 # Build script for python.
 # Also tries to add modules enumberated in m_list (needs `bear' installed for this)
 #
-set -ex
+
+set -e
+if [ -v BASH_TRACING ] ; then set -x ; fi
 
 if [ ! -d cpython ]; then
-    set -x
     git clone https://github.com/python/cpython.git -b v3.7.4
     pushd cpython
     ./configure

--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 
 KM_TOP=$(git rev-parse --show-cdup)
 PATH=${KM_TOP}/tools:$PATH

--- a/payloads/python/link-static-musl.sh
+++ b/payloads/python/link-static-musl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+if [ -v BASH_TRACING ] ; then set -x ; fi
 
 MUSL_TOP=../$(git rev-parse --show-cdup)runtime/musl
 


### PR DESCRIPTION
this makes scipts less verbose by default, and allows similar way to enable -x without
editing (by setting env BASH_TRACING to something)

Fixes #327

Tested  by CI pass and manually using the env with `cloud/azure/apply_openwhisk_vms.sh:
```
[msterin@msterin-x250 km]$ BASH_TRACING=true  cloud/azure/apply_openwhisk_vms.sh ls
+ op=ls
+ [[ ls == \h\e\l\p ]]
+ [[ ls == \-\-\h\e\l\p ]]
++ az vm list -g kontainKubeRG --query '[?contains(name, '\''openwhisk-kontain'\'')].id' -o tsv
+ list='/subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/client-openwhisk-kontain
/subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/docker-openwhisk-kontain
/subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/km-openwhisk-kontain'
+ for i in $list
+ case $op in
+ cmd='az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/client-openwhisk-kontain --query '\''{ IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState }'\'' -o tsv'
+ eval az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/client-openwhisk-kontain --query ''\''{' IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState '}'\''' -o tsv
++ az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/client-openwhisk-kontain --query '{ IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState }' -o tsv
	client-openwhisk-kontain.westus.cloudapp.azure.com	Standard_B2ms	VM deallocated
+ for i in $list
+ case $op in
+ cmd='az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/docker-openwhisk-kontain --query '\''{ IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState }'\'' -o tsv'
+ eval az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/docker-openwhisk-kontain --query ''\''{' IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState '}'\''' -o tsv
++ az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/docker-openwhisk-kontain --query '{ IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState }' -o tsv
13.83.130.246	docker-openwhisk-kontain.westus.cloudapp.azure.com	Standard_D2s_v3	VM running
+ for i in $list
+ case $op in
+ cmd='az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/km-openwhisk-kontain --query '\''{ IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState }'\'' -o tsv'
+ eval az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/km-openwhisk-kontain --query ''\''{' IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState '}'\''' -o tsv
++ az vm show --show-details --id /subscriptions/bd3e8581-9352-4514-8e09-cf9b771b2155/resourceGroups/kontainKubeRG/providers/Microsoft.Compute/virtualMachines/km-openwhisk-kontain --query '{ IP:publicIps, FQDN:fqdns, Type:hardwareProfile.vmSize , Power:powerState }' -o tsv
104.42.38.211	km-openwhisk-kontain.westus.cloudapp.azure.com	Standard_D2s_v3	VM running

```
