### PR TITLE
initial kkm pipeline

### DIFF
--- a/azure-pipeline-kkm.yml
+++ b/azure-pipeline-kkm.yml
@@ -1,0 +1,47 @@
+name: ci-$(BuildID) $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  branches:
+    include:
+      - master
+      - kkm/ci/* # Force CI run. For example, kkm/ci/some-changes
+  paths:
+    exclude:
+      - README.md
+      - compile_commands.json
+      - .vscode/*
+      - docs/*
+      - demo/nokia/*
+
+pr:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - README.md
+      - compile_commands.json
+      - .vscode/*
+      - docs/*
+      - demo/nokia/*
+
+jobs:
+  - job: kkm_ci
+    variables:
+      vmImage: "ubuntu-18.04"
+
+    # Default job has a 60 minutes timeout. Sets this to 0 to use the max
+    # 360 minutes timeout.
+    timeoutInMinutes: 0
+    pool:
+      vmImage: $(vmImage)
+    steps:
+      - template: templates/setup.yaml
+
+      - template: templates/kkm.yaml
+
+      - bash: |
+          set -ex
+          az logout
+        condition: always()
+        displayName: Cleanup and logout

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,27 +6,27 @@ name: ci-$(BuildID) $(Date:yyyyMMdd)$(Rev:.r)
 trigger:
   branches:
     include:
-    - master
-    - ci/* # prefix ci/ to force CI on every push. e.g. ci/msterin/test-azure-devops
+      - master
+      - ci/* # prefix ci/ to force CI on every push. e.g. ci/msterin/test-azure-devops
   paths:
     exclude:
-    - README.md
-    - compile_commands.json
-    - .vscode/*
-    - docs/*
-    - demo/nokia/*
+      - README.md
+      - compile_commands.json
+      - .vscode/*
+      - docs/*
+      - demo/nokia/*
 
 pr:
   branches:
     include:
-    - master
+      - master
   paths:
     exclude:
-    - README.md
-    - compile_commands.json
-    - .vscode/*
-    - docs/*
-    - demo/nokia/*
+      - README.md
+      - compile_commands.json
+      - .vscode/*
+      - docs/*
+      - demo/nokia/*
 
 jobs:
   - job: normal_ci
@@ -35,7 +35,7 @@ jobs:
       # NOTE: In Azure pipeline setting a variable also makes variable's UPPCASE_NAME
       # exposed in environment for all tasks. E.g. 'dtype=fedora' means all tasks will have
       # an environment DTYPE=fedora.
-      dtype: $(buildenv.type)  # until we add other distros, this always maps to fedora (see 'strategy' below)
+      dtype: $(buildenv.type) # until we add other distros, this always maps to fedora (see 'strategy' below)
       buildenv_image_version: latest # use this for all buildenv containers
       image_version: ci-$(Build.BuildId) # use this for all other containers
       #trace: true # uncomment to enable '-x' in all bash scripts

--- a/templates/kkm.yaml
+++ b/templates/kkm.yaml
@@ -1,0 +1,13 @@
+# Contains steps to build kkm
+steps:
+  - bash: cd kkm/kkm; make
+    displayName: build kkm
+
+  - bash: sudo insmod kkm/kkm/kkm.ko
+    displayName: install kkm
+
+  - bash: cd kkm/test_kkm; make
+    displayName: build test kkm
+
+  - bash: sudo ./kkm/test_kkm/test_kkm
+    displayName: test kkm


### PR DESCRIPTION
We introduce this new pipeline for kkm integration specifically. This pipeline can be merged into the normal CI pipeline in the future. This is a skeleton, which uses only a simple test from kkm directory. Once #569 is merged, we will add full km tests that will run on the CI VM directly.