### PR TITLE
force no compile warnings in our code

### DIFF
--- a/km/Makefile
+++ b/km/Makefile
@@ -19,6 +19,7 @@ VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info
 INCLUDES := ${TOP}/include
 LLIBS := elf z
 COVERAGE := yes
+LOCAL_COPTS := -Werror
 LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd
 
 include ${TOP}/make/actions.mk

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -41,7 +41,7 @@ SHRSRC := dlopen_test.c dlopen_test_lib.c dlopen_test_lib2.c
 BUILDENV_PATH  := ./gdb
 TESTENV_PATH := .
 
-CFLAGS = -Wall $(COPTS) -ggdb3 -fPIC -fno-stack-protector -pthread -I${TOP}/include -I${TOP}/km
+CFLAGS = -Wall -Werror $(COPTS) -ggdb3 -fPIC -fno-stack-protector -pthread -I${TOP}/include -I${TOP}/km
 LDFLAGS = -ggdb3 -pthread -ldl
 KCC := kontain-gcc
 DEPS = ${SRC:%.c=%.d} ${SHRSRC:%.c=%.d} ${SRC_CPP:%.cpp=%.d}
@@ -137,7 +137,7 @@ coverage: all ## Build with code coverage, then run tests and generate reports
 	$(MAKE) BLDTYPE=$(COV_BLDTYPE) MAKEFLAGS="$(MAKEFLAGS)" .coverage
 
 .coverage: test
-	${COVERAGE_SCRIPT} ${TOP}/km ${KM_BLDDIR} ${KM_BLDDIR} 
+	${COVERAGE_SCRIPT} ${TOP}/km ${KM_BLDDIR} ${KM_BLDDIR}
 
 covclean: ## Clean up code coverage build artifacts
 	$(MAKE) BLDTYPE=$(COV_BLDTYPE) MAKEFLAGS="$(MAKEFLAGS)" .cov_clean


### PR DESCRIPTION
I'd rather do it in `actions.mk` but unfortunately musl has some warnings. Let me know what you guys thinks about this?