### PR TITLE
fixes to make coverage and make in tests

### DIFF
--- a/make/locations.mk
+++ b/make/locations.mk
@@ -14,7 +14,7 @@
 default: all
 
 ifeq (${TOP},)
-  $(error "TOP needs to be set before including this mk file ") 
+  $(error "TOP needs to be set before including this mk file ")
 endif
 
 # this is the path from the TOP to current dir. Note this has a trailing /
@@ -87,11 +87,8 @@ IMAGE_VERSION ?= latest
 BUILDENV_IMAGE_VERSION ?= ${IMAGE_VERSION}
 
 
-# Code coverage support. If enabled, build with code coverage in dedicate dir
+# Build with code coverage if BLDTYPE set to this.
 COV_BLDTYPE := coverage
-
-# location for html coverage report
-COVERAGE_REPORT  = $(KM_BLDDIR)/coverage.html
 
 # Generic support - applies for all flavors (SUBDIR, EXEC, LIB, whatever)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,10 +7,11 @@
 #   such source code. Disclosure of this source code or any related proprietary
 #   information is strictly prohibited without the express written permission of
 #   Kontain Inc.
-SHELL=/bin/bash
-TOP := $(shell git rev-parse --show-toplevel)
 
+TOP := $(shell git rev-parse --show-toplevel)
 COMPONENT := km
+include ${TOP}/make/images.mk
+
 # this is how we run tests in containers:
 CONTAINER_TEST_CMD :=  run_bats_tests.sh --km=/tests/km
 
@@ -130,8 +131,8 @@ covclean: ## Clean up code coverage build artifacts
 coverage: all  ## Build with code coverage, then run tests and generate reports
 	@$(MAKE) BLDTYPE=$(COV_BLDTYPE) MAKEFLAGS="$(MAKEFLAGS)" .coverage
 
-ifeq (${BLDTYPE},$(COV_BLDTYPE))
-# we need this nesting to pass COV_BLDTYPE and set env. properly
+ifeq (${BLDTYPE},${COV_BLDTYPE})
+# we need this nesting (.cov* targets) to pass BLDTYPE and set env.
 .PHONY: .coverage .cov_init .cov_clean
 .cov_clean:
 	rm -rf ${BLDDIR}
@@ -176,4 +177,3 @@ buildenv-local-fedora:  ${KM_OPT_RT} ## make local build environment for KM
 
 .PHONY: all clean test help gdb coverage covclean
 
-include ${TOP}/make/images.mk


### PR DESCRIPTION
`make test` was building coverage instead of regular test; also there were multiple. bugs in
tests dir `test` target - all because `images.mk` as at the bottom , not top of Makefile, thus mutliple `ifeq` section of tests/Makefile were misinterpreted. 
It seems we have pretty much all other Makefiles working fine whether `include *.mk` is at the top or bottom, but tests/Makefile is an exception due to ifdef sections dedicated to coverage

CI missed it because it calls run bats script directly for tests