### PR TITLE
Stop the dup2 hypercall from replacing km's stderr, in, and out.

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -708,7 +708,8 @@ uint64_t km_fs_dup2(km_vcpu_t* vcpu, int fd, int newfd)
       return -EBADF;
    }
    int host_newfd;
-   if ((host_newfd = guestfd_to_hostfd(newfd)) < 0) {
+   if ((host_newfd = guestfd_to_hostfd(newfd)) <= 2) {
+      // Target fd not open or is stdin, stdout, or stderr
       if ((host_newfd = open("/", O_RDONLY)) < 0) {
          return -errno;
       }


### PR DESCRIPTION
While testing nginx I discover the km trace was going into the nginx log file.
The cause was dup2() can be used to replace km's stdin, out and err.

The bats tests all pass.