### PR TITLE
fix compile warning in __unmapself()

### DIFF
--- a/runtime/unmapself_km.c
+++ b/runtime/unmapself_km.c
@@ -6,7 +6,9 @@ _Noreturn void __unmapself(void* base, size_t size)
 {
    km_hc_args_t args = {0};
 
-   args.arg1 = base;
+   args.arg1 = (uint64_t)base;
    args.arg2 = size;
-   km_hcall(HC_unmapself, &args);
+   while (1) {
+      km_hcall(HC_unmapself, &args);
+   }
 }


### PR DESCRIPTION
no function change, just compile warning