### PR TITLE
make valgrind run cleanly

### DIFF
--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -416,7 +416,7 @@ void km_machine_init(km_machine_init_params_t* params)
            sizeof(kvm_run_t));
    }
    if ((machine.cpuid =
-            malloc(sizeof(kvm_cpuid2_t) + CPUID_ENTRIES * sizeof(struct kvm_cpuid_entry2))) == NULL) {
+            calloc(1, sizeof(kvm_cpuid2_t) + CPUID_ENTRIES * sizeof(struct kvm_cpuid_entry2))) == NULL) {
       err(1, "KVM: no memory for CPUID");
    }
    machine.cpuid->nent = CPUID_ENTRIES;

--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -64,7 +64,7 @@ km_gva_t km_init_main(km_vcpu_t* vcpu, int argc, char* const argv[], int envc, c
 
    // Set environ - copy strings and prep the envp array
    char* km_envp[envc + 1];
-   memcpy(km_envp, envp, sizeof(km_envp));
+   memcpy(km_envp, envp, sizeof(km_envp) - sizeof(char*));
    for (int i = 0; i < envc - 1; i++) {
       int len = strnlen(km_envp[i], PATH_MAX) + 1;
 


### PR DESCRIPTION
Note this two fixes address valgrind complains.
Valgrind will still report a lot of issues if km is build static,
as standard suppression for libc is based on .so names.

To run valgrind manually:

- build dynamic km, by changing custom.mk and rebuilding
- run `valgrind --sim-hints=lax-ioctls --trace-children=yes ../build/km/km a_test.km`
- in case of errors, rerun with extra `--read-var-info=yes --track-origins=yes` flags to get better info. This runs slower

