### PR TITLE
Use TRACE=1 to trace bash, and fix to bus_width in tests [trivial]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ variables:
   dtype: $(buildenv.type)  # until we add other distros, this always maps to fedora (see 'strategy' below)
   buildenv_image_version: latest # use this for all buildenv containers
   image_version: ci-$(Build.BuildId) # use this for all other containers
-  #bash_tracing: true # uncomment to enable '-x' in all bash scripts
+  #trace: true # uncomment to enable '-x' in all bash scripts
 
 strategy:
   matrix:
@@ -74,7 +74,7 @@ steps:
 
   - bash: |
       set -e
-      if [ -v BASH_TRACING ] ; then set -x ; fi
+      [ "$TRACE" ] && set -x
       make -C tests pull-buildenv-image
       make -j withdocker
       make -C tests testenv-image push-testenv-image
@@ -100,7 +100,7 @@ steps:
     timeoutInMinutes: 5
 
   - bash: |
-      if [ -v BASH_TRACING ] ; then set -x ; fi
+      [ "$TRACE" ] && set -x
       make -C cloud/azure ci-image-purge CI_IMAGE_DRY_RUN=""
       # TODO - if the **test** failed (especially with kmcore), we want to keep these pods for a few days
       # Setting vars doc: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables

--- a/cloud/azure/apply_openwhisk_vms.sh
+++ b/cloud/azure/apply_openwhisk_vms.sh
@@ -15,7 +15,7 @@
 source `dirname $0`/cloud_config.mk
 SUFFIX='openwhisk-kontain'
 
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 op=${1:-help}
 if [[ "$op" == "help" || "$op" == "--help" ]] ; then
    cat <<EOF

--- a/cloud/azure/clear_initial_resources.sh
+++ b/cloud/azure/clear_initial_resources.sh
@@ -15,7 +15,7 @@
 source `dirname $0`/cloud_config.mk
 
 set -e
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 az account set -s ${CLOUD_SUBSCRIPTION}
 az configure --defaults location=${CLOUD_LOCATION}}
 az acr delete --resource-group ${CLOUD_RESOURCE_GROUP} --name  ${REGISTRY_NAME}

--- a/cloud/azure/clear_kube_cluster.sh
+++ b/cloud/azure/clear_kube_cluster.sh
@@ -17,7 +17,7 @@ cd `dirname $0`
 source ./cloud_config.mk
 
 #set -e  # even if some resource deletion fails, keep deleting others. Thus no need for 'set -e' here
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 sp_id=`az ad sp list  --query "[?contains(servicePrincipalNames,'$K8_SERVICE_PRINCIPAL')].{Id: objectId}"  --output tsv`
 az aks delete -y --resource-group ${CLOUD_RESOURCE_GROUP}  --name ${K8S_CLUSTER}
 az ad sp delete --id $sp_id

--- a/cloud/azure/create_initial_resources.sh
+++ b/cloud/azure/create_initial_resources.sh
@@ -14,7 +14,7 @@
 source `dirname $0`/cloud_config.mk
 
 set -e
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 az account set -s ${CLOUD_SUBSCRIPTION}
 az configure --defaults location=${CLOUD_LOCATION}
 az group create --name ${CLOUD_RESOURCE_GROUP} --output ${OUT_TYPE}

--- a/cloud/azure/create_kube_cluster.sh
+++ b/cloud/azure/create_kube_cluster.sh
@@ -23,7 +23,7 @@ set -e
 # create service principal, give it access to ACR, create cluster with the SP
 appPwd=`az ad sp create-for-rbac --name ${K8_SERVICE_PRINCIPAL} --skip-assignment --query password --output tsv`
 echo Do not lose it PWD $appPwd . TODO: switch to pre-generated PEM certs
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 acrId=`az acr show --resource-group ${CLOUD_RESOURCE_GROUP} --name ${REGISTRY_NAME} --query "id" --output tsv`
 sp_id=`az ad sp list  --query "[?contains(servicePrincipalNames,'$K8_SERVICE_PRINCIPAL')].{Id: objectId}"  --output tsv`
 appId=`az ad sp show --id ${sp_id}  --query appId --output tsv`

--- a/cloud/azure/create_openwhisk_vms.sh
+++ b/cloud/azure/create_openwhisk_vms.sh
@@ -12,7 +12,7 @@
 # Deploys VMs for Openwhisk demo to Azure.
 # Also preps this VM to fetch from Kontain github
 set -e
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 
 source `dirname $0`/cloud_config.mk
 

--- a/cloud/azure/untag_image.sh
+++ b/cloud/azure/untag_image.sh
@@ -23,7 +23,7 @@ image="$1"
 version="$2"
 if [ -z "$image" -o -z "$version" ] ; then echo Usage: $0 image_short_name version; exit; fi
 
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 $DEBUG az acr login -n ${REGISTRY_NAME}
 $DEBUG az acr repository show-tags --repository ${image} -n ${REGISTRY_NAME} --output ${out_type}
 $DEBUG az acr repository untag  -n ${REGISTRY_NAME}  --image ${image}:${version}

--- a/payloads/busybox/build.sh
+++ b/payloads/busybox/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 src=busybox
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 set -e
 
 if [ ! -d $src ]; then

--- a/payloads/node/link-km.sh
+++ b/payloads/node/link-km.sh
@@ -3,7 +3,7 @@
 # Create node.km by linking the objects files from build artifacts located at $1 (like /home/appuser/node in a "blank")
 # and put the result into location at $2
 
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 
 if [[ $# -ne 0 ]] ; then NODE=$1 ; else exit 1 ; fi
 OUT=${2:-$NODE}

--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -8,9 +8,8 @@
 # $2 is where to put the results of the link
 # $3 is optional space separated list of modules to link in (e.g. "numpy markupsafe")
 #
-# set -x
-
-if [ -v BASH_TRACING ] ; then set -x ; fi
+set -e
+[ "$TRACE" ] && set -x
 
 cd $(dirname ${BASH_SOURCE[0]})
 KM_TOP=$(git rev-parse --show-cdup)

--- a/payloads/python/link-static-musl.sh
+++ b/payloads/python/link-static-musl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -v BASH_TRACING ] ; then set -x ; fi
+[ "$TRACE" ] && set -x
 
 MUSL_TOP=../$(git rev-parse --show-cdup)runtime/musl
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -69,11 +69,10 @@ case $test_type in
 esac
 
 # we will kill any test if takes longer
-timeout=150
+timeout=150s
 
 # this is how we invoke KM - with a timeout and reporting run time
 function km_with_timeout () {
-
    # Treat all before '--' as KM arguments, and all after '--' as payload arguments
    # With no '--', finding $ext (.km, .kmd. .so) has the same effect.
    # Note that we whitespace split KM args always, so no spaces inside of KM args are allowed
@@ -117,8 +116,9 @@ function gdb_with_timeout () {
 TERM=xterm
 
 bus_width() {
-   #  use KM to print out physical memory width on the test machine
-   echo $(${KM} -V exit_value_test.km 2>& 1 | awk '/physical memory width/ {print $6;}')
+   bw=$(${KM_BIN} -V exit_value_test.km |& awk '/physical memory width/ {print $9;}')
+   if [ -z "$bw" ] ; then bw=39 ; fi # default is enough memory, if the above failed
+   echo $bw
 }
 
 # Setup and teardown for each test.
@@ -141,12 +141,12 @@ EOF
 }
 
 
-# Helper for generic skipping
-# rely on lists
+# Helper for generic tests skipping based on test description.
+# Relies on lists:
 #  `not_needed_{generic,static,dynamic,shared}` and
 #  `todo_{generic,static,dynamic,shared}`
-# to be defined in the actual test and define list of test to skip.
-# See km*.bats
+# These need to be defined in the actual test and contain lists of tests to skip.
+# See km*.bats for example.
 
 # Checks if word "$1" is in list "$2"
 # There HAS to be a space before and after each word in the list, so there is always leading and trailing space in the lists


### PR DESCRIPTION
A small simplification of how to turn on tracing in misc. bash scritps and CI
`TRACE=1 <bash-script>`
or, for all scripts in CI,  just un-comment 'trace: true' in azure-pipelines.yml

tested: manually

Note: bus_width location was changed when the output format changed, so fixing it here