### PR TITLE
set buildenv tags used in CI back to 'latest'

### DIFF
--- a/azure-pipeline-kkm.yml
+++ b/azure-pipeline-kkm.yml
@@ -29,7 +29,7 @@ jobs:
   - job: kkm_ci
     variables:
       vmImage: "ubuntu-18.04"
-      buildenv_image_version: alpine_libs # use this for all buildenv containers
+      buildenv_image_version: latest # use this for all buildenv containers
       # trace: true # uncomment to enable '-x' in all bash scripts
 
     # Default job has a 60 minutes timeout. Sets this to 0 to use the max

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -17,7 +17,7 @@ jobs:
       VM_IMAGE: "ubuntu-18.04"
       CLUSTER_NAME: "aks-kontain-ci-nightly-$(Build.BuildId)"
       VM_SIZE: "Standard_D4_v3" # choose a vm size to avoid the vcpu quota on azure
-      buildenv_image_version: alpine_libs # use this for all buildenv containers
+      buildenv_image_version: latest # use this for all buildenv containers
       # BUILDENV_IMAGE_VERSION: latest # use this for all buildenv containers. TODO - rollback to latest when we all rebase
       IMAGE_VERSION: ci-nightly-$(Build.BuildId) # use this for all other containers
       K8S_TEST_ERR_NO_CLEANUP: true # OK to not clean up after error for nightly

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
       # exposed in environment for all tasks. E.g. 'dtype=fedora' means all tasks will have
       # an environment DTYPE=fedora.
       dtype: $(buildenv.type) # until we add other distros, this always maps to fedora (see 'strategy' below)
-      buildenv_image_version: alpine_libs # use this for all buildenv containers
+      buildenv_image_version: latest # use this for all buildenv containers
       image_version: ci-$(Build.BuildId) # use this for all other containers
       # trace: true # uncomment to enable '-x' in all bash scripts
 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -115,9 +115,7 @@ You can also run `make -C tests .buildenv-local-lib` if all DNF packages on your
 
 NOW
 
-* recover buildenv-image tag in azure pipelines to latest (from alpine_libs)
 * fix and enable demo-dweb - Maybe just revert to Aline:3.10 or Alpine:3.8 ? Fails with a mix between ubuntu gcc /ninutils/elfutils and latest alpine stuff
-* drop useless ls -L and trace in build.yaml and pipeline
 
 LATER
 
@@ -125,6 +123,6 @@ LATER
   * try to put only NEEDED libraries
   * remove -v from testenv and runenv usage - and only mount BIN for testenv
 * review install of the above on kontaind/kuberneres as optimization (see kontaind/installer)
-* reconcile docker run option s to test/run/build env - we seem to be repeating them multple times
+* reconcile docker run option for test/run/build env - we seem to be repeating them multiple times
 
 *** END OF DOCUMENT ***


### PR DESCRIPTION
Currently  all buildenv images on azure tagged as "latest" and "alpine_libs" (same images) so  this change should have no immediate impact.

It is just a clean up so CI uses correctly named tags. it also allows to drop alpine_libs tags from azure going forward