### PR TITLE
TRIVIAL : do not print warning when not needed

### DIFF
--- a/km/km_mmap.c
+++ b/km/km_mmap.c
@@ -525,7 +525,7 @@ static km_gva_t km_guest_mmap_nolock(
 {
    int ret;
 
-   if ((flags & MAP_ANONYMOUS) == MAP_ANONYMOUS) {
+   if ((flags & MAP_ANONYMOUS) == MAP_ANONYMOUS && fd != -1) {
       km_infox(KM_TRACE_MMAP, "Ignoring fd due to MAP_ANONYMOUS");
       fd = -1;   // per mmap(3) fd can be ignored if MAP_ANONYMOUS is set
    }

--- a/tests/mmap_1_test.c
+++ b/tests/mmap_1_test.c
@@ -106,7 +106,8 @@ TEST mmap_fixed_basic()
    ASSERT_EQ(MAP_FAILED, area);
    ASSERT_EQ_FMT(EPERM, errno, "%d");
 
-   area = mmap(0, area_sz, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+   // fd=1 should be ignored with log message. The rest should work
+   area = mmap(0, area_sz, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, 1, 0);
    ASSERT_NOT_EQ(MAP_FAILED, area);
    ASSERT_MMAPS_CHANGE(1, initial_busy_count);
 
@@ -245,9 +246,9 @@ TEST mmap_fixed_incompat()
    // grabbing something too high, so it steps on Monitor reserved - KM only test
    if (KM_PAYLOAD() == 1) {
       errno = 0;
-get_maps(1);
+      get_maps(1);
       insert = mmap(area, area_sz + insert1_sz, rw, MAP_FIXED | flags, -1, 0);
-get_maps(1);
+      get_maps(1);
       ASSERT_EQ_FMT(MAP_FAILED, insert, "%p");
       ASSERT_EQ_FMT(EINVAL, errno, "%d");
    }


### PR DESCRIPTION
tested manually: 

before: 
```
$ ../build/km/km -Vmmap ./mmap_1_test  |& grep Ignoring | wc -l 
22
```

after: 

```
$ ../build/km/km -Vmmap ./mmap_1_test  |& grep Ignoring | wc -l 
1
```

