### PR TITLE
WIP: Avoid hw break test on AMD, and compile all with -ggdb3

### DIFF
--- a/make/actions.mk
+++ b/make/actions.mk
@@ -36,7 +36,7 @@ include ${TOP}make/locations.mk
 # customization of build should be in custom.mk
 include ${TOP}make/custom.mk
 
-CFLAGS = ${COPTS} ${LOCAL_COPTS} -Wall -ggdb -pthread $(addprefix -I , ${INCLUDES})
+CFLAGS = ${COPTS} ${LOCAL_COPTS} -Wall -ggdb3 -pthread $(addprefix -I , ${INCLUDES})
 DEPS = $(addprefix ${BLDDIR}, $(addsuffix .d, $(basename ${SOURCES})))
 OBJS = $(sort $(addprefix ${BLDDIR}, $(addsuffix .o, $(basename ${SOURCES}))))
 BLDEXEC = $(addprefix ${BLDDIR},${EXEC})

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -63,7 +63,7 @@ CWARNS := -Wno-parentheses -Wno-uninitialized -Wno-missing-braces -Wno-unused-va
 
 # -ffunction-sections -fdata-sections work together with linker script, see km.ld
 # Other -f... options are to reduce generated code size
-COPTS := -Os -ggdb -D_XOPEN_SOURCE=700 -pipe -nostdinc \
+COPTS := -Os -ggdb3 -D_XOPEN_SOURCE=700 -pipe -nostdinc \
 	-fomit-frame-pointer -fno-unwind-tables -fno-asynchronous-unwind-tables \
 	-ffunction-sections -fdata-sections -fexcess-precision=standard -frounding-math \
 	-fno-tree-loop-distribute-patterns -fno-stack-protector \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,8 +32,8 @@ SHRSRC := dlopen_test.c dlopen_test_lib.c dlopen_test_lib2.c
 BUILDENV_PATH  := ./gdb
 TESTENV_PATH := .
 
-CFLAGS = -Wall $(COPTS) -ggdb -fPIC -fno-stack-protector -pthread -I$(TOP)include -I$(TOP)km
-LDFLAGS = -ggdb -pthread
+CFLAGS = -Wall $(COPTS) -ggdb3 -fPIC -fno-stack-protector -pthread -I$(TOP)include -I$(TOP)km
+LDFLAGS = -ggdb3 -pthread
 KCC := kontain-gcc
 DEPS = ${SRC:%.c=%.d} ${SHRSRC:%.c=%.d} ${SRC_CPP:%.cpp=%.d}
 KM_PAYLOADS := ${SRC:%.c=%.km} ${SRC_CPP:%.cpp=%.km}

--- a/tests/cmd_for_test.gdb
+++ b/tests/cmd_for_test.gdb
@@ -18,7 +18,9 @@ command
   p var1
 end
 
-hbreak rand_func if i > 1
+# usually we test hbreak, but can override it from upstairs by setting this alias to 'break'
+ignore-errors alias mybreak=hbreak
+mybreak rand_func if i > 1
 command
   p/s "** HWBREAK "
   p/x i

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -54,12 +54,16 @@ function km_with_timeout () {
    s=$?; if [ $s -eq 124 ] ; then echo "\nTimed out in $timeout" ; fi ; return $s
 }
 
+gdb_hbreak_alias="$(if ! grep 'vendor_id' /proc/cpuinfo  | grep -iq intel ; \
+   then echo alias mybreak=hbreak ; else echo alias mybreak=break  ; \
+fi )"
 # this is how we invoke gdb - with timeout
 function gdb_with_timeout () {
    timeout --foreground $timeout \
-      gdb "$@"
+      gdb -ex="$gdb_hbreak_alias" "$@"
    s=$?; if [ $s -eq 124 ] ; then echo "\nTimed out in $timeout" ; fi ; return $s
 }
+
 
 # this is needed for running in Docker - bats uses 'tput' so it needs the TERM
 TERM=xterm


### PR DESCRIPTION
Fixes #368 (GDB tests fail on AMD CPUs) by using 'break' in the test on AMD, instead of 'hbreak'

Also adds -ggdb3 instead of -ggdb , to save macros info in gdb tables

tested with make tests on AMD Ryzen machine (at my home) and  Intel Xeon box (at the office)