### PR TITLE
Fix km so that payload calls to popen() will work

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -386,6 +386,7 @@ static inline void km_vcpu_sync_rip(km_vcpu_t* vcpu)
 void __km_trace(int errnum, const char* function, int linenumber, const char* fmt, ...)
     __attribute__((__format__(__printf__, 4, 5)));
 void km_trace_include_pid(uint8_t trace_pid);
+uint8_t km_trace_include_pid_value(void);
 
 char* km_get_self_name(void);
 
@@ -617,6 +618,7 @@ static inline void km_signal_unlock(void)
 #define KM_TRACE_PROC "proc"
 #define KM_TRACE_EXEC "exec"
 #define KM_TRACE_FORK "fork"   // also clone() for a process.
+#define KM_TRACE_ARGS "args"
 
 /*
  * The km definition of the link_map structure in runtime/musl/include/link.h

--- a/km/km_exec.h
+++ b/km/km_exec.h
@@ -13,11 +13,17 @@
 #ifndef __KM_EXEC_H__
 #define __KM_EXEC_H__
 
+static const_string_t KMPATH = "KMPATH";
+static const_string_t SHELL_PATH = "/bin/sh";
+
+extern char** km_exec_payload_env;
+
 extern char** km_exec_build_env(char** envp);
 extern char** km_exec_build_argv(char* filename, char** argv);
 extern int km_exec_recover_kmstate(void);
 extern int km_exec_recover_guestfd(void);
 extern void km_exec_init(int argc, char** argv);
 extern void km_exec_fini(void);
+extern char* km_get_payload_name(char* payload_file, char** extra_arg);
 
 #endif   // !defined(__KM_EXEC_H__)

--- a/km/km_fork.c
+++ b/km/km_fork.c
@@ -10,8 +10,11 @@
  * permission of Kontain Inc.
  */
 
+#define _GNU_SOURCE
 #include <assert.h>
 #include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/mman.h>
@@ -189,6 +192,13 @@ static void km_fork_child_vm_init(void)
 
 /*
  * fork() or clone() prefix function.
+ * For a clone:
+ *  arg->arg1 - flags
+ *  arg->arg2 - child_stack
+ *  arg->arg3 - ptid
+ *  arg->arg4 - ctid
+ *  arg->arg5 - newtls
+ * For a fork: no args
  */
 int km_before_fork(km_vcpu_t* vcpu, km_hc_args_t* arg, uint8_t is_clone)
 {
@@ -201,17 +211,61 @@ int km_before_fork(km_vcpu_t* vcpu, km_hc_args_t* arg, uint8_t is_clone)
       km_mutex_unlock(&km_fork_state.mutex);
       return -errno;
    }
+   if (is_clone != 0) {
+      km_infox(KM_TRACE_FORK,
+               "clone args: flags 0x%lx, child_stack 0x%lx, ptid 0x%lx, ctid 0x%lx, newtls 0x%lx",
+               arg->arg1,
+               arg->arg2,
+               arg->arg3,
+               arg->arg4,
+               arg->arg5);
+      km_infox(KM_TRACE_FORK,
+               "child 0x%llx, arg 0x%llx, child_stack 0x%llx",
+               km_fork_state.regs.rdi,
+               km_fork_state.regs.rcx,
+               km_fork_state.regs.rsi);
+   }
    km_fork_state.fork_in_progress = 1;
    km_fork_state.is_clone = is_clone;
    km_fork_state.km_parent_pid = machine.pid;
    km_fork_state.km_child_pid = km_newpid();
    km_fork_state.arg = arg;
-   km_fork_state.stack_top = vcpu->stack_top;
+
+   /*
+    * If a child stack was supplied with the clone() hypercall then we need to set it up with a copy
+    * km_hc_args_t on that stack so that musl clone code (see runtime/clone_km.s) can take the
+    * km_hc_args_t off the stack before calling the child function.  We also need to set the child
+    * return value to zero.
+    */
+   if (is_clone != 0 && arg->arg2 != 0) {
+      km_fork_state.stack_top = arg->arg2;
+
+      km_kma_t kma_sp = km_gva_to_kma(km_fork_state.arg->arg2);
+      kma_sp -= sizeof(km_hc_args_t);
+      memcpy(kma_sp, km_fork_state.arg, sizeof(km_hc_args_t));
+      *(uint64_t*)kma_sp = 0;
+      km_fork_state.regs.rsp = km_fork_state.arg->arg2 - sizeof(km_hc_args_t);
+   } else {
+      km_fork_state.stack_top = vcpu->stack_top;
+   }
    km_fork_state.guest_thr = vcpu->guest_thr;
    km_fork_state.sigaltstack = vcpu->sigaltstack;
 
    km_mutex_unlock(&km_fork_state.mutex);
    return 0;
+}
+
+static void km_fork_wait_for_gdb_attach(void)
+{
+   char* envp = getenv("KM_WAIT_FOR_GDB_ATTACH");
+   volatile int keep_waiting = 1;
+
+   if (envp != NULL) {
+      fprintf(stderr, "Waiting for gdb attach, pid %d, \"set var keep_waiting=0\"\n", getpid());
+      while (keep_waiting != 0) {
+         sleep(1);
+      }
+   }
 }
 
 /*
@@ -252,12 +306,22 @@ int km_dofork(int* in_child)
    km_trace_include_pid(1);   // include the pid in trace output
    if (km_fork_state.is_clone != 0) {
       km_hc_args_t* arg = km_fork_state.arg;
+      uint64_t clone_flags = arg->arg1;
+      if ((clone_flags & (CLONE_VM | CLONE_VFORK)) == (CLONE_VM | CLONE_VFORK)) {
+         /*
+          * musl posix_spawn() uses these options which km doesn't yet support.  Suppress and give
+          * them traditional fork() semantics
+          */
+         clone_flags &= ~(CLONE_VM | CLONE_VFORK);
+      }
       linux_child_pid =
-          syscall(SYS_clone, arg->arg1, arg->arg2, arg->arg3, (uint64_t)km_gva_to_kma(arg->arg4), arg->arg5);
+          syscall(SYS_clone, clone_flags, NULL, arg->arg3, (uint64_t)km_gva_to_kma(arg->arg4), arg->arg5);
    } else {
       linux_child_pid = fork();
    }
-   if (linux_child_pid == 0) {   // this is the child process
+   if (linux_child_pid == 0) {         // this is the child process
+      km_fork_wait_for_gdb_attach();   // if they have asked, let them attach the debugger to the child
+
       // Set the child's km pid immediately so km_info() reports correct process id.
       machine.pid = km_fork_state.km_child_pid;
       km_infox(KM_TRACE_FORK, "child: after fork/clone");

--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -34,6 +34,7 @@
 #include "km_proc.h"
 #include "km_syscall.h"
 #include "x86_cpu.h"
+#include "km_exec.h"
 
 /*
  * Allocate stack for main thread and initialize it according to ABI:
@@ -205,6 +206,7 @@ km_gva_t km_init_main(km_vcpu_t* vcpu, int argc, char* const argv[], int envc, c
    stack_top_kma -= envp_sz;
    stack_top -= envp_sz;
    memcpy(stack_top_kma, km_envp, envp_sz);
+   km_exec_payload_env = stack_top_kma;
 
    // place argv array
    stack_top_kma -= sizeof(argv_km);

--- a/km/km_trace.c
+++ b/km/km_trace.c
@@ -107,3 +107,8 @@ void km_trace_include_pid(uint8_t trace_pid)
 {
    km_trace_pid = trace_pid;
 }
+
+uint8_t km_trace_include_pid_value(void)
+{
+   return km_trace_pid;
+}

--- a/tests/pipetarget_test.c
+++ b/tests/pipetarget_test.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ */
+
+/*
+ * This is a small program used by the popen_test program as the command supplied to popen().
+ * You can write data to it via the pipe and the data is written to a file.
+ * Or this program can read data from a file and write it into the pipe back to the popen_test program.
+ *
+ *  pipetarget_test readfrompipe destfile
+ *  pipetarget_test writetopipe sourcefile
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+static char* PIPEWRITE = "writetoparent";
+static char* PIPEREAD = "readfromparent";
+
+void usage(void)
+{
+   fprintf(stderr, "pipetarget_test {%s|%s} filename\n",
+           PIPEWRITE, PIPEREAD);
+}
+
+int main(int argc, char* argv[])
+{
+   char linebuf[1024];
+   if (argc != 3) {
+      usage();
+      return 1;
+   }
+   if (strcmp(argv[1], PIPEREAD) == 0) {  // read from pipe, write into file
+      FILE* o = fopen(argv[2], "w");
+      if (o != NULL) {
+         while (fgets(linebuf, sizeof(linebuf), stdin) != NULL) {
+            fputs(linebuf, o);
+         }
+         fclose(o);
+      } else {
+         fprintf(stderr, "couldn't open %s for write, %s\n", argv[2], strerror(errno));
+         return 1;
+      }
+   } else if (strcmp(argv[1], PIPEWRITE) == 0) {  // open file for read, write into pipe
+      FILE* i = fopen(argv[2], "r");
+      if (i != NULL) {
+         while (fgets(linebuf, sizeof(linebuf), i) != NULL) {
+            fputs(linebuf, stdout);
+         }
+         fclose(i);
+      } else {
+         fprintf(stderr, "couldn't open %s for read, %s\n", argv[2], strerror(errno));
+         return 1;
+      }
+   } else {
+      fprintf(stderr, "Unknown operation %s, must be either %s or %s\n",
+              argv[1],
+              PIPEWRITE,
+              PIPEREAD);
+      return 1;
+   }
+   return 0;
+}

--- a/tests/popen_test.c
+++ b/tests/popen_test.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2020 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ */
+
+/*
+ * A small program to test popen() in 2 ways:
+ * - write the contents of a file to pipetarget_test via a pipe amd cat writes the data to a file
+ * - pipetarget_test reads a file and writes to stdout which is a pipe and this program reads the data and
+ *   writes to a file.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+char* progname;
+
+static void usage(void)
+{
+   fprintf(stderr, "Usage:\n  %s data_file outfile1 outfile2\n", progname);
+}
+
+int main(int argc, char* argv[])
+{
+   FILE* p;
+   char linebuf[1024];
+   char cmdbuf[512];
+   int exit_status;
+   char* testprog = "./pipetarget_test";
+
+   progname = argv[0];
+
+   if (argc != 4) {
+      usage();
+      return 1;
+   }
+
+   // Cleanup
+   unlink(argv[2]);
+   unlink(argv[3]);
+
+   char* env_testprog = getenv("TESTPROG");
+   if (env_testprog != NULL) {
+      fprintf(stderr, "Override testprog %s with %s\n", testprog, env_testprog);
+      testprog = env_testprog;
+   }
+
+   snprintf(cmdbuf, sizeof(cmdbuf), "%s writetoparent %s", testprog, argv[1]);
+   FILE* o;
+   o = fopen(argv[2], "w");
+   if (o == NULL) {
+      fprintf(stderr, "couldn't open %s for write, %s\n", argv[2], strerror(errno));
+      exit(1);
+   }
+   p = popen(cmdbuf, "r");
+   if (p == NULL) {
+      fclose(o);
+      fprintf(stderr, "popen %s failed, %s\n", cmdbuf, strerror(errno));
+      return 1;
+   }
+   while (fgets(linebuf, sizeof(linebuf), p) != NULL) {
+      fprintf(o, "%s", linebuf);
+   }
+   fclose(o);
+   exit_status = pclose(p);
+   fprintf(stdout, "command: %s, exit status 0x%x\n", cmdbuf, exit_status);
+   if (exit_status != 0) {
+      return 1;
+   }
+
+   snprintf(cmdbuf, sizeof(cmdbuf), "%s readfromparent %s", testprog, argv[3]);
+   FILE* i;
+   i = fopen(argv[1], "r");
+   if (i == NULL) {
+      fprintf(stderr, "couldn't open %s for read, %s\n", argv[1], strerror(errno));
+      exit(1);
+   }
+   p = popen(cmdbuf, "w");
+   if (p == NULL) {
+      fclose(i);
+      fprintf(stderr, "popen %s failed, %s\n", cmdbuf, strerror(errno));
+      return 1;
+   }
+   while (fgets(linebuf, sizeof(linebuf), i) != NULL) {
+      fprintf(p, "%s", linebuf);
+   }
+   fclose(i);
+   exit_status = pclose(p);
+   fprintf(stdout, "command: %s, exit status 0x%x\n", cmdbuf, exit_status);
+   if (exit_status != 0) {
+      return 1;
+   }
+
+   return 0;
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -109,6 +109,12 @@ function km_with_timeout () {
             shift
             break
             ;;
+         --putenv)
+            # The putenv arg may contain $ext, so grab the arg here to avoid *$ext below
+            __args="$__args $1"
+            shift
+            __args="$__args $1"
+            ;;
          *$ext)
             break
             ;;


### PR DESCRIPTION
This involved:
Added pid tracing flag to exec state so that after exec we still trace the pid.
Fix km process clone to correctly handle user supplied stacks
Fix km exec to handle popen's use of /bin/sh to run commands
Added a bats popen/pclose test

All bats test pass on my local workstation.