### PR TITLE
[Trivial] Remove install kustomize step

### DIFF
--- a/templates/setup.yaml
+++ b/templates/setup.yaml
@@ -20,12 +20,6 @@ steps:
       lscpu
     displayName: Print build environment info
 
-  - bash: |
-      curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-      sudo cp kustomize /usr/local/bin/kustomize
-      which kustomize
-    displayName: Install kustomize
-
   - bash: make -C cloud/azure login-cli
       SP_APPID=$(SP_appId) SP_PASSWORD=$(SP_password) SP_TENANT=$(SP_tenant) SP_DISPLAYNAME=$(SP_displayName)
     displayName: Login to Azure, container registry and Kubernetes


### PR DESCRIPTION
No longer need this step. The demo still use kubectl apply -k. Fix #525 