### PR TITLE
Fix the demo with runenv images

### DIFF
--- a/docs/image-targets.md
+++ b/docs/image-targets.md
@@ -89,6 +89,8 @@ Each payload also supports the same targets supported for KM, but uses payload-s
 * `make push-testenv-image` - re-tags and pushes test image to registry, mainly for CI
 * `make runenv-image` - builds bare minimum image to be released.
 * `make push-runenv-image` - retag and pushes runenv image to registry.
+* `make runenv-demo-image` - builds an application demo using the runenv-images. Used for python and node.
+* `make push-runenv-demo-image` - retag and pushes runenv demo image to registry.
 
 ## CI/CD
 

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -61,9 +61,14 @@ BUILDENV_IMG  ?= kontain/buildenv-${COMPONENT}-${DTYPE}
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
-DOCKER_BUILD := docker build \
+DOCKER_BUILD_LABEL := \
+	--label "Vendor=Kontain.app" \
+	--label "Version=0.1" \
+	--label "Description=${PAYLOAD_NAME} in Kontain" \
 	--label "KONTAIN:BRANCH=$(SRC_BRANCH)" \
 	--label "KONTAIN:SHA=$(SRC_SHA)"
+
+DOCKER_BUILD := docker build ${DOCKER_BUILD_LABEL}
 
 # Use DOCKER_RUN_CLEANUP="" if container is needed after a run
 DOCKER_RUN_CLEANUP ?= --rm

--- a/payloads/README.md
+++ b/payloads/README.md
@@ -9,10 +9,10 @@ We also keep here the `./k8s` dir with the code to customize payload deployments
   * `make build` also pulls only onces, but configures and builds payloads on every run
 * Package and publish:
   * Payloads are distributed as Docker images
-  * `make distro` creates Docker images (all images if run from the top, or specific image if run in a specifif dir)
+  * `make runenv-image` creates Docker images (all images if run from the top, or specific image if run in a specifif dir)
     * *Prerequisites*
       * Docker needs to be install and configured
-    * Doing `make distro` from top level will build payload Docker images.
+    * Doing `make runenv-image` from top level will build payload Docker images.
 * `make publish` will push them to container registry. You need to be logged in the proper registry (Azure ACR, dockerhub, etc.. - see below)
   * $(TOP)/make/`locations.mk` defines the CLOUD variable as `azure`, so by default, it will try to push to Azure Container Registry.
   * Registry name is defined in `./k8s/azure/kustomization.yml`.

--- a/payloads/demo-dweb/dweb-deployment.yml
+++ b/payloads/demo-dweb/dweb-deployment.yml
@@ -29,5 +29,12 @@ spec:
               devices.kubevirt.io/kvm: "1"
               cpu: 2
               memory: "500Mi"
+        args: [ "8080"]
+        volumeMounts:
+            - name: kontain-monitor
+              mountPath: /opt/kontain
+      volumes:
+        - name: kontain-monitor
+          hostPath:
+            path: /opt/kontain
 
-        args: [ "dweb.km", "8080"]

--- a/payloads/k8s/azure/dweb/kustomization.yaml
+++ b/payloads/k8s/azure/dweb/kustomization.yaml
@@ -12,6 +12,6 @@ nameSuffix: -azure-demo
 # see https://kubectl.docs.kubernetes.io/pages/app_management/container_images.html
 images:
   - name: "dweb-km"
-    newName: kontainkubecr.azurecr.io/runenv-dweb
+    newName: docker.io/kontainapp/runenv-dweb
     newTag: latest
 

--- a/payloads/k8s/azure/python/kustomization.yaml
+++ b/payloads/k8s/azure/python/kustomization.yaml
@@ -14,6 +14,6 @@ nameSuffix: -azure-demo
 # for now, just assume it's latest
 images:
   - name: "python-km"
-    newName: kontainkubecr.azurecr.io/python-km
+    newName: docker.io/kontainapp/runenv-python-demo
     newTag: latest
 

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -31,7 +31,9 @@ PAYLOAD_NAME := Python3.7
 
 # a list to be passed to tar to be packed into container image by 'make runenv-image'.
 PAYLOAD_FILES := --exclude='*/test/*' --exclude='*/__pycache__/*' --exclude '*.exe' --exclude '*.whl' \
-	cpython/Lib cpython/Modules/Setup
+	cpython/Lib \
+	cpython/Modules/Setup \
+	cpython/build/lib.linux-x86_64-3.7
 
 # List of artifacts necessary to run tests. See buildenv-fedora.dockerfile
 PYTHON_DISTRO_FILES := $(addprefix cpython/, Lib Modules build pybuilddir.txt dlstatic_km.mk)
@@ -128,17 +130,17 @@ test test-all: ${PAYLOAD_KM} ${TEST_KM}
 
 test-all-withdocker: test-withdocker # alias for test-withdocker
 
-# Set info for runenv-image build
-RUNENV_VALIDATE_SCRIPT := $(abspath scripts/hello_again.py)
-export define runenv_prep
-	cp ${PAYLOAD_KM} ${RUNENV_PATH}
-	tar -cf - ${PAYLOAD_FILES} | tar -C $(RUNENV_PATH) -xf -
-endef
-
 clobber: ## Clobber cpython build by removing cpython dir
 	rm -rf cpython
 
 clobber-modules:
 	cd cpython; git clean -xdff Lib Modules
+
+# Set info for runenv-image build
+RUNENV_VALIDATE_SCRIPT := $(abspath scripts/hello_again.py)
+export define runenv_prep
+	tar -cf - ${PAYLOAD_FILES} | tar -C $(RUNENV_PATH) -xf -
+	cp ${PAYLOAD_KM} ${RUNENV_PATH}
+endef
 
 include ${TOP}/make/images.mk

--- a/payloads/python/README.md
+++ b/payloads/python/README.md
@@ -18,7 +18,7 @@ After it is done, you can pass `cpython/python.km` to KM as a payload, e.g. `../
 
 ## Building distro package and publishing it
 
-`make distro` and `make publish` will build Docker image and publish it to Azure ACR. We expect that KM is already packaged as a container, and you logged in to ACR 9for publish. So generally, it's better to do `make distro` from top level - this will build KM image as well (or you can `make -C ../../km distro` to get KM image built)
+`make runenv-image` and `make push-runenv-image` will build Docker image and publish it to Azure ACR. 
 
 ## Known issues
 

--- a/payloads/python/pykm-deployment.yml
+++ b/payloads/python/pykm-deployment.yml
@@ -29,5 +29,11 @@ spec:
               devices.kubevirt.io/kvm: "1"
               cpu: 2
               memory: "500Mi"
-
-        args: [ "/cpython/python.km", "-u", "../scripts/micro_srv.py"]
+        args: [ "/scripts/micro_srv.py", "8080"]
+        volumeMounts:
+            - name: kontain-monitor
+              mountPath: /opt/kontain
+      volumes:
+        - name: kontain-monitor
+          hostPath:
+            path: /opt/kontain

--- a/payloads/python/runenv-demo.dockerfile
+++ b/payloads/python/runenv-demo.dockerfile
@@ -1,0 +1,3 @@
+FROM kontain/runenv-python
+
+COPY scripts /scripts

--- a/payloads/python/runenv.dockerfile
+++ b/payloads/python/runenv.dockerfile
@@ -1,6 +1,6 @@
 FROM scratch
 
-ENV PYTHONPATH=/cpython/Lib 
+ENV PYTHONPATH=/cpython/Lib:/cpython/build/lib.linux-x86_64-3.7 
 ENV PYTHONHOME=foo:bar
 
 COPY . /

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,6 +10,8 @@
 
 TOP := $(shell git rev-parse --show-toplevel)
 COMPONENT := km
+
+NO_RUNENV = true
 include ${TOP}/make/images.mk
 
 # this is how we run tests in containers:
@@ -176,4 +178,3 @@ buildenv-local-fedora:  ${KM_OPT_RT} ## make local build environment for KM
 	docker rm tmp_env
 
 .PHONY: all clean test help gdb coverage covclean
-

--- a/tests/runenv.dockerfile
+++ b/tests/runenv.dockerfile
@@ -1,7 +1,0 @@
-# Dummy Dockerfile for tests. We do not really build runenv-image here, 
-# but upper level Makefiles do scan this dir and for consistency, let's create dummy 
-# runenv-images 
-
-FROM scratch
-
-LABEL COMMENT "Dummy Image, just for making build target consistent"


### PR DESCRIPTION
* Fix demo under docker and k8s using the new runenv images.
* Fix missing libs for runenv-image python
* Created a runenv-demo-image target.
    * We want to seperate the demo with scripts and runenv-image that's bare minimum. It also serves as an example of how to consume runenv-image.
* Created NO_RUNENV variable. For components that doesn't have a concept of runenv, such as km and tests, this variable will remove the runenv related make targets.

Tested with demo-script.md. All steps works. Fix #480

With this change, km payload can be run on k8s the way we designed to be. runenv image will only carry the payload. KM will be installed on the host and be mounted in during runtime. custom yaml is still required, but the mechanism are all here. 