### PR TITLE
Nightly CI runs.

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -1,23 +1,36 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
+name: ci-nightly-$(BuildID) $(Date:yyyyMMdd)$(Rev:.r)
+
+# Must explicitly opt out of pr trigger.
+pr: none
 
 schedules:
-- cron: "0 0 * * *"
-  displayName: Daily midnight build
+- cron: "0 7 * * *"
+  displayName: Daily build midnight pacific time (UTC + 7)
   branches:
     include:
     - master
 
+variables:
+  VM_IMAGE: "ubuntu-18.04"
+  CLUSTER_NAME: "aks-kontain-ci-nightly-$(Build.BuildId)"
+  # Choose a vm size to avoid the vcpu quota on azure.
+  VM_SIZE: "Standard_D2_v3"
+  # TRACE: true
+
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: $(VM_IMAGE)
 
 steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
+- template: templates/setup.yaml
 
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+- bash: cloud/azure/aks_ci_create.sh $(CLUSTER_NAME) $(SP_appId) $(SP_password)
+  displayName: Create k8s Cluster
+
+- bash: cloud/azure/aks_ci_destroy.sh $(CLUSTER_NAME)
+  displayName: Tear down k8s Cluster
+
+- bash: |
+    rm -f ~/.kube/config
+    az logout
+  condition: always()
+  displayName: Cleanup and logout

--- a/cloud/azure/aks_ci_create.sh
+++ b/cloud/azure/aks_ci_create.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright © 2019 Kontain Inc. All rights reserved.
+#
+# Kontain Inc CONFIDENTIAL
+#
+#  This file includes unpublished proprietary source code of Kontain Inc. The
+#  copyright notice above does not evidence any actual or intended publication of
+#  such source code. Disclosure of this source code or any related proprietary
+#  information is strictly prohibited without the express written permission of
+#  Kontain Inc.
+#
+# Small script to create aks clusters.
+
+readonly PROGNAME=$(basename $0)
+readonly CUR_DIR=$(readlink -m $(dirname $0))
+readonly CLUSTER_NAME=$1
+readonly SP_APPID=$2
+readonly SP_PASSWORD=$3
+
+function usage() {
+    cat <<- EOF
+usage: $PROGNAME <CLUSTER_NAME> <SP_APPID> <SP_PASSWORD>
+
+Program is a helper to launch new k8s cluster on aks.
+
+EOF
+}
+
+function load_default_configs() {
+    source ${CUR_DIR}/cloud_config.mk
+    if [[ -z ${VM_SIZE} ]]; then
+        readonly VM_SIZE=${K8S_NODE_INSTANCE_SIZE}
+    fi
+}
+
+function create() {
+    az aks create \
+        --resource-group "${CLOUD_RESOURCE_GROUP}" \
+        --name "$CLUSTER_NAME"  \
+        --node-vm-size "$VM_SIZE" \
+        --node-count 1 \
+        --service-principal "${SP_APPID}" \
+        --client-secret "${SP_PASSWORD}" \
+        --generate-ssh-keys \
+        --output ${OUT_TYPE}
+	az aks get-credentials --resource-group "${CLOUD_RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --overwrite-existing
+}
+
+function main() {
+    if [[ -z $CLUSTER_NAME ]] | [[ -z $SP_APPID ]] | [[ -z $SP_PASSWORD ]]; then
+        usage
+        exit 1
+    fi
+
+    [ "$TRACE" ] && set -x
+
+    load_default_configs
+    create
+}
+
+main

--- a/cloud/azure/aks_ci_destroy.sh
+++ b/cloud/azure/aks_ci_destroy.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright © 2019 Kontain Inc. All rights reserved.
+#
+# Kontain Inc CONFIDENTIAL
+#
+#  This file includes unpublished proprietary source code of Kontain Inc. The
+#  copyright notice above does not evidence any actual or intended publication of
+#  such source code. Disclosure of this source code or any related proprietary
+#  information is strictly prohibited without the express written permission of
+#  Kontain Inc.
+#
+# Small script to destroy aks clusters.
+
+readonly PROGNAME=$(basename $0)
+readonly CUR_DIR=$(readlink -m $(dirname $0))
+readonly CLUSTER_NAME=$1
+
+function usage() {
+    cat <<- EOF
+usage: $PROGNAME <CLUSTER_NAME> 
+
+Program is a helper to launch new k8s cluster on aks.
+
+EOF
+}
+
+function load_default_configs() {
+    source ${CUR_DIR}/cloud_config.mk
+}
+
+function destroy() {
+    az aks delete -y --resource-group "${CLOUD_RESOURCE_GROUP}"  --name "${CLUSTER_NAME}" --output ${OUT_TYPE}
+}
+
+function main() {
+    if [[ -z $CLUSTER_NAME ]]; then
+        usage
+        exit 1
+    fi
+
+    [ "$TRACE" ] && set -x
+
+    load_default_configs
+    destroy
+}
+
+main

--- a/docs/azure_pipeline.md
+++ b/docs/azure_pipeline.md
@@ -123,3 +123,12 @@ pod "msterin-test-ci-695" deleted
 ```
 
 Note: a good set of recipes for kubectl interacting with a pod is, for example, [here](https://kubernetes.io/blog/2015/10/some-things-you-didnt-know-about-kubectl_28/)
+
+### Secrets and Pipeline variables
+
+  We use service principal extensively in the azure pipeline. To pass the
+crendentials of existing service principals, we use the variables in azure
+pipeline. For example, you will see variables such as `SP_appId`,
+`SP_password`, `SP_tenant`, `SP_displayName`. These are set in the pipeline
+UI by design. For reference, follow this:
+https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables

--- a/templates/setup.yaml
+++ b/templates/setup.yaml
@@ -1,0 +1,22 @@
+steps:
+  - checkout: self
+    submodules: true
+
+  - bash: |
+      echo ====Environment info===
+      echo "SHA: $(git rev-parse HEAD)"
+      echo "=== Last 10 commits:"
+      git log -n 10 --graph --pretty=format:'%h% %d %s %cr %ce'
+      echo "=== VM/OS:"
+      cat /proc/version
+      echo "=== Docker version:"
+      docker version
+      echo ==== Environment Variables
+      env
+      echo ==== CPU Info
+      lscpu
+    displayName: Print build environment info
+
+  - bash: make -C cloud/azure login-cli
+      SP_APPID=$(SP_appId) SP_PASSWORD=$(SP_password) SP_TENANT=$(SP_tenant) SP_DISPLAYNAME=$(SP_displayName)
+    displayName: Login to Azure, container registry and Kubernetes


### PR DESCRIPTION
This PR only creates and destroy the k8s clusters for the nightly run.

Tested manually with the pipeline.

The pipeline already has a SP configured and dedicated to it. Therefore there is no need to create yet another SP for the cluster to use. 

I try to leave as much of the existing code in place as possible. This is not to disturb the existing CI with a new change. Once the nightly pipeline is ready, we can start to replace the CI bits and merge some of the duplicated code.