### PR TITLE
Incremental improvement to exec

### DIFF
--- a/km/gdb_kvm_x86_64.c
+++ b/km/gdb_kvm_x86_64.c
@@ -80,14 +80,11 @@ static uint32_t nr_hw_breakpoints = 0;
 static const uint8_t int3 = 0xcc;   // trap instruction used for software breakpoints
 
 /*
- * Read /proc/self/maps looking for the entry that covers the address
- * supplied by the addr argument.  When a matching range is found,
- * return the PROT_{READ,WRITE,EXEC} equivalent of the rwxp field in *protection
- * If no matching addr range is found or we couldn't open the maps
- * file return a negative value.
- * If a page protection was found return 0.
+ * Read /proc/self/maps looking for the entry that covers the address supplied by the addr argument.
+ * When a matching range is found, return the PROT_{READ,WRITE,EXEC} equivalent of the rwxp field in
+ * *protection. If no matching addr range is found or we couldn't open the maps file return a
+ * negative value. If a page protection was found return 0.
  */
-#define PROC_SELF_MAPS "/proc/self/maps"
 int km_get_page_protection(km_kma_t addr, int* protection)
 {
    FILE* procmaps;

--- a/km/km.h
+++ b/km/km.h
@@ -33,6 +33,8 @@
 #define rounddown(x, y)                                                                            \
    (__builtin_constant_p(y) && powerof2(y) ? ((x) & ~((y)-1)) : (((x) / (y)) * (y)))
 
+typedef const char* const const_string_t;
+
 /*
  * Types from linux/kvm.h
  */

--- a/km/km_exec.c
+++ b/km/km_exec.c
@@ -43,7 +43,7 @@ static char KM_EXEC_PIDINFO[] = "KM_EXEC_PIDINFO";
 
 /*
  * An instance of this holds all of the exec state that the execing program puts
- * into the above environment variables.  The exec'ed instance of km retreives the
+ * into the above environment variables.  The exec'ed instance of km retrieves the
  * environment variables and builds an instance of this structure which is then
  * used to restore needed km state for the new payload to continue.
  */
@@ -65,6 +65,7 @@ typedef struct km_exec_state {
    int nfdmap;
    fdmap_t guestfd_hostfd[0];
 } km_exec_state_t;
+
 static km_exec_state_t* execstatep;
 
 // The args from main so that exec can rebuild the km command line
@@ -270,17 +271,13 @@ char** km_exec_build_argv(char* filename, char** argv)
 {
    char** nargv;
    int nargc;
-
-   // Count km related args from the invoking program.
-   int tmpargc;
-   for (tmpargc = 1; tmpargc < km_exec_argc && km_exec_argv[tmpargc][0] == '-'; tmpargc++) {
-   }
    int argc;
+
    for (argc = 0; argv[argc] != NULL; argc++) {
    }
 
    // Allocate memory for the km args plus the passed args
-   nargc = tmpargc + argc + 1;
+   nargc = km_exec_argc + argc + 1;
    nargv = calloc(nargc, sizeof(char*));
    if (nargv == NULL) {
       return NULL;
@@ -288,7 +285,7 @@ char** km_exec_build_argv(char* filename, char** argv)
 
    // Copy km related args in
    int i;
-   for (i = 0; i < tmpargc; i++) {
+   for (i = 0; i < km_exec_argc; i++) {
       nargv[i] = km_exec_argv[i];
    }
 
@@ -454,7 +451,7 @@ int km_exec_recover_guestfd(void)
    }
    for (int i = 0; i < execstatep->nfdmap && execstatep->guestfd_hostfd[i].guestfd >= 0; i++) {
       ssize_t bytes;
-      snprintf(linkname, sizeof(linkname), "/proc/self/fd/%d", execstatep->guestfd_hostfd[i].hostfd);
+      snprintf(linkname, sizeof(linkname), PROC_SELF_FD, execstatep->guestfd_hostfd[i].hostfd);
       if ((bytes = readlink(linkname, linkbuf, sizeof(linkbuf))) < 0) {
          err(2, "Can't get filename for hostfd %d, link %s", execstatep->guestfd_hostfd[i].hostfd, linkname);
       }

--- a/km/km_fork.c
+++ b/km/km_fork.c
@@ -92,7 +92,7 @@ static void km_fork_setup_child_vmstate(void)
       }
    }
 
-   km_signal_init();   // initalize signal wait queue and the signal entry free list
+   km_signal_init();   // initialize signal wait queue and the signal entry free list
 
    // No need to call km_init_guest_idt(). Use what was inherited from the parent process.
 
@@ -215,16 +215,14 @@ int km_before_fork(km_vcpu_t* vcpu, km_hc_args_t* arg, uint8_t is_clone)
 }
 
 /*
- * If needed, perform a fork() or clone() system call.
- * Call this from km's main() thread.  We want the
- * km main thread to be the surviving thread in the child
- * process since it is involved with payload termination
- * and the gdb server runs in the main thread context.
+ * If needed, perform a fork() or clone() system call. Call this from km's main() thread.  We want
+ * the km main thread to be the surviving thread in the child process since it is involved with
+ * payload termination and the gdb server runs in the main thread context.
+ *
  * Returns:
  *   0 - fork or clone was not requested
  *   1 - fork or clone requested and performed
- * in_child - returns to the caller whether we are returning in the
- *   child process or the parent process.
+ * in_child - returns to the caller whether we are returning in the child process or the parent process.
  */
 int km_dofork(int* in_child)
 {
@@ -312,10 +310,9 @@ void km_forward_sigchild(int signo, siginfo_t* sinfo, void* ucontext_unused)
 // TODO: pidmap belongs in its own source file.
 
 /*
- * This small group of code maps between km pids and their associated linux pids.
- * This is here so that the various wait() hypercalls can map a km pid into a linux
- * pid where needed before calling the kernel's wait() system call.
- * We also convert linux pids returned by wait back into km pid's.
+ * This small group of code maps between km pids and their associated linux pids. This is here so
+ * that the various wait() hypercalls can map a km pid into a linux pid where needed before calling
+ * the kernel's wait() system call. We also convert linux pids returned by wait back into km pid's.
  * And this is because the linux kernel has no knowledge of the km pids.
  */
 typedef struct km_linux_kontain_pidmap {

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -83,7 +83,7 @@ static char in_buffer[BUFMAX];   // TODO: malloc/free these two
 static unsigned char registers[BUFMAX];
 
 #define GDB_ERROR_MSG "E01"   // The actual error code is ignored by GDB, so any number will do
-static const char hexchars[] = "0123456789abcdef";
+static const_string_t hexchars = "0123456789abcdef";
 
 static void km_gdb_exit_debug_stopreply(km_vcpu_t* vcpu, char* stopreply);
 

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1374,7 +1374,7 @@ static int execveat_openexe(int dirfd, char* pathname, int flag, int open_flag)
 static int execveat_fd2path(int exefd, char* linkbuf, size_t linkbuf_size)
 {
    char procfdbuf[32];
-   snprintf(procfdbuf, sizeof(procfdbuf), "/proc/self/fd/%d", exefd);
+   snprintf(procfdbuf, sizeof(procfdbuf), PROC_SELF_FD, exefd);
    ssize_t linkbytes = readlink(procfdbuf, linkbuf, linkbuf_size);
    if (linkbytes < 0) {
       return -errno;

--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -97,7 +97,7 @@ km_gva_t km_init_main(km_vcpu_t* vcpu, int argc, char* const argv[], int envc, c
       strncpy(stack_top_kma, argv[i], len);
    }
 
-   static const char* pstr = "X86_64";
+   static const_string_t pstr = "X86_64";
    int pstr_len = strlen(pstr) + 1;
    stack_top -= pstr_len;
    stack_top_kma -= pstr_len;

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -143,12 +143,12 @@ static struct option long_options[] = {
     {0, 0, 0, 0},
 };
 
-static const char* SHEBANG = "#!";
+static const_string_t SHEBANG = "#!";
 static const size_t SHEBANG_LEN = 2;               // strlen(SHEBANG)
 static const size_t SHEBANG_MAX_LINE_LEN = 1000;   // note: grabbed on stack
 
-static const char* KM_BIN_NAME = "km";
-static const char* PAYLOAD_SUFFIX = ".km";
+static const_string_t KM_BIN_NAME = "km";
+static const_string_t PAYLOAD_SUFFIX = ".km";
 
 /*
  * Checks if the passed file is a shebang, and if it is gets payload file name from there.
@@ -383,7 +383,7 @@ int main(int argc, char* argv[])
    char* payload_file = argv[index];
 
    km_hcalls_init();
-   km_exec_init(argc, (char**)argv);
+   km_exec_init(index, (char**)argv);
    km_machine_init(&km_machine_init_params);
    km_exec_fini();
 

--- a/km/km_proc.c
+++ b/km/km_proc.c
@@ -26,8 +26,6 @@
 #include "km.h"
 #include "km_proc.h"
 
-static const char* PROC_SELF_MAPS = "/proc/self/maps";
-
 /*
  * Read /proc/self/maps looking for the entries that match the names supplied.
  */

--- a/km/km_proc.h
+++ b/km/km_proc.h
@@ -13,6 +13,10 @@
 #ifndef __KM_PROC_H__
 #define __KM_PROC_H__
 
+static const_string_t PROC_SELF_MAPS = "/proc/self/maps";
+static const_string_t PROC_SELF_FD = "/proc/self/fd/%d";
+static const_string_t PROC_SELF_EXE = "/proc/self/exe";
+
 typedef struct maps_region {
    char* name_substring;   // caller supplies this, the rest is filled in if name is found
    uint64_t begin_addr;

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -34,6 +34,8 @@
 int vcpu_dump = 0;
 int km_collect_hc_stats = 0;
 
+static const_string_t fx = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
+
 /*
  * run related err and errx - get regs, print RIP and the supplied message
  */
@@ -43,7 +45,6 @@ __run_err(void (*fn)(int, const char*, __builtin_va_list), km_vcpu_t* vcpu, int 
 static void
 __run_err(void (*fn)(int, const char*, __builtin_va_list), km_vcpu_t* vcpu, int s, const char* f, ...)
 {
-   static const char fx[] = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
    int save_errno = errno;
    va_list args;
    char fmt[strlen(f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];
@@ -66,7 +67,6 @@ __run_warn(void (*fn)(const char*, __builtin_va_list), km_vcpu_t* vcpu, const ch
     __attribute__((format(printf, 3, 4)));   // define attributes
 static void __run_warn(void (*fn)(const char*, __builtin_va_list), km_vcpu_t* vcpu, const char* f, ...)
 {
-   static const char fx[] = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
    va_list args;
    char fmt[strlen(f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];
 
@@ -96,7 +96,7 @@ static const char* kvm_reason_name(int reason)
 {
 #define __KVM_REASON_MAX (KVM_EXIT_HYPERV + 1)   // this is the current max
 #define __KVM_REASON_NAME(__r) [__r] = #__r
-   static const char* const reasons[__KVM_REASON_MAX] = {
+   static const_string_t reasons[__KVM_REASON_MAX] = {
        __KVM_REASON_NAME(KVM_EXIT_UNKNOWN),      __KVM_REASON_NAME(KVM_EXIT_EXCEPTION),
        __KVM_REASON_NAME(KVM_EXIT_IO),           __KVM_REASON_NAME(KVM_EXIT_HYPERCALL),
        __KVM_REASON_NAME(KVM_EXIT_DEBUG),        __KVM_REASON_NAME(KVM_EXIT_HLT),

--- a/tests/hcallargs_test.c
+++ b/tests/hcallargs_test.c
@@ -25,8 +25,8 @@
 #include <string.h>
 #include <unistd.h>
 #include "greatest/greatest.h"
-#include "sys/mman.h"
-#include "syscall.h"
+#include <sys/mman.h>
+#include <syscall.h>
 
 #define GIB (1024 * 1024 * 1024ul)
 
@@ -39,8 +39,8 @@ static inline char* simple_mmap(size_t size)
    return mmap(0, size, PROT_NONE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 }
 
-static const char* brick_msg = "brick in the wall ";
-static const char* dust_msg = "one bites the dust";
+static const char* const brick_msg = "brick in the wall ";
+static const char* const dust_msg = "one bites the dust";
 const long step = 100ul;
 
 void* run(void* unused)

--- a/tests/hello_2_loops_test.c
+++ b/tests/hello_2_loops_test.c
@@ -46,8 +46,8 @@ void make_mystr(char* msg)
    pthread_setspecific(mystr_key_2, strdup(msg));
 }
 
-static const char* brick_msg = "brick in the wall ";
-static const char* dust_msg = "one bites the dust";
+static const char* const brick_msg = "brick in the wall ";
+static const char* const dust_msg = "one bites the dust";
 const long step = 1ul;
 
 void subrun(char* msg)

--- a/tests/hello_2_loops_tls_test.c
+++ b/tests/hello_2_loops_tls_test.c
@@ -49,9 +49,9 @@ int check_mystr(char* msg)
    return strcmp(my_msg, msg);
 }
 
-static const char* brick_msg = "brick in the wall ";
-static const char* dust_msg = "one bites the dust";
-const long step = 1ul;
+static const char* const brick_msg = "brick in the wall ";
+static const char* const dust_msg = "one bites the dust";
+static const long step = 1ul;
 
 void* subrun(char* msg)
 {

--- a/tests/hello_loop_test.c
+++ b/tests/hello_loop_test.c
@@ -23,7 +23,7 @@
 #include <unistd.h>
 #include "syscall.h"
 
-static const char* msg1 = "Hello, I am a loop ";
+static const char* const msg1 = "Hello, I am a loop ";
 
 void run_forever(void)
 {

--- a/tests/intr_test.c
+++ b/tests/intr_test.c
@@ -19,8 +19,8 @@
 
 #include "greatest/greatest.h"
 
-static const char* brick_msg = "brick in the wall ";
-static const char* dust_msg = "one bites the dust";
+static const char* const brick_msg = "brick in the wall ";
+static const char* const dust_msg = "one bites the dust";
 const long step = 100 * 1024 * 1024 * 1024ul;
 
 // simple thread create with check. assert macro can use params more than once, so using separate <ret>

--- a/tests/mmap_test.h
+++ b/tests/mmap_test.h
@@ -85,8 +85,8 @@ typedef struct mmap_test {
 #define OK 0   // expected good result
 
 #define UNUSED __attribute__((unused))
-static const char* errno_fmt UNUSED = "errno 0x%x";   // format for offsets/types error msg
-static const char* ret_fmt UNUSED = "ret 0x%x";       // format for offsets/types error msg
+static const char* const errno_fmt UNUSED = "errno 0x%x";   // format for offsets/types error msg
+static const char* const ret_fmt UNUSED = "ret 0x%x";       // format for offsets/types error msg
 // just to type less going forward
 static const int flags = (MAP_PRIVATE | MAP_ANONYMOUS);
 


### PR DESCRIPTION
This is an incremental step to fix `known_issues/test-dgram-bind-shared-ports-after-port-0.js` node test.

There are two fixes here. One returns payload file name as was passed to `load_elf()` when payload does `readlink("/proc/self/exe")`. The other improves on the original km arguments parsing for exec.

The node test still doesn't finish successfully but instead of crashing with kmcore it now proceeds much further and hangs in `epoll_pwait()`. Our tests all pass.

While this is not full fix I believe it is worth merging as it is an improvement.