### PR TITLE
WIP: fix for mprotect collapsing mem regs, handle busy concat consequences

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -333,6 +333,7 @@
             "brk_test",
             "gdb_test",
             "mmap_test",
+            "mmap_1_test",
             "getline_test",
             "mem_test",
             "mprotect_test",

--- a/km/Makefile
+++ b/km/Makefile
@@ -14,6 +14,7 @@ EXEC := km
 SOURCES := load_elf.c km_cpu_init.c km_main.c km_vcpu_run.c km_hcalls.c km_mem.c km_mmap.c \
 		km_gdb_stub.c gdb_kvm_x86_64.c km_signal.c km_init_guest.c km_intr.c km_coredump.c \
 		km_filesys.c km_unittest.c km_hc_name.c km_trace.c
+LOCAL_COPTS := -D_KM_UNITTEST
 VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info changes
 INCLUDES := ${TOP}include
 LLIBS := elf z
@@ -45,4 +46,3 @@ distro: ${BLDEXEC}
 
 distroclean:
 	-docker rmi -f ${KM_IMAGE_FULL_NAME}
-

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -126,7 +126,7 @@ int main(int argc, char* const argv[])
    int longopt_index;
    char** envp = calloc(1, sizeof(char*));   // NULL terminated array of env pointers
    int envc = 1;                             // count of elements in envp (including NULL)
-   int putenv_used = 0, copyenv_used = 0;    // they are mutually exlusive
+   int putenv_used = 0, copyenv_used = 0;    // they are mutually exclusive
 
    assert(envp != NULL);
    while ((opt = getopt_long(argc, argv, "+g::V::P:vC:", long_options, &longopt_index)) != -1) {

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -36,7 +36,7 @@ include ${TOP}make/locations.mk
 # customization of build should be in custom.mk
 include ${TOP}make/custom.mk
 
-CFLAGS = ${COPTS} -Wall -ggdb -pthread $(addprefix -I , ${INCLUDES})
+CFLAGS = ${COPTS} ${LOCAL_COPTS} -Wall -ggdb -pthread $(addprefix -I , ${INCLUDES})
 DEPS = $(addprefix ${BLDDIR}, $(addsuffix .d, $(basename ${SOURCES})))
 OBJS = $(sort $(addprefix ${BLDDIR}, $(addsuffix .o, $(basename ${SOURCES}))))
 BLDEXEC = $(addprefix ${BLDDIR},${EXEC})

--- a/make/custom.mk
+++ b/make/custom.mk
@@ -11,5 +11,5 @@
 # customizable build parameters
 
 # default optimization flag
-COPTS ?= -D_KM_UNITTEST -O2 #-Wunused-parameter
+COPTS ?= -O2 #-Wunused-parameter
 LDOPTS ?= -static

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -183,8 +183,8 @@ load test_helper
 }
 
 @test "mem_mmap_1(static): mmap then smaller mprotect (mmap_1_test)" {
-   assert_success
    run km_with_timeout mmap_1_test.km
+   assert_success
 }
 
 @test "futex example(static)" {
@@ -294,11 +294,10 @@ load test_helper
 @test "threads_basic(static): threads with TLS, create, exit and join (hello_2_loops_tls_test)" {
    run km_with_timeout hello_2_loops_tls_test.km
    assert_success
-   refute_line --partial 'BAD'
 }
 
 @test "threads_basic(static): threads with TSD, create, exit and join (hello_2_loops_test)" {
-   run km_with_timeout -Vsignal hello_2_loops_test.km
+   run km_with_timeout hello_2_loops_test.km
    assert_success
 }
 

--- a/tests/km_dyn_tests.bats
+++ b/tests/km_dyn_tests.bats
@@ -177,9 +177,9 @@ load test_helper
    assert [ $status -eq $expected_status ]
 }
 
-@test "mem_mmap_1(static): mmap then smaller mprotect (mmap_1_test)" {
-   assert_success
+@test "mem_mmap_1(dynamic): mmap then smaller mprotect (mmap_1_test)" {
    run km_with_timeout mmap_1_test.km
+   assert_success
 }
 
 @test "futex example(dynamic)" {
@@ -293,7 +293,7 @@ load test_helper
 }
 
 @test "threads_basic(dynamic): threads with TSD, create, exit and join (hello_2_loops_test)" {
-   run km_with_timeout -Vsignal hello_2_loops_test.kmd
+   run km_with_timeout hello_2_loops_test.kmd
    assert_success
 }
 

--- a/tests/km_so_tests.bats
+++ b/tests/km_so_tests.bats
@@ -184,9 +184,9 @@ load test_helper
    #[ $status -eq $expected_status ]
 }
 
-@test "mem_mmap_1(static): mmap then smaller mprotect (mmap_1_test)" {
-   assert_success
+@test "mem_mmap_1(shared): mmap then smaller mprotect (mmap_1_test)" {
    run km_with_timeout mmap_1_test.km
+   assert_success
 }
 
 @test "futex example(shared)" {
@@ -277,28 +277,22 @@ load test_helper
 }
 
 @test "threads_basic(shared): threads with TLS, create, exit and join (hello_2_loops_tls_test)" {
-   skip "TODO: shared version"
-   # TODO: error loading ld-linux-x86-64.so !!! fix this (shared)
-   #run km_with_timeout ${KM_LDSO} --library-path=${KM_LDSO_PATH} -- hello_2_loops_tls_test.so
-   #assert_success
-   #refute_line --partial 'BAD'
+   run km_with_timeout ${KM_LDSO} --library-path=${KM_LDSO_PATH} -- hello_2_loops_tls_test.so
+   assert_success
 }
 
 @test "threads_basic(shared): threads with TSD, create, exit and join (hello_2_loops_test)" {
-   # shared
-   run km_with_timeout -Vsignal ${KM_LDSO} --library-path=${KM_LDSO_PATH} -- hello_2_loops_test.so
+   run km_with_timeout ${KM_LDSO} --library-path=${KM_LDSO_PATH} -- hello_2_loops_test.so
    assert_success
 }
 
 @test "threads_exit_grp(shared): force exit when threads are in flight (exit_grp_test)" {
-   # shared
    run km_with_timeout ${KM_LDSO} --library-path=${KM_LDSO_PATH} -- exit_grp_test.so
    # the test can exit(17) from main thread or random exit(11) from subthread
    assert [ $status -eq 17 -o $status -eq 11  ]
 }
 
 @test "threads_mutex(shared): mutex (mutex_test)" {
-   # shared
    run km_with_timeout ${KM_LDSO} --library-path=${KM_LDSO_PATH} -- mutex_test.so
    assert_success
 }

--- a/tests/mmap_1_test.c
+++ b/tests/mmap_1_test.c
@@ -42,17 +42,43 @@ TEST mmap_overlap()
    static const size_t map_size = 1024 * 1024;
    static const size_t guard_size = 4 * 1024;
 
-   for (int i = 0; i < 16; i++) {
-      void* s1 = mmap(0, map_size + 2 * guard_size, PROT_NONE, MAP_PRIVATE, -1, 0);
-      mprotect(s1 + guard_size, map_size, PROT_READ | PROT_WRITE);
-      munmap(s1, map_size + 2 * guard_size);
-      printf("==== Pass %d s1=%p\n", i, s1);
-      get_maps();
+   if (greatest_get_verbosity() > 0) {
+      printf("==== mmap_overlap\n");
    }
+   void* s1 = mmap(0, map_size + 2 * guard_size, PROT_NONE, MAP_PRIVATE, -1, 0);
+   mprotect(s1 + guard_size, map_size, PROT_READ | PROT_WRITE);
+   munmap(s1, map_size + 2 * guard_size);
+   if (greatest_get_verbosity() > 0) {
+      printf("==== Pass s1=%p\n", s1);
+   }
+   get_maps(greatest_get_verbosity());
    ASSERT_EQ(2, info->ntotal);
+   printf("total: %d free: %d\n", info->ntotal, info->nfree);
    PASS();
 }
 
+TEST mmap_mprotect_overlap()
+{
+   if (greatest_get_verbosity() > 0) {
+      printf("==== mmap_mprotect_overlap\n");
+   }
+   void* s1 = mmap(0, 1 * GIB, PROT_NONE, MAP_PRIVATE, -1, 0);
+   mprotect(s1 + 1 * MIB, 1 * MIB, PROT_READ | PROT_WRITE);
+   mprotect(s1 + 3 * MIB, 1 * MIB, PROT_READ | PROT_WRITE);   // gap 1MB
+   get_maps(greatest_get_verbosity());
+   ASSERT_EQ(7, info->ntotal);
+   mprotect(s1 + 2 * MIB, 2 * MIB, PROT_READ | PROT_WRITE);   // fill in the gap and some more
+   get_maps(greatest_get_verbosity());
+   mprotect(s1 + 2 * MIB, 1 * MIB, PROT_READ | PROT_WRITE);
+   get_maps(greatest_get_verbosity());
+   ASSERT_EQ(5, info->ntotal);
+
+   munmap(s1, 1 * GIB);
+   get_maps(greatest_get_verbosity());
+   ASSERT_EQ(2, info->ntotal);
+   printf("total: %d free: %d\n", info->ntotal, info->nfree);
+   PASS();
+}
 /* Inserts misc defintions */
 GREATEST_MAIN_DEFS();
 
@@ -61,6 +87,7 @@ int main(int argc, char** argv)
    GREATEST_MAIN_BEGIN();
 
    RUN_TEST(mmap_overlap);
+   RUN_TEST(mmap_mprotect_overlap);
 
    GREATEST_PRINT_REPORT();
    exit(greatest_info.failed);   // return count of errors (or 0 if all is good)

--- a/tests/mmap_test.c
+++ b/tests/mmap_test.c
@@ -142,12 +142,12 @@ TEST mmap_test(void)
                ASSERT_EQ_FMTm(t->info, MAP_FAILED, new_addr, ret_fmt);
                ASSERT_EQ_FMTm(t->info, t->expected, errno, errno_fmt);
             }
-            get_maps();
+            get_maps(greatest_get_verbosity());
             break;
          case TYPE_MUNMAP:
             assert(last_addr != MAP_FAILED);   // we should have failed test already
             ret = munmap(last_addr + t->offset, t->size);
-            get_maps();
+            get_maps(greatest_get_verbosity());
             if (t->expected == OK) {
                ASSERT_EQ_FMTm(t->info, 0, errno, errno_fmt);
                ASSERT_EQ_FMTm(t->info, 0, ret, ret_fmt);
@@ -162,7 +162,7 @@ TEST mmap_test(void)
             size_t old_size = t->size;
             size_t new_size = t->prot;
             new_addr = mremap(remapped_addr, old_size, new_size, t->flags);
-            get_maps();
+            get_maps(greatest_get_verbosity());
             if (t->expected == OK) {
                ASSERT_EQ_FMTm(t->info, 0, errno, errno_fmt);   // print errno out if test fails
                ASSERT_NOT_EQ_FMTm(t->info, MAP_FAILED, new_addr, ret_fmt);
@@ -219,7 +219,7 @@ TEST mmap_test(void)
                ASSERT_NOT_EQ_FMTm(t->info, 0, ret, ret_fmt);
                ASSERT_EQ_FMTm(t->info, t->expected, errno, errno_fmt);
             }
-            get_maps();
+            get_maps(greatest_get_verbosity());
             break;
          case TYPE_WRITE:
             assert(last_addr != MAP_FAILED);   // we should have failed test already
@@ -432,7 +432,7 @@ TEST mremap_test()
 
    printf("===== mremap: Testing mremap() functionality\n");
    tests = mremap_tests;
-   get_maps();
+   get_maps(greatest_get_verbosity());
    CHECK_CALL(mmap_test());
    PASS();
 }

--- a/tests/mmap_test.h
+++ b/tests/mmap_test.h
@@ -48,7 +48,7 @@ typedef struct mmap_test {
 
 #define UNUSED __attribute__((unused))
 static const char* errno_fmt UNUSED = "errno 0x%x";   // format for offsets/types error msg
-static const char* ret_fmt UNUSED = "ret 0x%x";              // format for offsets/types error msg
+static const char* ret_fmt UNUSED = "ret 0x%x";       // format for offsets/types error msg
 // just to type less going forward
 static const int flags = (MAP_PRIVATE | MAP_ANONYMOUS);
 
@@ -72,14 +72,11 @@ static char* out_sz(uint64_t val)
    return buf;
 }
 
-static int get_maps(void) UNUSED;
-static int get_maps(void)
+static int get_maps(int verbose) UNUSED;
+static int get_maps(int verbose)
 {
    int ret;
 
-   if (greatest_get_verbosity() <= 0) {
-      return 0;
-   }
    if (info == NULL) {
       info = calloc(1, sizeof(km_ut_get_mmaps_t) + MAX_MAPS * sizeof(km_mmap_reg_t));
       assert(info != NULL);
@@ -102,17 +99,19 @@ static int get_maps(void)
       if (reg == info->maps + info->nfree) {   // reset distance on 'busy' list stat
          old_end = reg->start;
       }
-      printf("mmap %s: 0x%lx size 0x%lx (%s) distance 0x%lx (%s), flags 0x%x prot 0x%x km_flags "
-             "0x%x\n",
-             type,
-             reg->start,
-             reg->size,
-             out_sz(reg->size),
-             reg->start - old_end,
-             out_sz(reg->start - old_end),
-             reg->flags,
-             reg->protection,
-             reg->km_flags.data32);
+      if (verbose > 0) {
+         printf("mmap %s: 0x%lx size 0x%lx (%s) distance 0x%lx (%s), flags 0x%x prot 0x%x km_flags "
+                "0x%x\n",
+                type,
+                reg->start,
+                reg->size,
+                out_sz(reg->size),
+                reg->start - old_end,
+                out_sz(reg->start - old_end),
+                reg->flags,
+                reg->protection,
+                reg->km_flags.data32);
+      }
       old_end = reg->start + reg->size;
    }
    return 0;


### PR DESCRIPTION
I believe we should merge this, as it clearly fixes known mmap issue. The vcpu fix will come in a separate PR.

I marked it as WIP as we need to discuss/agree on the way `km_mmap_busy_range_apply()` is done, with the action names hard coded and such.