### PR TITLE
Added dummy runenv-image to tests [TRIVIAL]

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -177,7 +177,3 @@ buildenv-local-fedora:  ${KM_OPT_RT} ## make local build environment for KM
 .PHONY: all clean test help gdb coverage covclean
 
 include ${TOP}/make/images.mk
-
-# No runenv for tests.
-runenv-image validate-runenv-image push-runenv-image pull-runenv-image distro:
-	@echo $(notdir $(CURDIR)): nothing to do for target '$@'

--- a/tests/runenv.dockerfile
+++ b/tests/runenv.dockerfile
@@ -1,0 +1,7 @@
+# Dummy Dockerfile for tests. We do not really build runenv-image here, 
+# but upper level Makefiles do scan this dir and for consistency, let's create dummy 
+# runenv-images 
+
+FROM scratch
+
+LABEL COMMENT "Dummy Image, just for making build target consistent"


### PR DESCRIPTION
No impact on actual functionality, but
(1) heals warnings in ./tests about overwriting runenv* targets
e.g. 
```
Makefile:183: warning: overriding recipe for target 'runenv-image'
/home/paulp/ws/ws1/km/make/images.mk:163: warning: ignoring old recipe for target 'runenv-image'
```
(2) builds dummy runenv-image for tests, so top level build works consistently