### PR TITLE
hid trace print for EFAULT

### DIFF
--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -569,7 +569,20 @@ static void* km_faulting_address(km_vcpu_t* vcpu)
          return (void*)*regp;
       }
    }
-   warnx("EFAULT - Unknown faulting address. RIP=0x%llx", vcpu->regs.rip);
+   /*
+    * If we did not handle the instruction at the failure RIP, we don't know what exactly it was
+    * addressing and so we do not know the exact faulting address. So we cannot properly fill in
+    * sa_addr, and payload handlers will get 0 in sa_addr... For now we saw this in JIT only and
+    * it's handled above.
+    * TODO for the rest of instructions (https://github.com/kontainapp/km/issues/436)
+    */
+   if (km_trace_enabled() != 0) {   // if ANY -V flag is enabled
+      km_trace(errno,
+               __FUNCTION__,
+               __LINE__,
+               "EFAULT - Unknown faulting address. RIP=0x%llx",
+               vcpu->regs.rip);
+   }
    return NULL;
 }
 

--- a/tests/mmap_tester.c
+++ b/tests/mmap_tester.c
@@ -112,7 +112,7 @@ int mmap_test(mmap_test_t* tests)
                          out_sz(new_size));
                }
                if (old_size < new_size) {   // WE ASSUME PROT_READ for the parent map !
-                  printf("VALUE %d at %p\n", *(int*)(new_addr + old_size), new_addr);
+                  printf("%s: VALUE %d at %p\n", __FUNCTION__, *(int*)(new_addr + old_size), new_addr);
                   ASSERT_EQm("new range in remap should be zeroed", 0, *(int*)(new_addr + old_size));
                }
                memset(new_addr, '2', new_size);   // just core dumps if something is wrong


### PR DESCRIPTION
tested manually, 

```
[msterin@msterin-p330 tests]$ ../build/km/km -Vx ./mmap_test 
...
02:47:57.274680 km_faulting_address    582 vcpu-0 EFAULT - Unknown faulting address. RIP=0x209f10
mmap_test: VALUE 0 at 0x7ffffeefe000
02:47:57.279717 km_faulting_address    582 vcpu-0 EFAULT - Unknown faulting address. RIP=0x209f10
...
Total: 6 tests (5065168 ticks, 5.065 sec), 4253 assertions
Pass: 6, fail: 0, skip: 0.
```