### PR TITLE
small improvement to error results readability in mmap tests

### DIFF
--- a/tests/mmap_test.h
+++ b/tests/mmap_test.h
@@ -140,5 +140,5 @@ static int get_maps(int verbose)
 
 sigjmp_buf jbuf;
 int fail;
-int mmap_test(mmap_test_t* tests);
+enum greatest_test_res mmap_test(mmap_test_t* tests);
 void sig_handler(int signal);


### PR DESCRIPTION
When the test fails in bats, it's very hard to find errors since the FAIL messages intermingled with
mmap tracing. This fix simple adds `ERROR ***`.

The result looks along these lines (still not perfect but slightly easier to find stuff)
```
busy 0x7fffffdfe000 size 0x00002000 (      8192) distance 0x0000 (  0), flags 0x22 prot 0x03 km_flags 0x01 fn 0
   * Swiss cheese-munmap3: last_addr 0x7fffd03fe000, offset 0x12c00000 (300mb) size 0xc800000 (200mb)
   maps: total 2 free 0 busy 2
   busy 0x7fffffbfe000 size 0x00200000FAIL mmap_test_36:
   ***** ERROR Mmaped memory should be zeroed (mmap_tester.c:67) (1069439 ticks, 1.069 sec)
    (       2mb) distance 0x0000 (  0), flags 0x22 prot 0x03 km_flags 0x00 fn 0
   busy 0x7fffffdfe000 size 0x00002000 (      8192) distance 0x0000 (  0), flags 0x22 prot 0x03 km_flags 0x01 fn 0
   * simple map to set addr for test: last_addr 0x7fffd03fe000, offset 0x0 (0) size 0x100000 (1mb)
   return: 0x7fffffafe000 (131071gb + 1018mb)
```