### PR TITLE
mremap test fix in mmap_test.c

### DIFF
--- a/tests/mmap_helper.c
+++ b/tests/mmap_helper.c
@@ -59,6 +59,7 @@ enum greatest_test_res mmap_test(mmap_test_t* tests)
       }
       switch (t->type) {
          case TYPE_MMAP:
+         case TYPE_MMAP_AUX:
             new_addr = mmap((void*)t->offset, t->size, t->prot, t->flags, -1, 0);
             if (greatest_get_verbosity() == 1) {
                printf("return: %p (%s)\n", new_addr, out_sz((uint64_t)new_addr));
@@ -78,7 +79,10 @@ enum greatest_test_res mmap_test(mmap_test_t* tests)
                   }
                   memset(new_addr, '2', t->size);
                }
-               last_addr = new_addr;
+
+               if (t->type == TYPE_MMAP) {
+                  last_addr = new_addr;
+               }
             } else {
                ASSERT_EQ_FMTm(t->info, MAP_FAILED, new_addr, ret_fmt);
                ASSERT_EQ_FMTm(t->info, t->expected, errno, errno_fmt);
@@ -237,7 +241,8 @@ int maps_count(int expected_count, int query)
    }
    char read_check_result[256];
    int verbosity = greatest_get_verbosity() >= 1;
-   // Forming a request. Example: 2,1,12 would mean mean 'check BUSY maps (BUSY=2); with verbosity=1 and expect the count of 12
+   // Forming a request. Example: 2,1,12 would mean mean 'check BUSY maps (BUSY=2); with verbosity=1
+   // and expect the count of 12
    sprintf(read_check_result, "%i,%i,%i", query, verbosity, expected_count);
    int ret = read(ASSERT_MMAP_FD, read_check_result, sizeof(read_check_result));
    if (ret == -1 && errno == EBADF) {

--- a/tests/mmap_test.c
+++ b/tests/mmap_test.c
@@ -211,7 +211,7 @@ TEST mremap_test()
        {__LINE__, "1f5 mremap param - wrong flags", TYPE_MREMAP, 0, 2 * MIB, 1 * MIB, 0x44, EINVAL},
 
        {__LINE__, "1 mremap shrink makes 1mb hole", TYPE_MREMAP, 0, 2 * MIB, 1 * MIB, MREMAP_MAYMOVE, OK},
-       {__LINE__, "1 mmap refill the hole", TYPE_MMAP, 1 * MIB, 1 * MIB, prot, flags, OK},
+       {__LINE__, "1 mmap refill the hole", TYPE_MMAP_AUX, 1 * MIB, 1 * MIB, prot, flags, OK},
        {__LINE__, "1 cleanup (unmap)", TYPE_MUNMAP, -1 * MIB, 10 * MIB, PROT_NONE, flags, OK},   //// BUG
 
        // grow should move ptr; old area should be unaccessible.

--- a/tests/mmap_test.h
+++ b/tests/mmap_test.h
@@ -54,6 +54,7 @@ extern int main(int argc, char** argv);
 // Type of operation invoked by a single line in test tables
 typedef enum {
    TYPE_MMAP,   // see mmap_test_t below
+   TYPE_MMAP_AUX,
    TYPE_MUNMAP,
    TYPE_MPROTECT,
    TYPE_MREMAP,   // for remapped memory, PROT_WRITE should have been set on mmmap (test will write!)
@@ -61,6 +62,7 @@ typedef enum {
    TYPE_WRITE,    // do a write to <offset, offset+size> from last mmap (use 'prot' for data)
    TYPE_USE_MREMAP_ADDR,   // in further tests, base all on address returned by last mremap (not mmap)
    TYPE_MADVISE,
+
 } call_type_t;
 
 typedef enum { BUSY_MMAPS = 1, FREE_MMAPS = 2, TOTAL_MMAPS = 3 } write_querry_t;


### PR DESCRIPTION
Fixes issue with mmapping to hole in the test where last_addr was improperly saved