### PR TITLE
optimize zeroing out mmap regions 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,7 @@
             "-g",
             "tests/${input:test_payload}.km"
          ],
-         "stopAtEntry": false,
+         "stopAtEntry": true,
          "cwd": "${workspaceFolder}",
          "environment": [],
          "externalConsole": false,

--- a/km/km.h
+++ b/km/km.h
@@ -21,10 +21,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/eventfd.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/types.h>
 #include <linux/kvm.h>
-#include <sys/ioctl.h>
 
 #include "bsd_queue.h"
 #include "km_elf.h"
@@ -203,6 +203,7 @@ typedef struct km_mmap_list km_mmap_list_t;
 typedef union {
    struct {
       uint32_t km_mmap_monitor : 1;   // 1 if area is allocated by monitor
+      uint32_t km_mmap_clean : 1;     // doesn't need zeroing when exposed to payload
       uint32_t km_unused : 30;
    };
    uint32_t data32;
@@ -233,10 +234,12 @@ typedef struct km_mmap_cb {   // control block
 static const int CPUID_ENTRIES = 100;   // A little padding, kernel says 80
 #define KVM_MAX_VCPUS 288
 
-#define KM_MEM_SLOTS 42   // We use 36 on 512GB machine, 42 on 4TB, out of 509 KVM_USER_MEM_SLOTS
-                          // slot 0 is used for pages tables and some other things
-                          // slot 41 is used to map the vdso and vvar pages into the payload address
-                          //  space
+/*
+ * We use 36 on 512GB machine, 42 on 4TB, out of 509 KVM_USER_MEM_SLOTS slot 0 is used for pages
+ * tables and some other things slot 41 is used to map the vdso and vvar pages into the payload
+ * address space
+ */
+#define KM_MEM_SLOTS 42
 
 typedef struct km_machine {
    int kvm_fd;                                // /dev/kvm file descriptor

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -219,7 +219,7 @@ todo_so="hc_check mem_slots mem_mmap gdb_basic gdb_signal gdb_exception gdb_serv
    # make sure there is a filename somwewhere in the maps
    run km_with_timeout mmap_test$ext -v -t mmap_file_test_ex # KM test
    assert_success
-   assert_line --regexp 'flags 0x02 prot 0x01 km_flags 0x00 fn 0x[^0]'
+   assert_line --regexp 'flags 0x02 prot 0x01 km_flags 0x02 fn 0x[^0]'
 }
 
 @test "mmap_1($test_type): mmap then smaller mprotect (mmap_1_test$ext)" {


### PR DESCRIPTION
keep track of mmap_reg clean/dirty state and only zero out dirty ones when they exposed to the workload.

Free list mmap_reg are always marked as dirty. When the are used for mmap/mremap/mprotect and such,
keep track when they are about to be presented to payload with protection not PROT_NONE,
i.e. content becomes visible, madvise(DONTNEED) then.

No extra tests, just regular battery, also node, python, and some Java.

Timing wise, Java Hello, World sped up 2 - 3 times.