### PR TITLE
Add debug to the BATS sigsuspend test.

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -876,7 +876,7 @@ fi
    LINUXOUT=/tmp/sigsuspend_linuxout.$$
    KMOUT=/tmp/sigsuspend_kmout.$$
 
-echo "# === start linux sigsuspend === " >&3
+   echo "# === start linux sigsuspend === " >&3
    rm -f $FLAGFILE $KMTRACE
    ./sigsuspend_test $FLAGFILE >$LINUXOUT &
    pid=$!
@@ -885,7 +885,7 @@ echo "# === start linux sigsuspend === " >&3
    do
       sleep .1
       now=`date +%s`
-echo "# === now $now ===" >&3
+      echo "# === now $now ===" >&3
       test `expr $now - $start` -lt $WAIT
       assert_success
    done
@@ -894,7 +894,7 @@ echo "# === now $now ===" >&3
    kill -SIGUSR2 $pid
    wait $pid
 
-echo "# === start km sigsuspend ===" >&3
+   echo "# === start km sigsuspend ===" >&3
    rm -f $FLAGFILE $KMTRACE
    $KM_BIN -V sigsuspend_test$ext $FLAGFILE >$KMOUT 2>$KMTRACE &
 #   km_with_timeout sigsuspend_test$ext $FLAGFILE >$KMOUNT 2>$KMTRACE &
@@ -904,7 +904,7 @@ echo "# === start km sigsuspend ===" >&3
    do
       sleep .1
       now=`date +%s`
-echo "# === now $now ===" >&3
+      echo "# === now $now ===" >&3
       if test `expr $now - $start` -ge $WAIT
       then
          # Put the km trace in the TAP stream
@@ -919,7 +919,7 @@ echo "# === now $now ===" >&3
    kill -SIGUSR2 $pid
    wait $pid
    rm -f $FLAGFILE
-echo "# === done with km sigsuspend test ===" >&3
+   echo "# === done with km sigsuspend test ===" >&3
 
    # Debug.
    diff $LINUXOUT $KMOUT


### PR DESCRIPTION
Change the test to wait up to 5 seconds for the flagfile to come into existence,
in place of the current 1000 .01 second sleeps.
If the flagfile doesn't appear in 5 seconds, the test will dump the km trace for the test into
the TAP stream which should show up in the CI log.