### PR TITLE
Fix the time going backwards for clock_gettime() through VDSO

### DIFF
--- a/km/x86_cpu.h
+++ b/km/x86_cpu.h
@@ -320,4 +320,6 @@ typedef struct x86_interrupt_frame {
 #define MSR_IA32_STAR 0xc0000081
 #define MSR_IA32_LSTAR 0xc0000082
 #define MSR_IA32_FMASK 0xc0000084
+#define MSR_IA32_TSC 0x00000010
+
 #endif

--- a/tests/clock_gettime_test.c
+++ b/tests/clock_gettime_test.c
@@ -1,0 +1,66 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include "greatest/greatest.h"
+#include "syscall.h"
+
+// Do clock_gettime() through VDSO and then through system call. Make sure subsequent calls are monotonic
+
+static const int count = 100;
+
+static inline u_int64_t nsecs(struct timespec ts)
+{
+   return ts.tv_sec * 1000000000l + ts.tv_nsec;
+}
+
+static inline void print_ts(char* msg, struct timespec ts1, struct timespec ts2)
+{
+   printf("%s: %ld.%9ld\t%ld.%9ld\n", msg, ts1.tv_sec, ts1.tv_nsec, ts2.tv_sec, ts2.tv_nsec);
+}
+
+TEST test(void)
+{
+   struct timespec ts1, ts2;
+
+   for (int i = 0; i < count; i++) {
+      clock_gettime(CLOCK_MONOTONIC, &ts1);
+      syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &ts2);
+      if (greatest_get_verbosity() != 0 && !(nsecs(ts1) <= nsecs(ts2))) {
+         print_ts("vdso > syscall", ts1, ts2);
+      }
+      ASSERT(nsecs(ts1) <= nsecs(ts2));
+   }
+   for (int i = 0; i < count; i++) {
+      syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &ts1);
+      clock_gettime(CLOCK_MONOTONIC, &ts2);
+      if (greatest_get_verbosity() != 0 && !(nsecs(ts1) <= nsecs(ts2))) {
+         print_ts("syscall > vdso", ts1, ts2);
+      }
+      ASSERT(nsecs(ts1) <= nsecs(ts2));
+   }
+   // tighter loop to make sure clock_gettime VDSO is monotonic
+   for (int i = 0; i < count; i++) {
+      clock_gettime(CLOCK_MONOTONIC, &ts1);
+      clock_gettime(CLOCK_MONOTONIC, &ts2);
+      if (greatest_get_verbosity() != 0 && !(nsecs(ts1) <= nsecs(ts2))) {
+         print_ts("vdso > vdso", ts1, ts2);
+      }
+      ASSERT(nsecs(ts1) <= nsecs(ts2));
+   }
+   PASS();
+}
+
+GREATEST_MAIN_DEFS();
+
+int main(int argc, char** argv)
+{
+   GREATEST_MAIN_BEGIN();
+
+   RUN_TEST(test);
+   GREATEST_PRINT_REPORT();
+   return greatest_info.failed;
+}

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -16,7 +16,7 @@ load test_helper
 # not_needed_{generic,static,dynamic,shared} - skip since it's not needed
 # todo_{generic,static,dynamic,shared} - skip since it's a TODO
 not_needed_generic=''
-todo_generic='futex_example'
+todo_generic='futex_example clock_gettime'
 
 not_needed_static='gdb_sharedlib'
 todo_static=''
@@ -954,3 +954,8 @@ fi
    assert_line --partial "env[0] = 'ONE=one'"
    assert_line --partial "env[3] = 'FOUR=four'"
 }
+@test "clock_gettime($test_type): VDSO clock_gettime, dependency on TSC (clock_gettime$ext)" {
+   run km_with_timeout clock_gettime_test$ext -v
+   assert_success
+}
+


### PR DESCRIPTION
It turns out VDSO logic for `clock_gettime()` depends on the TSC values stored in VVAR pages. The TSC values are stored there by the kernel so they reflect TSC of physical CPUs. But KVM resets TSC to 0 when new machine gets created.

KVM helps us here. Turns out it helps synchronize TSCs between all VCPUs so we don't have to. All we got to do it to change the initial value. So when the first VCPU is created we get TSC value from the host using RDTSC instruction, and set that value via SET_MSR ioclt(). After that KVM takes over and all seems to work.

This makes vdso login happy as it keys off of TSC values stored in vvar.

Added test for monotonic time behavior.

Fixes #576
