### PR TITLE
detect executable type(native or km)

### DIFF
--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -231,6 +231,20 @@ uint64_t km_load_elf(const char* file)
       sprintf(fn, "%s.km", file);
       file = fn;
    }
+ 
+   int fn_length = strlen(file);
+   if ((fn_length > 11) && (strcmp(".native.kmd", file + fn_length - 11) == 0)) {
+      machine.ex_type = EXE_TYPE_NATIVE_KMD;
+   } else if ((fn_length > 10) && (strcmp(".native.km", file + fn_length - 10) == 0)) {
+      machine.ex_type = EXE_TYPE_NATIVE_KM;
+   } else if ((fn_length > 3) && (strcmp(".km", file + fn_length - 3) == 0)) {
+      machine.ex_type = EXE_TYPE_KM;
+   } else if ((fn_length > 4) && (strcmp(".kmd", file + fn_length - 4) == 0)) {
+      machine.ex_type = EXE_TYPE_KMD;
+   } else {
+      machine.ex_type = EXE_TYPE_KMDSO;
+   }
+
    char* filename = NULL;
    if ((filename = realpath(file, NULL)) == NULL) {
       err(2, "%s realpath failed: %s", __FUNCTION__, file);


### PR DESCRIPTION
use this information to adjust stack for newly cloned thread

when using native libraries with kvm
syscall code pushes parameters to stack and then calls out instruction to cause vmexit.

control flow with KVM
clone
      syscall
          push parameters to stack
          out instruction to exit from vm
--->    control reaches here after clone is complete both in parent and child. km adjusts child stack accordingly
          adjust stack in opposite to push

km adjusts stack by km_hc_args_t size when returning from clone in child.


KKM does not have the translation layer between syscall and out instruction.
So stack adjustment should not be done.
parent KKM has context that it is a syscall instruction and it adjusts the stack.
KKM does not know if this is a normal KVM_RUN or right after clone KVM_RUN. This information is only with KM.

control flow with KKM
clone
     syscall
     push parameters to stack, track this is syscall.
---> control returns here both parent and child. parent knows this was because of syscall and does the adjustment.
