### PR TITLE
Set ImagePullPolicy to Always for test-withk8s-manual target [trivial]

### DIFF
--- a/cloud/k8s/test-pod-template.yaml
+++ b/cloud/k8s/test-pod-template.yaml
@@ -17,7 +17,7 @@ spec:
   containers:
     - name: NAME()
       image: IMAGE()
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always
       securityContext:
         privileged: false
         allowPrivilegeEscalation: false


### PR DESCRIPTION
This is needed for Kubernetes to re-fetch the image for each manual run .... a little slower, but guarantees to pick up the right stuff

tested: it's one of standard policies in Kubernetes, no extra testing was done