### PR TITLE
Return km to being built statically.

### DIFF
--- a/km/Makefile
+++ b/km/Makefile
@@ -20,7 +20,7 @@ VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info
 INCLUDES := ${TOP}/include
 LLIBS := elf z
 COVERAGE := yes
-LDOPTS := -Wl,--script=km_guest_ldcmd
+LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd
 
 include ${TOP}/make/actions.mk
 

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -70,7 +70,7 @@ ifneq (${EXEC},)
 
 all: ${BLDEXEC}
 ${BLDEXEC}: $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) $(LDOPTS) $(addprefix -l ,${LLIBS}) -o $@
+	$(CC) $(CFLAGS) $(OBJS) $(LDOPTS) $(LOCAL_LDOPTS) $(addprefix -l ,${LLIBS}) -o $@
 
 # if VERSION_SRC is defined, force-rebuild these sources on 'git info' changes
 ifneq (${VERSION_SRC},)


### PR DESCRIPTION
The change that moved payload trampoline functions into km also overwrote the -static option supplied when km is linked.
This change returns km to being statically linked.

Tested with bats test and ran ldd km.
```
[paulp@localhost km]$ ldd build/km/km
	not a dynamic executable
[paulp@localhost km]$ 
```
Fixes #515