### PR TITLE
enable node long running

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -17,6 +17,7 @@ variables:
   VM_SIZE: "Standard_D4_v3" # choose a vm size to avoid the vcpu quota on azure
   BUILDENV_IMAGE_VERSION: latest # use this for all buildenv containers
   IMAGE_VERSION: ci-nightly-$(Build.BuildId) # use this for all other containers
+  K8S_TEST_ERR_NO_CLEANUP: true # OK to not clean up after error for nightly
   # TRACE: true
 
 pool:
@@ -34,7 +35,7 @@ steps:
     make -C cloud/k8s/kontaind install
   displayName: deploy and verify kontaind
 
-- template: templates/ci_normal.yaml
+- template: templates/ci_nightly.yaml
 
 - bash: cloud/azure/aks_ci_destroy.sh $(CLUSTER_NAME)
   displayName: Tear down k8s Cluster

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,21 +55,17 @@ steps:
 
   - template: templates/ci_normal.yaml
 
-  - bash: make -C payloads/python clean all runenv-image
-    displayName: Python.km build runenv
-    timeoutInMinutes: 2
-
   - bash: echo TODO push-runenv-image and test in kubernetes... see make validate-runenv-image
     displayName: Python.km runenv test (TODO)
     timeoutInMinutes: 2
 
-  - bash: make -C payloads/node clean all runenv-image
-    displayName: Node.km build runenv
+  - bash: echo TODO push-runenv-image and test in kubernetes... see make validate-runenv-image
+    displayName: Node.km runenv test (TODO)
     timeoutInMinutes: 2
 
-  - bash: make -C payloads/java clean pull-buildenv-image all runenv-image
-    displayName: Java.kmd build and Java 'runenv' build
-    timeoutInMinutes: 5
+  - bash: echo TODO push-runenv-image and test in kubernetes... see make validate-runenv-image
+    displayName: Java.kmd runenv test (TODO)
+    timeoutInMinutes: 2
 
   - bash: |
       [ "$TRACE" ] && set -x

--- a/cloud/k8s/tests/k8s-run-tests.sh
+++ b/cloud/k8s/tests/k8s-run-tests.sh
@@ -24,7 +24,7 @@ readonly RUNTIME_DIR=$(mktemp -d)
 readonly TEST_POD_TEMPLATE_NAME="test-pod-template.yaml"
 readonly POD_WAIT_TIMEOUT=${K8S_POD_WAIT_TIMEOUT:-2m}
 
-if [[ -n ${PIPELINE_WORKSPACE} ]]; then
+if [[ -z ${PIPELINE_WORKSPACE} ]]; then
     readonly GREEN=\\e[32m
     readonly NOCOLOR=\\e[0m
 fi
@@ -57,6 +57,7 @@ function manual_usage {
     echo -e "Run bash in your pod '$pod_name' using '${GREEN}kubectl exec $pod_name -it -- bash${NOCOLOR}'"
     echo -e "Run tests inside your pod using '${GREEN}${TEST_COMMAND}${NOCOLOR}'"
     echo -e "When you are done, do not forget to '${GREEN}kubectl delete pod $pod_name${NOCOLOR}'"
+    echo -e "Deployment spec is written to '${GREEN}${RUNTIME_DIR}${NOCOLOR}'"
 }
 
 function process_op {
@@ -128,7 +129,7 @@ function main {
         cleanup $pod_name $exit_code
     fi
 
-    kubectl exec -it ${pod_name} -- ${TEST_COMMAND}
+    kubectl exec -it ${pod_name} --request-timeout=0 -- bash -c "${TEST_COMMAND}"
     local exit_code=$?
 
     # For manual, we don't do any form of clean up. Users want to examine the

--- a/payloads/node/Makefile
+++ b/payloads/node/Makefile
@@ -79,10 +79,7 @@ test-all: test
 
 # Command to run tests in testenv-image container:
 CONTAINER_TEST_CMD := scripts/test-run.sh test ./km ${PAYLOAD_KM} ${TEST_KM}
-
-test-all-withdocker: ## a special helper to run more node.km tests. TODO - does it run script/test-run outside of docker ?
-	${DOCKER_RUN_TEST} ${TEST_IMG}:${IMAGE_VERSION} ${CONTAINER_TEST_CMD} && scripts/test-run.sh test-all ${NODETOP} ${BUILD}
-
+CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD} && scripts/test-run.sh test-all ${NODETOP} ${BUILD}
 
 # Use existing small dir for buildenv image builds (saves on sending data to docker svc)
 BUILDENV_PATH  := ./scripts

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -125,8 +125,6 @@ clean:
 test test-all: ${PAYLOAD_KM} ${TEST_KM}
 	scripts/test-run.sh ${KM_BIN} ${PAYLOAD_KM}
 
-test-all-withdocker: test-withdocker # alias for test-withdocker
-
 clobber: ## Clobber cpython build by removing cpython dir
 	rm -rf cpython
 

--- a/templates/ci_nightly.yaml
+++ b/templates/ci_nightly.yaml
@@ -1,0 +1,12 @@
+steps:
+  - bash: make -C tests test-all-withk8s
+    displayName: KM tests - run on Kubernetes
+    timeoutInMinutes: 15
+
+  - bash: make -C payloads/python test-all-withk8s
+    displayName: Python.km tests - run on Kubernetes
+    timeoutInMinutes: 15
+
+  - bash: make -C payloads/node test-all-withk8s
+    displayName: Node.km tests - run on Kubernetes
+    timeoutInMinutes: 30

--- a/templates/setup.yaml
+++ b/templates/setup.yaml
@@ -18,7 +18,7 @@ steps:
     displayName: Print build environment info
 
   - bash: |
-      curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+      curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
       sudo cp kustomize /usr/local/bin/kustomize
       which kustomize
     displayName: Install kustomize

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -168,8 +168,6 @@ endif # ifeq (${BLDTYPE},$(COV_BLDTYPE))
 
 test-all: test ## alias for test
 
-test-all-withdocker: test-withdocker ## alias for test-withdocker
-
 # install stuff for fedora per docker image info. Assume buildenv-image either built or pulled
 # TODO: maybe make it generic to scan folders
 buildenv-local-fedora:  ${KM_OPT_RT} ## make local build environment for KM


### PR DESCRIPTION
* Added a `test-all-withk8s` target.
* Refactor and consolidated all `test-all` targets. Centralized `test-all-withdocker` to image.mk. Use CONTAINER_TEST_CMD and CONTAINER_TEST_ALL_CMD to control the behavior.