### PR TITLE
Added BUILDENV_IMAGE_VERSION to control which buildenv image to use

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,10 +21,12 @@ variables:
   pod_test_km: "pod/test-km-$(buildenv.type)-ci-$(Build.BuildId)"
   pod_test_node: "pod/test-node-$(buildenv.type)-ci-$(Build.BuildId)"
   pod_test_python: "pod/test-python-$(buildenv.type)-ci-$(Build.BuildId)"
-  # Helper vars for the build. Note that in Azure pipeline this also makes UPPCASE_NAME
-  # of a var exposed in environment. E.g. 'dtype=fedora' means all shells will see DTYPE=fedora.
-  dtype: $(buildenv.type) # until we add other distros, this always maps to DTYPE=fedora (see 'strategy' below)
-  image_version: ci-$(Build.BuildId) # defaut IMAGE_VERSION setting for all commands
+  # NOTE: In Azure pipeline setting a variable also makes variable's UPPCASE_NAME
+  # exposed in environment for all tasks. E.g. 'dtype=fedora' means all tasks will have
+  # an environment DTYPE=fedora.
+  dtype: $(buildenv.type)  # until we add other distros, this always maps to fedora (see 'strategy' below)
+  buildenv_image_version: latest # use this for all buildenv containers
+  image_version: ci-$(Build.BuildId) # use this for all other containers
   #bash_tracing: true # uncomment to enable '-x' in all bash scripts
 
 strategy:
@@ -61,7 +63,7 @@ steps:
   - bash: |
       set -e
       if [ -v BASH_TRACING ] ; then set -x ; fi
-      make -C tests pull-buildenv-image IMAGE_VERSION=latest
+      make -C tests pull-buildenv-image
       make -j withdocker
       make -C tests testenv-image push-testenv-image
     displayName: KM test - set build environment, build, create test container and push it to registry

--- a/cloud/azure/Makefile
+++ b/cloud/azure/Makefile
@@ -105,14 +105,14 @@ endif
 	@echo "Purging images for $(CI_IMAGE_REPOS_TO_PURGE) older than $(CI_IMAGE_PURGE_AGE)"
 	$(foreach repo,${CI_IMAGE_REPOS_TO_PURGE}, az acr run --cmd '${CI_IMAGE_PURGE_CMD}' --registry ${REGISTRY_NAME} /dev/null; )
 
-# Helpers to avoid cut-n-paste in pipeline definition
+# Helpers to avoid cut-n-paste in pipeline definition.
 ci-prepare-testenv:
-	make -C $(TOP)$(LOCATION) pull-buildenv-image all IMAGE_VERSION=latest
-	make -C $(TOP)$(LOCATION) testenv-image push-testenv-image IMAGE_VERSION=$(IMAGE_VERSION)
+	make -C $(TOP)$(LOCATION) pull-buildenv-image all
+	make -C $(TOP)$(LOCATION) testenv-image push-testenv-image
 
 ci-run-tests:
 	@# Note that we can get pod name from make, but to simplify the code we get it also from upstairs
-	make -C $(TOP)$(LOCATION) test-withk8s IMAGE_VERSION=$(IMAGE_VERSION)
+	make -C $(TOP)$(LOCATION) test-withk8s
 	kubectl wait --for=condition=Ready --timeout=2m $(POD_NAME)
 	kubectl logs -f $(POD_NAME)
 	@if [[ "$$(kubectl get ${POD_NAME} -o 'jsonpath={..terminated.exitCode}')" != "0" ]] ; then \

--- a/cloud/k8s/test-pod-template.yaml
+++ b/cloud/k8s/test-pod-template.yaml
@@ -5,7 +5,7 @@
 # m4 -D NAME=pod-name -D IMAGE=full-image-name -D COMMAND=command-to-run | kubectl apply -f -
 #
 # e.g.
-# IMAGE=kontainkubecr.azurecr.io/test-km-fedora:CI-781
+# IMAGE=kontainkubecr.azurecr.io/test-km-fedora:ci-781
 # NAME=test-km-fedora-ci-781
 # COMMAND='"run_bats_tests.sh", "--km=/tests/km"'
 #

--- a/docs/azure_pipeline.md
+++ b/docs/azure_pipeline.md
@@ -86,9 +86,9 @@ Note that push is protected (see Makefiles)
   * click on Checks tab in the PR
   * click on `Show all checks`
   * click on 1st `Details`
-  * Click on `Create and Push KM Test container`. You will see something like `make -C tests testenv-image push-testenv-image IMAGE_VERSION=CI-695 DTYPE=fedora`.
-* pull the test image for the correct version, e.g. `make -C tests pull-testenv-image IMAGE_VERSION=CI-695`
-* Run container locally `docker run -it --rm --device=/dev/kvm kontain/test-km-fedora:CI-695`
+  * Click on `Create and Push KM Test container`. You will see something like `make -C tests testenv-image push-testenv-image IMAGE_VERSION=ci-695 DTYPE=fedora`.
+* pull the test image for the correct version, e.g. `make -C tests pull-testenv-image IMAGE_VERSION=ci-695`
+* Run container locally `docker run -it --rm --device=/dev/kvm kontain/test-km-fedora:ci-695`
 * in the Docker prompt, run tests: `./run_bats_tests.sh`
 
 ### How to debug code if it fails on Kubernetes only (and passes locally)
@@ -98,16 +98,16 @@ First of all, make sure that
 1. kubectl is installed (`sudo dnf install kubernetes-client` on Fedora)
 1. you are logged in Azure and Kubernetes (`make -C cloud/azure login`)
 
-Then, find IMAGE_VERSION for your CI run (see above). Let's say this was build 695, so the image version is `CI-695`
+Then, find IMAGE_VERSION for your CI run (see above). Let's say this was build 695, so the image version is `ci-695`
 
-* `make -C tests test-withk8s-manual IMAGE_VERSION=CI-695` to run image in Kubernetes
+* `make -C tests test-withk8s-manual IMAGE_VERSION=ci-695` to run image in Kubernetes
 * This will create a pod and  print out the commands to run bash there, as well as the ones to clean up when you are done.
 
 Here is an example of a session:
 
 ```sh
-[msterin@msterin-p330 tests]$ make  test-withk8s-manual IMAGE_VERSION=CI-695
-Creating or updating Kubernetes pod for USER=msterin IMAGE_VERSION=CI-695
+[msterin@msterin-p330 tests]$ make  test-withk8s-manual IMAGE_VERSION=ci-695
+Creating or updating Kubernetes pod for USER=msterin IMAGE_VERSION=ci-695
 Run bash in your pod 'msterin-test-ci-695' using 'kubectl exec msterin-test-ci-695 -it -- bash'
 Run tests inside your pod using './run_bats_tests.sh --km=/tests/km'
 When you are done, do not forget to 'kubectl delete pod msterin-test-ci-695'

--- a/docs/image-targets.md
+++ b/docs/image-targets.md
@@ -27,10 +27,19 @@ Dockerized build is using `buildenv-component-platform` images (i.e.`buildenv-km
 * `make push-buildenv-image` - rare op, updates buildenv image
 * `make -C tests buildenv-local-fedora` is a convenience target which extracts prerequisites (DNF package list and libstdc++ lib) from buildenv image and installs on on local box, thus allowing to run regular `make`
 
+### Image Versions
+
+We use the following environment (and Makefile) variables to control which versions are used:
+
+* `IMAGE_VERSION` - use this version (aka Docker tag) for all container images. Default is `latest`
+* `BUILDENV_IMAGE_VERSION` - use this version (aka Docker tag) for all buildenv images. Default is `IMAGE_VERSION`
+
+For example, if IMAGE_VERSION is set to `myver`, then defaut for all buidlenv images will also be `myver`. If you want to use latest buldenv images with `myver` of test images, also et BUILDENV_IMAGE_VERSION to *latest*
+
 ### Testing in docker container, locally or remotely
 
 * `make testenv-image` - image with test environment - i.e. stuff needed for testing - bats code, /bin/time, timeout, etc.. (note: currently is *FROM buildenv*, can be scaled down if needed - since it's the only one pushed to Kubernetes for testing)
-* `make push-testenv-image` - pushes test image to registry. Since all test images are different, **we require to pass IMAGE_VERSION=version** for this target to work. **Version* can be SHA. or buildID, or other unique tag to diffirentiate images - e.g. CI uses `make testenv-image IMAGE_VERSION=CI-$(BuildId)`. We will block *:latest* tag to avoid accidental conflicts.
+* `make push-testenv-image` - pushes test image to registry. Since all test images are different, **we require to pass IMAGE_VERSION=version** for this target to work. **Version* can be SHA. or buildID, or other unique tag to diffirentiate images - e.g. CI uses `make testenv-image IMAGE_VERSION=ci-$(BuildId)`. We will block *:latest* tag to avoid accidental conflicts.
 
 To run full test in Docker container (based on testenv-image) we provide 2 simple wrappers:
 
@@ -42,7 +51,7 @@ To run full test in Docker container (based on testenv-image) we provide 2 simpl
 All images are named `kontain/name-component-platform:version`.
 
 * Version default  is `latest` for buildenv images e.g. `kontain/buildenv-km-fedora:latest`.
-* Names are `buildenv` for build environment and `test` for test images - e.g `kontain/buildenv-km-fedora` or `kontain/buildenv-node-fedora` or `kontain/test-km-fedora:CI-512`
+* Names are `buildenv` for build environment and `test` for test images - e.g `kontain/buildenv-km-fedora` or `kontain/buildenv-node-fedora` or `kontain/test-km-fedora:ci-512`
 * **Push operations adds Docker image name alias (aka tag) pointing to to target registry, pushes and then clear the tag**. e.g. image `kontain/image:latest` will be tagged as `kontainkubecr.azurecr.io/image:latest` before push.
 * Pull does the opposite (pulls, then re-tags to `kontain/`)
 

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -73,6 +73,8 @@ endif
 
 # Use current branch as image version (tag) for doccker images.
 IMAGE_VERSION ?= latest
+BUILDENV_IMAGE_VERSION ?= ${IMAGE_VERSION}
+
 
 # Code coverage support. If enabled, build with code coverage in dedicate dir
 COV_BLDTYPE := coverage

--- a/payloads/node/test-fedora.dockerfile
+++ b/payloads/node/test-fedora.dockerfile
@@ -11,7 +11,9 @@
 # Dockerfile to package node.km and friends for testing in CI/CD
 
 ARG DTYPE=fedora
-FROM kontain/buildenv-km-${DTYPE}
+ARG BUILDENV_IMAGE_VERSION=latest
+FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
+
 
 ARG MODE=Release
 ENV MODE=$MODE VERS=$VERS NODETOP=/home/appuser/node

--- a/payloads/python/test-fedora.dockerfile
+++ b/payloads/python/test-fedora.dockerfile
@@ -11,7 +11,8 @@
 # Dockerfile to package python.km and friends for testing in CI/CD
 
 ARG DTYPE=fedora
-FROM kontain/buildenv-km-${DTYPE}
+ARG BUILDENV_IMAGE_VERSION=latest
+FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 ENV PHOME /home/$USER/python/
 

--- a/tests/test-fedora.dockerfile
+++ b/tests/test-fedora.dockerfile
@@ -12,7 +12,8 @@
 # Usage will be 'docker run -it --rm --env BRANCH=$(git rev-parse --abbrev-ref HEAD) --device=/dev/kvm --user 0 test-km-fedora km_cdocker run <container> make TARGET=<target> - see ../../Makefile
 #
 ARG DTYPE=fedora
-FROM kontain/buildenv-km-${DTYPE}:latest
+ARG BUILDENV_IMAGE_VERSION=latest
+FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 ARG branch
 


### PR DESCRIPTION
It is hard to modify buildenv images since it's hard to test.
This PR allows to select which version of buildenv images to push/pull/use in builds,
so we can selectively change it for different components in CI

Also, some docs for CI image versions are fixed to reflect we use lowcase ci

test: manually. 
