### PR TITLE
changes to build debug node testenv-image

### DIFF
--- a/make/images.mk
+++ b/make/images.mk
@@ -63,8 +63,9 @@ testenv-image: ## build test image with test tools and code
 	@# Copy KM there. TODO - remove when we support pre-installed KM
 	$(foreach f,${TESTENV_EXTRA_FILES}, cp $f ${TESTENV_PATH};)
 	${DOCKER_BUILD} --no-cache \
-			--build-arg branch=${SRC_SHA} \
+			--build-arg=branch=${SRC_SHA} \
 			--build-arg=BUILDENV_IMAGE_VERSION=${BUILDENV_IMAGE_VERSION} \
+			--build-arg=MODE=${BUILD} \
 			-t ${TEST_IMG}:${IMAGE_VERSION} \
 			${TESTENV_PATH} -f ${TEST_DOCKERFILE}
 	$(foreach f,${TESTENV_EXTRA_FILES},rm ${TESTENV_PATH}/$(notdir $f);)

--- a/payloads/node/.dockerignore
+++ b/payloads/node/.dockerignore
@@ -4,6 +4,7 @@
 !skip_*
 !km
 !node/out/Release/*.km
+!node/out/Debug/*.km
 !node/deps
 !node/tools
 !node/test

--- a/payloads/node/Makefile
+++ b/payloads/node/Makefile
@@ -60,7 +60,7 @@ in-blank-container: ## invoked in blank contaier by ``make all''. DO NOT invoke 
 
 fromsrc:
 	git clone https://github.com/nodejs/node.git -b ${VERS}
-	cd ${NODETOP} && ./configure --gdb `[[ $BUILD == Debug ]] && echo -n --debug` && make -j`expr 2 \* $(nproc)` && make jstest
+	cd ${NODETOP} && ./configure --gdb `[[ ${BUILD} == Debug ]] && echo -n --debug` && make -j`expr 2 \* $$(nproc)` && make jstest
 	mv ${NODEBUILD}/node ${NODEBUILD}/node.static
 	./link-km.sh ${NODEBUILD} ${NODEOUT}
 

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -75,7 +75,7 @@ in-blank-container: ## invoked in blank container by ``make all''. DO NOT invoke
 
 fromsrc: ## Clean build cpython from source. Use 'make clobber' to prepare for this one
 	git clone https://github.com/python/cpython.git -b ${VERS}
-	cd cpython && ./configure && make -j`expr 2 \* $(nproc)` | tee bear.out
+	cd cpython && ./configure && make -j`expr 2 \* $$(nproc)` | tee bear.out
 	cd cpython && patch -p1 < ../unittest.patch
 	eval $(prepare_builtins)
 	eval $(link_cpython_km)

--- a/runtime/runtime_stub_km.c
+++ b/runtime/runtime_stub_km.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <syscall.h>
+#include <sys/socket.h>
 #include "km_hcalls.h"
 
 int __dummy_stub(void)
@@ -83,4 +84,14 @@ const int gnu_dev_makedev(int x, int y)
 {
    return ((((x)&0xfffff000ULL) << 32) | (((x)&0x00000fffULL) << 8) | (((y)&0xffffff00ULL) << 12) |
            (((y)&0x000000ffULL)));
+}
+
+char** backtrace_symbols(void* const* buffer, int size)
+{
+   return NULL;
+}
+
+struct cmsghdr* __cmsg_nxthdr(struct msghdr* msgh, struct cmsghdr* cmsg)
+{
+   return CMSG_NXTHDR(msgh, cmsg);
 }


### PR DESCRIPTION
Couple of stubs for runtime functions needed by debug build of node.

Also fixes in Makefiles and such to support debug build.

Tested manually