### PR TITLE
file descriptors translations

### DIFF
--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -266,7 +266,7 @@ static km_hc_ret_t sendrecvmsg_hcall(void* vcpu, int hc, km_hc_args_t* arg)
       arg->hc_ret = -EFAULT;
       return HC_CONTINUE;
    }
-   msg.msg_name = km_gva_to_kma_nocheck((uint64_t)msg_kma->msg_name);   // optional
+   msg.msg_name = km_gva_to_kma((uint64_t)msg_kma->msg_name);   // optional
    msg.msg_namelen = msg_kma->msg_namelen;
    msg.msg_iovlen = msg_kma->msg_iovlen;
    struct iovec iov[msg.msg_iovlen];
@@ -281,7 +281,7 @@ static km_hc_ret_t sendrecvmsg_hcall(void* vcpu, int hc, km_hc_args_t* arg)
       iov[i].iov_len = iov_kma[i].iov_len;
    }
    msg.msg_iov = iov;
-   msg.msg_control = km_gva_to_kma_nocheck((uint64_t)msg_kma->msg_control);   // optional
+   msg.msg_control = km_gva_to_kma((uint64_t)msg_kma->msg_control);   // optional
    msg.msg_controllen = msg_kma->msg_controllen;
    msg.msg_flags = msg_kma->msg_flags;
    arg->hc_ret = km_fs_sendrecvmsg(vcpu, hc, arg->arg1, &msg, arg->arg3);


### PR DESCRIPTION
Support for send/receive file descriptors via {send,recv}msg. fixes in guest <-> host fd translation.

This is to make node concurrency work. Turns out there were a couple of issues. The main one is that `{send,recv}msg` mechanism for sending/receiving file descriptors is entirely broken in km. Node uses that to communicate between workers.

While looking at the km traces I noticed there were duplicate close syscalls. Tracking it down revealed `dup{2,3}` implementation would try to close the new fd twice. No real harm but not exactly pretty.

Regular tests pass. Node concurrency tests now start the multiple workers as required. Traces show the fd passing works as it should. Many of the node tests fail after that for multiple reasons such as unsupported hcalls.

I'd like to merge this and keep on node concurrency.

John, I'd like you to look specifically into the changes in host <-> guest fd translation to confirm I got it right.
