### PR TITLE
bump km testenv deployment wait timeout to 5m

### DIFF
--- a/cloud/k8s/tests/k8s-run-tests.sh
+++ b/cloud/k8s/tests/k8s-run-tests.sh
@@ -22,7 +22,7 @@ readonly TEST_COMMAND=$4
 # Using a /tmp directory so we can have a fresh record for every run.
 readonly RUNTIME_DIR=$(mktemp -d)
 readonly TEST_POD_TEMPLATE_NAME="test-pod-template.yaml"
-readonly POD_WAIT_TIMEOUT=${K8S_POD_WAIT_TIMEOUT:-2m}
+readonly POD_WAIT_TIMEOUT=${K8S_POD_WAIT_TIMEOUT:-5m}
 
 if [[ -z ${PIPELINE_WORKSPACE} ]]; then
     readonly GREEN=\\e[32m

--- a/cloud/k8s/tests/test-pod-template.yaml
+++ b/cloud/k8s/tests/test-pod-template.yaml
@@ -17,5 +17,5 @@ spec:
         limits:
           devices.kubevirt.io/kvm: "1"
           cpu: "1"
-      command: ["sh", "-c", "sleep infinity"]
+      command: ["sh", "-c", "tail -f /dev/null"]
   restartPolicy: Never


### PR DESCRIPTION
Sometimes, the testenv takes a long time to be pulled. For now, just bump the timeout. The ideal solution is to do a bit more complex error checking, but that would require a bigger efforts.