### PR TITLE
reworked clone system call to work with system call emulation.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -348,6 +348,8 @@
          "type": "pickString",
          "options": [
             "sigaltstack_test",
+            "clone_test",
+            "socket_test",
             "pthread_cancel_test",
             "var_storage_test",
             "exit_value_test",

--- a/km/gdb/list.gdb
+++ b/km/gdb/list.gdb
@@ -39,8 +39,8 @@ if $argc == 0
    while $item != 0
       set $distance = $item->start - $last_end
       printf "%3d 0x%-12lx next 0x%-12lx start= 0x%lx size = 0x%05x (%08ld) prot 0x%x flags 0x%x fn %s km_fl 0x%x distance %d (%ld)\n", \
-               $count, $item, $item->link->tqe_next, $item->start/4096ul, $item->size/4096ul, \
-               $item->size, $item->protection, $item->flags, $item->filename, $item->km_flags.data32, $distance/4096ul, $distance
+               $count, $item, $item->link->tqe_next, $item->start/0x1000ul, $item->size/0x1000ul, $item->size, \
+               $item->protection, $item->flags, $item->filename, $item->km_flags.data32, $distance/0x1000ul, $distance
       set $count++
       set $last_end = $item->start + $item->size
       set $item=$item->link->tqe_next

--- a/km/km_guest_asmcode.s
+++ b/km/km_guest_asmcode.s
@@ -9,7 +9,7 @@
  * proprietary information is strictly prohibited without the express written
  * permission of Kontain Inc.
  *
- * Signal trampoline for KM guests. KM starts signal handling at the guest signal 
+ * Signal trampoline for KM guests. KM starts signal handling at the guest signal
  * guest signal handler itself with the stack setup for return to __km_sigreturn.
  * Most of this file is about describing the stack so it can be correctly unwound.
  * Since this code is now part of km and mapped into the guest address
@@ -33,7 +33,7 @@ __km_sigreturn:
      *   Second parameter is DWARF stack offset for the register. The
      *   layout conforms to the contents of kvm_regs_t.
      * This code must be kept in sync with signal code in KM to ensure that
-     * GDB can interpret stacks that include a signal from KM. 
+     * GDB can interpret stacks that include a signal from KM.
      */
     .set HCARG_SIZE, 56     # size of km_hc_args_t at top of stack
 
@@ -60,7 +60,7 @@ __km_sigreturn:
     mov $0xffff800f, %edx   # SYS_rt_sigreturn
     out %eax, %dx           # Enter KM
     .cfi_endproc
-__km_sigreturn_end:        # We'll need this to define the the DWARF 
+__km_sigreturn_end:        # We'll need this to define the the DWARF
 
 /*
  * Trampoline for x86 exception and interrupt handling. IDT entries point here.
@@ -93,7 +93,7 @@ handler\name :
     mov $0x81fd, %dx        # HC_guest_interrupt
     outl %eax, (%dx)        # Enter KM
     hlt                     # Should never hit here.
-    
+
 .endm
 
 /*
@@ -176,20 +176,17 @@ __km_syscall_handler:
     push %rdi   # arg1
     push %rax   # hc_ret - don't care about value. %rax is convienent.
 
-    // Do the KM HCall
-    mov %ax, %dx
+    mov %ax, %dx     # Do the KM HCall
     or $0x8000, %dx
-    mov %rsp, %rax
+    mov %rsp, %rax   # km_hcall_t on the stack
     outl %eax, (%dx)
 
-    // Get return code into RAX
-    mov (%rsp), %rax
-    // Restore stack
-    add $56, %rsp
+    mov (%rsp), %rax # Get return code into RAX
+    add $56, %rsp    # Restore stack
 
     /*
-     * SYSRET is hardcoded to return to PL=3, so
-     * we can't use it. We don't change PL or RFLAGS
-     * so we can just jump back.
+     * SYSCALL saved address of the next instruction in %rcx.
+     * SYSRET is hardcoded to return to PL=3, so we can't use it.
+     * We don't change PL or RFLAGS so we can just jump back.
      */
     jmp *%rcx

--- a/km/km_intr.c
+++ b/km/km_intr.c
@@ -161,9 +161,6 @@ void km_handle_interrupt(km_vcpu_t* vcpu)
    km_infox(KM_TRACE_SIGNALS, "    RFLAGS: 0x%lx", iframe->rflags);
    km_infox(KM_TRACE_SIGNALS, "       RSP: 0x%lx", iframe->rsp);
    km_infox(KM_TRACE_SIGNALS, "        SS: 0x%lx", iframe->ss);
-   if (km_trace_tag_enabled(KM_TRACE_SIGNALS) != 0) {
-      km_dump_vcpu(vcpu);
-   }
 
    // Restore register to what they were before the interrupt.
    vcpu->regs.rip = iframe->rip;

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -404,7 +404,7 @@ static int hypercall(km_vcpu_t* vcpu, int* hc)
               r->io.size,
               r->io.direction == KVM_EXIT_IO_OUT ? "out" : "in");
 
-      siginfo_t info = {.si_signo = SIGSYS, .si_code = SI_KERNEL};
+      siginfo_t info = {.si_signo = SIGBUS, .si_code = SI_KERNEL};
       km_post_signal(vcpu, &info);
       return -1;
    }
@@ -446,7 +446,7 @@ static int hypercall(km_vcpu_t* vcpu, int* hc)
    km_kma_t ga_kma;
    if ((ga_kma = km_gva_to_kma(ga)) == NULL || km_gva_to_kma(ga + sizeof(km_hc_args_t) - 1) == NULL) {
       km_infox(KM_TRACE_SIGNALS, "hc: %d bad km_hc_args_t address:0x%lx", *hc, ga);
-      siginfo_t info = {.si_signo = SIGSYS, .si_code = SI_KERNEL};
+      siginfo_t info = {.si_signo = SIGSEGV, .si_code = SI_KERNEL};
       km_post_signal(vcpu, &info);
       return -1;
    }

--- a/runtime/clone_km.s
+++ b/runtime/clone_km.s
@@ -19,8 +19,9 @@ __clone:
    mov %rsp, %rax
    outl %eax, (%dx)
    mov (%rsp), %eax # Get return code into %rax
+   add $56, %rsp
    test %eax,%eax
-   jnz 1f       # parent jumps
+   jnz 1f         # parent jumps
    # child - on a new stack now
    mov %rdi, %r9  # fn
    mov %rcx, %rdi # args
@@ -32,5 +33,4 @@ __clone:
    outl %eax, (%dx)
    hlt
 1:
-   add $56, %rsp
    ret

--- a/tests/clone_test.c
+++ b/tests/clone_test.c
@@ -15,7 +15,7 @@
 
 static int childFunc(void* arg)
 {
-   printf("Hello from clone\n");
+   fprintf(stderr, "Hello from clone\n");
    return 0; /* Child terminates now */
 }
 
@@ -25,21 +25,19 @@ int main(int argc, char* argv[])
 {
    unsigned flags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD |
                     CLONE_SYSVSEM | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID | CLONE_DETACHED;
-   char* stack;    /* Start of stack buffer */
-   char* stackTop; /* End of stack buffer */
+   char* stack;     /* Start of stack buffer */
    pid_t pid, tid;
 
    stack = malloc(STACK_SIZE);
-   if (stack == NULL)
+   if (stack == NULL) {
       errExit("malloc");
-   stackTop = stack + STACK_SIZE - 16; /* Assume stack grows downward */
+   }
 
    printf("clone()\n");
-
-   pid = clone(childFunc, stackTop, flags, NULL, &pid, NULL, &tid);
-   if (pid == -1)
+   pid = clone(childFunc, stack + STACK_SIZE, flags, NULL, &pid, NULL, &tid);
+   if (pid == -1) {
       errExit("clone");
-
+   }
    printf("clone() returned %ld\n", (long)pid);
 
    usleep(1000);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -59,16 +59,16 @@ todo_so="hc_check mem_slots mem_mmap gdb_basic gdb_signal gdb_exception gdb_serv
    assert_output --partial "Bad system call"
 
    run km_with_timeout stray_test$ext hc -10
-   assert_failure 31  #SIGSYS
-   assert_output --partial "Bad system call"
+   assert_failure 7   #SIGBUS
+   assert_output --partial "Bus error"
 
    run km_with_timeout stray_test$ext hc 1000
-   assert_failure 31  #SIGSYS
-   assert_output --partial "Bad system call"
+   assert_failure 7   #SIGBUS
+   assert_output --partial "Bus error"
 
    run km_with_timeout stray_test$ext hc-badarg 3
-   assert_failure 31  #SIGSYS
-   assert_output --partial "Bad system call"
+   assert_failure 11  #SIGSEGV
+   assert_output --partial "Segmentation fault"
 
    run km_with_timeout stray_test$ext syscall
    assert_success


### PR DESCRIPTION
The issue was caused by `km_hc_args_t` structure put on the stack for hcalls args. It gets put on the stack either in out syscall wrapper we link with musl, or by system call intercept code. When hypercall returns we get the result off of the top of the stack, or `hc_ret` filed of `km_hc_args_t`, then restore the stack to the original value.

All was good everywhere other that `clone` system call. With `clone` there are two threads, not one. In the parent we put the `km_hc_args_t` as usual. When parent returns it is on the same stack and all works well. However the child is **on a different stack**, and we didn't put the `km_hc_args_t` there.

Our clone wrapper was aware of that, so the stack was only adjusted for the parent. When we went though syscall emulation there is no wrapper other that the emulation code, and the emulation code is generic and not aware of `clone` particulars. The stack was adjusted back for both parent **and the child**, making the RSP pointing outside of allocated memory.

The `clone` implementation now sets the stack in the child pretending the `km_hc_args_t` is there, so that the RSP adjustment works for either the same way. The `clone` wrapper doesn't make the distinction any more.

Also set MSRs for system call emulation for all VCPUs.
