### PR TITLE
fix load_elf to work with native static and static pie execs

### DIFF
--- a/km/km_elf.h
+++ b/km/km_elf.h
@@ -27,14 +27,16 @@
  * in guest address space. We'll need to convert them to monitor (KM) addresses to acces.
  */
 typedef struct km_payload {
-   Elf64_Ehdr km_ehdr;                     // elf file header
-   Elf64_Phdr* km_phdr;                    // elf program headers
-   Elf64_Addr km_dlopen;                   // dlopen() address to find link_map chain
-   Elf64_Addr km_load_adjust;              // elf->guest vaddr adjustment
-   char* km_filename;                      // elf file name
-   Elf64_Addr km_interp_vaddr;             // interpreter name vaddr (if exist)
-   Elf64_Off km_interp_len;                // interpreter name length (if exist)
-   Elf64_Addr km_min_vaddr;                // minimum vaddr
+   Elf64_Ehdr km_ehdr;            // elf file header
+   Elf64_Phdr* km_phdr;           // elf program headers
+   Elf64_Addr km_dlopen;          // dlopen() address to find link_map chain
+   Elf64_Addr km_load_adjust;     // elf->guest vaddr adjustment
+   char* km_filename;             // elf file name
+   Elf64_Addr km_interp_vaddr;    // interpreter name vaddr (if exist)
+   Elf64_Off km_interp_len;       // interpreter name length (if exist)
+   Elf64_Addr km_dynamic_vaddr;   // dynamic section
+   Elf64_Off km_dynamic_len;      // and length (if exist)
+   Elf64_Addr km_min_vaddr;       // minimum vaddr
 } km_payload_t;
 
 typedef struct km_tls_module {

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -156,6 +156,10 @@ static Elf* km_open_elf_file(km_payload_t* payload, int* fd)
          payload->km_interp_vaddr = phdr->p_vaddr;
          payload->km_interp_len = phdr->p_filesz;
       }
+      if (phdr->p_type == PT_DYNAMIC) {
+         payload->km_dynamic_vaddr = phdr->p_vaddr;
+         payload->km_dynamic_len = phdr->p_filesz;
+      }
    }
    return e;
 }
@@ -242,7 +246,24 @@ uint64_t km_load_elf(const char* file)
       errx(2, "%s km_open_elf failed: %s", __FUNCTION__, km_dynlinker.km_filename);
    }
 
-   km_gva_t adjust = GUEST_MEM_START_VA - km_guest.km_min_vaddr;
+   km_gva_t adjust = 0;
+   /*
+    * Tell static vs dynamic executable.
+    *
+    * DYNAMIC section indicates dynamically linked executable or static PIE. The later also has
+    * PT_INTERPRETER.
+    *
+    * We load pure static (no DYNAMIC) at the addresses in ELF file, i.e. adjust == 0. For our own
+    * .km files they will load starting at GUEST_MEM_START_VA because its the way we build them.
+    * Others will go where they request, typical Linux exec would start at 4MB.
+    *
+    * We load DYNAMIC starting at GUEST_MEM_START_VA, adjust will tell how much shift there was. For
+    * loading PIE that doesn't matter, but we need to keep it for coredump and such. For dynamic
+    * linking adjust is passed to the dynamic linker so it know how to do relocations.
+    */
+   if (km_guest.km_dynamic_vaddr != 0 && km_guest.km_dynamic_len != 0) {
+      adjust = GUEST_MEM_START_VA - km_guest.km_min_vaddr;
+   }
    /*
     * Read symbol table and look for symbols of interest to KM
     */
@@ -264,7 +285,7 @@ uint64_t km_load_elf(const char* file)
    }
    km_guest.km_load_adjust = adjust;
 
-   // We need to verify the payload is a km executable, issue #512.
+   // TODO: need to verify the payload is a km executable, issue #512.
 
    return adjust;
 }


### PR DESCRIPTION
`load_elf` checks for DYNAMIC section. If it is there assume the code is position independent, i.e. dynamic or PIE, and loads it at 2MB (GUEST_MEM_START_VA). Also computes how much was the shift in `adjust` variable. If no DYNAMIC then `adjust` is `0` and the code loads as per ELF program headers.

To tell PIE from dynamic exec `load_elf` looks at PR_INTERPRETER. If it is there the dynamic linked is called, and `adjust` then is passed to it to do correct relocation. PIE is not relocated, but `adjust` is kept around for core dump and such.

Regular tests pass confirming no regression with our static and dynamic .km files.

Manually tested with PIE and static executables produced on Alpine.

Note that Fedora static or PIE executable does not work. They load correctly (confirmed by gdb on km) but then do a bunch of unsupported hypercalls. I guess glibc initialization sequence is more complex than musl.