### PR TITLE
Add openat hcall

### DIFF
--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -51,6 +51,9 @@ int km_fs_init(void);
 void km_fs_fini(void);
 // int open(char *pathname, int flags, mode_t mode)
 uint64_t km_fs_open(km_vcpu_t* vcpu, char* pathname, int flags, mode_t mode);
+// int openat(int dirfd, const char *pathname, int flags);
+// int openat(int dirfd, const char* pathname, int flags, mode_t mode);
+uint64_t km_fs_openat(km_vcpu_t* vcpu, int dirfd, char* pathname, int flags, mode_t mode);
 // int close(fd)
 uint64_t km_fs_close(km_vcpu_t* vcpu, int fd);
 // int shutdown(int sockfd, int how);

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -566,6 +566,19 @@ static km_hc_ret_t open_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
+static km_hc_ret_t openat_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   // int openat(int dirfd, const char *pathname, int flags);
+   // int openat(int dirfd, const char* pathname, int flags, mode_t mode);
+   void* pathname = km_gva_to_kma(arg->arg2);
+   if (pathname == NULL) {
+      arg->hc_ret = -EFAULT;
+      return HC_CONTINUE;
+   }
+   arg->hc_ret = km_fs_openat(vcpu, arg->arg1, pathname, arg->arg3, arg->arg4);
+   return HC_CONTINUE;
+}
+
 static km_hc_ret_t lseek_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
    // off_t lseek(int fd, off_t offset, int whence);
@@ -1347,6 +1360,7 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_readlink] = readlink_hcall;
    km_hcalls_table[SYS_getrandom] = getrandom_hcall;
    km_hcalls_table[SYS_open] = open_hcall;
+   km_hcalls_table[SYS_openat] = openat_hcall;
    km_hcalls_table[SYS_lseek] = lseek_hcall;
    km_hcalls_table[SYS_rename] = rename_hcall;
    km_hcalls_table[SYS_link] = symlink_hcall;

--- a/tests/filesys_test.c
+++ b/tests/filesys_test.c
@@ -142,7 +142,7 @@ TEST test_socketpair()
 }
 
 /*
- * Tests that lowest availble file descriptor is used for open
+ * Tests that lowest available file descriptor is used for open
  */
 TEST test_open_fd_fill()
 {
@@ -166,6 +166,36 @@ TEST test_open_fd_fill()
    ASSERT_EQ(0, rc);
    rc = close(fd3);
    ASSERT_EQ(0, rc);
+
+   PASS();
+}
+
+TEST test_openat()
+{
+   int fd;
+   struct stat st1, st2;
+
+   fd = openat(-1, "/", O_RDONLY);
+   ASSERT_NOT_EQ(-1, fd);
+   fstat(fd, &st1);
+   stat("/", &st2);
+   ASSERT_EQ(st1.st_ino, st2.st_ino);
+   close(fd);
+
+   fd = openat(AT_FDCWD, "Makefile", O_RDONLY);
+   ASSERT_NOT_EQ(-1, fd);
+   fstat(fd, &st1);
+   stat("Makefile", &st2);
+   ASSERT_EQ(st1.st_ino, st2.st_ino);
+   close(fd);
+
+   int fd1 = open("..", O_RDONLY);
+   fd = openat(fd1, "tests", O_RDONLY);
+   ASSERT_NOT_EQ(-1, fd);
+   fstat(fd, &st1);
+   stat("../tests", &st2);
+   ASSERT_EQ(st1.st_ino, st2.st_ino);
+   close(fd);
 
    PASS();
 }
@@ -412,6 +442,7 @@ int main(int argc, char** argv)
    RUN_TEST(test_stat);
    RUN_TEST(test_getdents);
    RUN_TEST(test_socketpair);
+   RUN_TEST(test_openat);
    RUN_TEST(test_open_fd_fill);
    RUN_TEST(test_dup_fd_fill);
    RUN_TEST(test_dup);


### PR DESCRIPTION
Attempts to run native go executable require `openat()`, not quite sure why, as it is static executable and all it does is print on stdout. However it seems good to have anyways.

Some tests added.