### PR TITLE
Fix id: cannot find name for user ID 1001

### DIFF
--- a/make/images.mk
+++ b/make/images.mk
@@ -215,13 +215,11 @@ test-all-withk8s: .check_vars
 
 # Manual version... helpful when debugging failed CI runs by starting new pod from CI testenv-image
 # Adds 'user-' prefix to names and puts container to sleep so we can exec into it
-test-withk8s-manual: USER_NAME := $(shell id -un)
 test-withk8s-manual: .check_vars ## same as test-withk8s, but allow for manual inspection afterwards
-	${K8S_RUNTEST} "manual" "${TEST_K8S_IMAGE}" "${USER_NAME}-${TEST_K8S_NAME}" "${CONTAINER_TEST_CMD}"
+	${K8S_RUNTEST} "manual" "${TEST_K8S_IMAGE}" "${USER}-${TEST_K8S_NAME}" "${CONTAINER_TEST_CMD}"
 
-test-all-withk8s-manual: USER_NAME := $(shell id -un)
 test-all-withk8s-manual: .check_vars ## same as test-withk8s, but allow for manual inspection afterwards
-	${K8S_RUNTEST} "manual" "${TEST_K8S_IMAGE}" "${USER_NAME}-${TEST_K8S_NAME}" "${CONTAINER_TEST_ALL_CMD}"
+	${K8S_RUNTEST} "manual" "${TEST_K8S_IMAGE}" "${USER}-${TEST_K8S_NAME}" "${CONTAINER_TEST_ALL_CMD}"
 
 
 ifeq (${NO_RUNENV}, false)


### PR DESCRIPTION
Inside the container, only uid is mapped, not the username. This is a known
issue with docker. For us, we invoke `make` inside the container, and some of
our make file includes calls `id -un` which prints the error. For now, removing
the offending variable will resolve the issue. However, this is only because we
can get away with not using the value.

Fix #556