### PR TITLE
Fix gdb default port

### DIFF
--- a/km/km_gdb.h
+++ b/km/km_gdb.h
@@ -22,6 +22,8 @@
 #include "km.h"
 #include "km_signal.h"
 
+#define GDB_DEFAULT_PORT 2159   // per /etc/services, this is gdbremote default
+
 /* GDB breakpoint/watchpoint types */
 typedef enum {
    /*

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -155,15 +155,8 @@ int km_gdb_setup_listen(void)
       warn("setsockopt(SO_REUSEADDR) failed");
    }
 
-   if (gdbstub.port == 0) {  // use the gdb default port from /etc/services if no override supplied
-      struct servent *sep;
-
-      if ((sep = getservbyname("gdbremote", "tcp")) == NULL) {
-         warn("getservbyname failed");
-         close(listen_socket_fd);
-         return -1;
-      }
-      gdbstub.port = ntohs(sep->s_port);
+   if (gdbstub.port == 0) {
+      gdbstub.port = GDB_DEFAULT_PORT;
    }
 
    server_addr.sin_family = AF_INET;

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -27,8 +27,6 @@
 #include "km_mem.h"
 #include "km_signal.h"
 
-#define GDB_DEFAULT_PORT 2159   // per /etc/services, this is gdbremote default
-
 km_info_trace_t km_info_trace;
 
 extern int vcpu_dump;


### PR DESCRIPTION
Use the default port defined. Remove the dependency to `getservbyname`.