### PR TITLE
Stop __km_syscall_handler from destroying rdx

### DIFF
--- a/km/km_guest_asmcode.s
+++ b/km/km_guest_asmcode.s
@@ -160,6 +160,8 @@ __km_interrupt_table:
  * R10 = 4th parameter
  * R8  = 5th parameter
  * R9  = 6th parameter
+ * On entry: rcx contains the return address and r11 contains the
+ * callers eflags register.
  * Return value saved in RAX
  */
     .section .km_guest_text, "ax", @progbits
@@ -181,8 +183,13 @@ __km_syscall_handler:
     mov %rsp, %rax   # km_hcall_t on the stack
     outl %eax, (%dx)
 
+    mov 24(%rsp), %rdx  # restore rdx
     mov (%rsp), %rax # Get return code into RAX
     add $56, %rsp    # Restore stack
+
+    andq $0x3C7FD7, %r11    # restore the flag register
+    push %r11
+    popfq
 
     /*
      * SYSCALL saved address of the next instruction in %rcx.

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -24,7 +24,7 @@ todo_static=''
 # skip slow ones
 not_needed_native_static='linux_exec setup_link setup_load gdb_sharedlib mem_regions threads_mutex sigaltstack mem_test'
 # review - some fail. Some slow
-todo_native_static='sigsuspend mem_mmap mmap_1 gdb_attach exception signals dl_iterate_phdr filesys hc_check'
+todo_native_static='mem_mmap mmap_1 gdb_attach exception signals dl_iterate_phdr filesys hc_check'
 
 not_needed_native_dynamic=$not_needed_native_static
 todo_native_dynamic=$todo_native_static
@@ -860,9 +860,13 @@ fi
    rm -f $FLAGFILE
    ./sigsuspend_test $FLAGFILE &
    pid=$!
+   trys=0
    while [ ! -e $FLAGFILE ]
    do
       sleep .01
+      trys=`expr $trys + 1`
+      test $trys -lt 1000
+      assert_success
    done
    kill -SIGUSR1 $pid
    kill -SIGUSR1 $pid
@@ -874,9 +878,13 @@ fi
    $KM_BIN sigsuspend_test$ext $FLAGFILE &
 #   km_with_timeout sigsuspend_test$ext $FLAGFILE &
    pid=$!
+   trys=0
    while [ ! -e $FLAGFILE ]
    do
       sleep .01
+      trys=`expr $trys + 1`
+      test $trys -lt 1000
+      assert_success
    done
    kill -SIGUSR1 $pid
    kill -SIGUSR1 $pid


### PR DESCRIPTION
Looks like the callers of syscalls expect at least rdx to be preserved.
__km_syscall_handler wasn't doing that which caused pthread_sigmask() to
seg fault which caused the sigsuspend test to wait forever for the begin
test flag file to exist.  This was fixed by saving rdx in r11 across the
syscall and then restoring rdx upon syscall return.

I don't know why other tests that were using sigprocmask() were succeeding.
I also don't know for sure if r11 is a scratch register.  The following web page has a chart extracted from the abi document which says r11 is a temp register.  Of course that probable means others are free to destroy it.  This change is more to highlight what is wrong and we can decide the truly correct way to fix this.  I thought about pushing rdx onto the stack and poping it after the syscall.  That will slow syscall down a little more.

Changed the sigsuspend_test to wait for 10 seconds for its flag file to appear.
If the flag file isn't created in that time then abort the test.

This change passes the bats test suite.