### PR TITLE
mmap testing fix for fedora 30 and earlier gdb versions

### DIFF
--- a/tests/gdb_simple_test.py
+++ b/tests/gdb_simple_test.py
@@ -35,7 +35,7 @@ def bp_handler(event):
             # Fetch data from command in 'buf'. Command format is "query,verbosity,expected_count", e.g. "2,1,12"
             frame = gdb.selected_frame()
             block = frame.block()
-            value = block['buf'].value(frame)
+            value = gdb.lookup_symbol('buf', block)[0].value(frame)
             str_t = gdb.lookup_type('char').pointer()
             command = value.cast(str_t).string()
             query, verbosity, expected_count = [


### PR DESCRIPTION
Fixes issue that John and possibly Srini had in running tests on master.
8.3-fc30 gdb versions had issues with gdb testing due to gdb.Block object not being subscriptable, so we use gdb.lookup_symbol instead