### PR TITLE
vcpu state transitions cleanup

### DIFF
--- a/km/km_gdb.h
+++ b/km/km_gdb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Kontain Inc. All rights reserved.
+ * Copyright © 2019-2020 Kontain Inc. All rights reserved.
  *
  * Kontain Inc CONFIDENTIAL
  *
@@ -192,7 +192,7 @@ extern int km_gdb_wait_for_connect(const char* image_name);
 extern void km_gdb_main_loop(km_vcpu_t* main_vcpu);
 extern void km_gdb_fini(int ret);
 extern void km_gdb_start_stub(char* const payload_file);
-extern void km_gdb_notify_and_wait(km_vcpu_t* vcpu, int signo, bool need_wait);
+extern void km_gdb_notify(km_vcpu_t* vcpu, int signo);
 extern char* mem2hex(const unsigned char* mem, char* buf, size_t count);
 extern void km_guest_mem2hex(km_gva_t addr, km_kma_t kma, char* obuf, int len);
 extern int km_gdb_update_vcpu_debug(km_vcpu_t* vcpu, uint64_t unused);

--- a/km/km_intr.c
+++ b/km/km_intr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Kontain Inc. All rights reserved.
+ * Copyright © 2019-2020 Kontain Inc. All rights reserved.
  *
  * Kontain Inc CONFIDENTIAL
  *
@@ -216,13 +216,5 @@ void km_handle_interrupt(km_vcpu_t* vcpu)
          info.si_signo,
          strsignal(info.si_signo));
 
-   if (km_gdb_is_enabled() != 0) {
-      vcpu->cpu_run->exit_reason = KVM_EXIT_INTR;
-      km_gdb_notify_and_wait(vcpu, info.si_signo, true);
-   }
-
    km_post_signal(vcpu, &info);
-
-   // We know there is a signal. Force delivery now.
-   km_deliver_signal(vcpu);
 }

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Kontain Inc. All rights reserved.
+ * Copyright © 2018-2020 Kontain Inc. All rights reserved.
  *
  * Kontain Inc CONFIDENTIAL
  *
@@ -253,6 +253,9 @@ int main(int argc, char* const argv[])
    if (wait_for_signal == 1) {
       warnx("Waiting for kill -SIGUSR1  %d", getpid());
       km_wait_for_signal(SIGUSR1);
+   }
+   if (km_gdb_is_enabled() == 1) {
+      km_vcpu_pause_all();
    }
    if (km_run_vcpu_thread(vcpu, km_vcpu_run_main) < 0) {
       err(2, "Failed to create main run_vcpu thread");

--- a/km/km_signal.h
+++ b/km/km_signal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Kontain Inc. All rights reserved.
+ * Copyright © 2019-2020 Kontain Inc. All rights reserved.
  *
  * Kontain Inc CONFIDENTIAL
  *
@@ -20,7 +20,8 @@
 void km_signal_init(void);
 void km_signal_fini(void);
 void km_post_signal(km_vcpu_t* vcpu, siginfo_t* info);
-void km_deliver_signal(km_vcpu_t* vcpu);
+void km_deliver_signal(km_vcpu_t* vcpu, siginfo_t* info);
+void km_deliver_next_signal(km_vcpu_t* vcpu);
 void km_dequeue_signal(km_vcpu_t* vcpu, siginfo_t* info);
 int km_signal_ready(km_vcpu_t*);
 
@@ -61,7 +62,7 @@ static inline void km_sigdelset(km_sigset_t* set, int signo)
    }
 }
 
-static inline int km_sigismember(km_sigset_t* set, int signo)
+static inline int km_sigismember(const km_sigset_t* set, int signo)
 {
    if (signo < 1 && signo >= _NSIG) {
       return 0;

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -258,18 +258,15 @@ todo_so="hc_check mem_slots mem_mmap gdb_basic gdb_signal gdb_exception gdb_serv
    km_trace_file=/tmp/gdb_server_race_test_static_$$.out
    # Test with breakpoints triggering and SIGILL being happending continuously
    # Save output to a log file for our own check using grep below.
+   echo trace in $km_trace_file
    km_with_timeout -V -g gdb_server_entry_race_test$ext >$km_trace_file 2>&1 &
    gdb_pid=$! ; sleep 0.5
    run gdb_with_timeout -q -nx --ex="target remote :$km_gdb_default_port" --ex="source cmd_for_gdbserverrace_test.gdb" \
          --ex=c --ex=q gdb_server_entry_race_test$ext
    assert_success
    # check that KM exited normally
-   run wait $gdb_pid
+   wait $gdb_pid
    assert_success
-
-   # look for km trace entries that show older gdb events for a paused thread are
-   # being bypassed when deciding to tell the gdb client why the target stopped.
-   assert grep -q "Skipping event for paused vcpu:" $km_trace_file
    rm -f $km_trace_file
 }
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -2,7 +2,7 @@
 # use this if started as a standalone script:
 if [ -z "$BATS_TEST_FILENAME" ] ; then "exec" "`dirname $0`/bats/bin/bats" "$0" "$@" ; fi
 
-# Copyright © 2019 Kontain Inc. All rights reserved.
+# Copyright © 2019-2020 Kontain Inc. All rights reserved.
 #
 # Kontain Inc CONFIDENTIAL
 #
@@ -127,6 +127,7 @@ bus_width() {
 
 function setup() {
   skip_if_needed "$BATS_TEST_DESCRIPTION"
+  echo --- Test script output:
 }
 
 teardown() {


### PR DESCRIPTION
Cleanup vcpu state transitions.

`is_paused` is replaced with `is_running` and it simply indicates when vcpu is in KVM_RUN ioctl. The logic the pauses the vcpus use this to decide if we need to send a signal to the vcpu to stop guest executing commands. If a thread is in KM system call `is_running` will be `0` and no signal is send. If syscall ends while the vcpu still is paused it will pause in the same place as all the others, so no special treatment is needed.

VCPUs are paused in one place in the vcpu_run loop, based on `machine.paused_requested` value or gdb threads disposition.

Consolidated signals delivery mechanism in one place. In case of gdb all signals are passed through the client first, then delivere when the client tells us to. Added special treatment for unblockable signals. 

Removed the retry logic in `vcpu_pause`. Reduced wait timeout in `pause_all_vcpus` from 10 to 1 ms. 

Regular tests were run many time, with special focus on gdb_server_race, other gdb and signals tests.