### PR TITLE
Fixed python fromsrc build and removed cut-n-paste

### DIFF
--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -36,6 +36,13 @@ PAYLOAD_FILES := --exclude='*/test/*' --exclude='*/__pycache__/*' --exclude '*.e
 # List of artifacts necessary to run tests. See buildenv-fedora.dockerfile
 PYTHON_DISTRO_FILES := $(addprefix cpython/, Lib Modules build pybuilddir.txt dlstatic_km.mk)
 
+# Build dlstatic extensions and link cpython.km
+export define link_cpython_km
+	make -C cpython -f dlstatic_km.mk   # compile built-in modules
+	./extensions/build_extensions.sh    # add additional modules as configured
+	./link-km.sh ${PYTHONTOP} cpython   # and link
+endef
+
 # either run all in 'blank' container, or local.
 # in blank: link + tar + create shebang
 # fromsrc local: link + create shebang
@@ -44,9 +51,7 @@ all:
 ifneq ($(shell test -d cpython/.git && echo OK),OK)
 	${DOCKER_RUN} -v $(realpath ${TOP}):/src:Z -w /src ${BUILDENV_IMG}:${BUILDENV_IMAGE_VERSION} make -C payloads/python in-blank-container
 else
-	 make -C cpython -f dlstatic_km.mk
-	./extensions/build_extensions.sh
-	./link-km.sh ${PYTHONTOP} cpython
+	 eval $(link_cpython_km)
 endif
 
 in-blank-container: ## invoked in blank container by ``make all''. DO NOT invoke manually
@@ -56,15 +61,19 @@ in-blank-container: ## invoked in blank container by ``make all''. DO NOT invoke
 	@echo "Info - .so are linked in for built-in modules only. Additional modules are supported via 'make fromsrc'"
 	./link-km.sh ${PYTHONTOP} cpython
 
-fromsrc:
+# rebuild builtin extensions
+define prepare_builtins
+	cd cpython && ../extensions/prepare_extension.py bear.out --skip ../extensions/skip_builtins.txt
+endef
+builtins: ## helper target to rebuilt builtin extension in clone cpython dir
+	eval $(prepare_builtins)
+
+fromsrc: ## Clean build cpython from source. Use 'make clobber' to prepare for this one
 	git clone https://github.com/python/cpython.git -b ${VERS}
 	cd cpython && ./configure && make -j`expr 2 \* $(nproc)` | tee bear.out
 	cd cpython && patch -p1 < ../unittest.patch
-	cd cpython && ../extensions/prepare_extension.py bear.out --skip ../extensions/skip_builtins.txt
-	# this seems repetitive, TODO - clean cut-n-paste:
-	make -C cpython -f dlstatic_km.mk
-	./extensions/build_extensions.sh
-	./link-km.sh cpython cpython
+	eval $(prepare_builtins)
+	eval $(link_cpython_km)
 
 clean:
 	@echo "Nothing to do for 'clean' - use 'clobber' to force remove build artifacts"
@@ -83,7 +92,7 @@ export define runenv_prep
 	tar -cf - ${PYTHON_DISTRO_FILES} scripts | tar -C $(RUNENV_PATH) -xf -
 	echo '#!/km --putenv=PYTHONPATH=/cpython/Lib' > $(RUNENV_PATH)/python ; chmod a+x $(RUNENV_PATH)/python
 endef
-clobber:
+clobber: ## Clobber cpython build by removing cpython dir
 	rm -rf cpython
 
 clobber-modules:

--- a/payloads/python/extensions/modules.txt
+++ b/payloads/python/extensions/modules.txt
@@ -61,7 +61,7 @@
 # 5 hr build with Bazel and there are no .so in the output. Needs investigation
 
 # gevent  1.4.0 https://github.com/gevent/gevent cython
-# undefined: `__read_chk `__fdelt_chk `__memmove_chk `__open64_2 `__pread64_chk
+# undefined ref to : `_dl_x86_cpu_features` and `errno` !??
 
 #h5py 2.10.0 https://github.com/h5py/h5py
 # neeeds hdf5 hdf5-static (dnf). undefined: `__vasprintf_chk `__realpath_chk` SZ_encoder_enabled `SZ_BufftoBuffDecompress

--- a/payloads/python/extensions/prepare_extension.py
+++ b/payloads/python/extensions/prepare_extension.py
@@ -132,7 +132,7 @@ clobber:
 \t\tfor obj in $^ ; do \\
 \t\t\tmunged_obj="/tmp/$$(basename $${obj/.o/$$id.o})" ; cp $$obj $$munged_obj; ofiles="$$ofiles $$munged_obj" ; \\
 \t\t\t{{ echo_if_no_mung }} objcopy --redefine-syms={{ line["so"] | replace(".so", ".km.symmap") }} $$munged_obj; \\
-\t\tdone && ar rv $@ $$ofiles && rm $$ofiles
+\t\tdone && ar rv $@ $$ofiles && rm -f $$ofiles
 {% endfor %}
 
 # allows to do 'make print-varname'

--- a/payloads/python/extensions/skip_builtins.txt
+++ b/payloads/python/extensions/skip_builtins.txt
@@ -22,4 +22,6 @@ _codecs_tw
 _codecs_hk
 _codecs_iso2022
 _sqlite3
-
+_tkinter
+_dbm
+_gdbm


### PR DESCRIPTION
* a couple of built-in modules were errneously picked up by the build. Removed them
* removed a couple of cut-n-pasted actions in makefile by adding define block

tested: manual rebuild from container and fromsrc