### PR TITLE
Added pre-commit hook for auto-format, and adjusted code style doc

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Git pre-commit hook to format files in git staging.
+# Only files with names matching $FILES below will be formatted
+#
+
+# glob pattern of files to format
+FILES='*[chp]'
+RED="\033[31m"
+GREEN="\033[32m"
+NOCOLOR="\033[0m"
+
+cd $(git rev-parse --show-toplevel)
+
+if ! command -vp clang-format > /dev/null ; then
+   echo -e "Warning: failed to format: clang-format is not found, please install clang package (sudo dnf install clang)"
+   exit 0
+fi
+if [[ ! -f .clang-format ]] ; then
+   echo -e "Warning: failed to format: file `pwd`/.clang-format is not found"
+   exit 0
+fi
+
+case "${1}" in
+  --about )
+    echo "Runs clang-format on source files matching '$FILES' in git commit staging"
+    ;;
+  * )
+    files=$(git diff-index --cached --name-only HEAD -- "$FILES")
+    if [ -z "$files" ] ; then
+      exit 0 # nothing to format
+    fi
+    if ! clang-format -i $files; then
+         echo -e "${RED}Error: failed to format $files. Commit blocked$NOCOLOR"
+         exit 1
+    fi
+    if [[ $(git diff -- $files  | wc -l) != 0 ]] ; then
+        echo -e "${GREEN}Formatted $files${NOCOLOR}"
+        git add $files
+    fi
+    ;;
+esac

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 #
 # Basic build for kontain machine (km) and related tests/examples.
-# Subject to change - code is currently PoC
 #
-# dependencies:
-#  elfutils-libelf-devel and elfutils-libelf-devel-static for gelf.h and related libs
-#  OR:
-#  docker - for 'make withdocker TARGET=<target>
+# See README.md for details. run 'make help' for help.
+# Dependencies are enumerated in  tests/buildenv-fedora.dockerfile.
+# See 'make -C tests buildenv-fedora-local' for installing dependencies
 #
 # ====
 #  Copyright © 2018-2019 Kontain Inc. All rights reserved.
@@ -30,4 +28,12 @@ TOP := $(shell git rev-parse --show-cdup)
 ifeq ($(shell uname), Darwin)
 MAKE := make
 endif
+
+# Install git hooks, if needed
+GITHOOK_DIR ?= .githooks
+git-hooks-init: ## make git use GITHOOK_DIR (default .githooks) for pre-commit and other hooks
+	git config core.hooksPath $(GITHOOK_DIR)
+git-hooks-reset: ## reset git hooks location to git default of .git/hooks (not version controlled)
+	git config core.hooksPath .git/hooks
+
 include ${TOP}make/actions.mk

--- a/README.md
+++ b/README.md
@@ -50,37 +50,47 @@ We use Visual Studio Code as recommended IDE; install it and use `code km_repo_r
 
 ## Code style
 
-* Our coding style doc is still TBD
+* Detailed document  for coding style is still TBD, below is a high level outline
 * The majority of formatting is handled by Visual Studio Code.
-  * We use clang-format forcing to be compliant with tabs and the likes.
+  * We use clang-format forcing to be compliant with tabs and the likes. **Do not forget to `sudo dnf install clang`** (or install clang with whatever package manager you are using)
   * KM workspace has "Format on Save" turned on, please do not turn it off in your User settings.
-  * If you edit the source using other tools, please make sure to use `clang-format -i `*`filename`*. it will format the *`filename`* in place using the same presets as Visual Studio Code. You'll need to install it: `sudo dnf install clang.x86_64`
-* Generally, we pay attention to the code being easy to read. Give short (but meaningful) names to all, do not save on comments, and try to stay within the look and feel of the other code.
+  * **If you prefer to edit the source using other tools**, you *MUST* enable git pre-commit hooks (`make git-hook-init`) to auto-format on commit.
+* Generally, we pay attention to the code being easy to read.
+  * Give short (but meaningful) names to all, do not save on comments, and try to stay within the look and feel of the other code.
+  * Try to limit function / methods / blocks size to a readable page (50-60 lines). "50-60" is not a hard requirement, but please do not create multi-page functions.
 * Single line comments are `//` , multiple lines `/* ... */`
 * We use km_underscore_notation for vars and functions.
 * Never use single lines `if (cond) do_something`. *Always* use `{}` - i.e.
-```
+
+```C
 if (cond) {
    do something;
 }
 ```
+
 * we always compare function results with explicit value. E.g. we do `if (my_check() == 0) ...` instead of `if (!my_check())...`
-* for `return` statement, if we return a single token (with or without sign), then we do not use `()`, otherwise we do. E.g. `return 0;` and `return -ENOMEM;`, but `return (value + 1); `
-* Don't decare multiple variable on the same line, particularly when there are initial values assigned.
+* for `return` statement, if we return a single token (with or without sign), then we do not use `()`, otherwise we do. E.g. `return 0;` and `return -ENOMEM;`, but `return (value + 1);`
+* Don't declare multiple variable on the same line, particularly when there are initial values assigned.
 * Don't assign multiple variables on the same line. Instead of `a = b = 0;` use two separate assignments.
-### The following isn't hard requirement but a strong preference ###
+
+### The following isn't hard requirement but a strong preference
+
 * We like the code to be compact, for instance we like
-```
+
+```C
 if ((rc = function()) < 0) {
    do something;
 }
 ```
+
 Or, if applicable
-```
+
+```C
 for (int index = 0; index < MAX_INDEX; index++) {
    loop body;
 }
 ```
+
 * We like variable declaration closer to the place in the function where they are used, instead of more traditional way to put all declarations at the top of a function.
 
 ## Test runs


### PR DESCRIPTION
Run `make git-hook-init` to enable git hooks for your local git.
Currently only one hook is installed there - pre-commit. It will use clang-format
to format all *[chp] files in git commit, and then add formatted files back to the commit

**IF YOU EDIT OUTSIDE OF VS CODE, PLEASE DO ENABLE git hooks**

otherwise it's optional , but it won't hurt