### PR TITLE
added trivial tgkil (with no group support)

### DIFF
--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -998,9 +998,21 @@ static km_hc_ret_t kill_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
+static km_hc_ret_t tgkill_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   // int tgkill(int tgid, int tid, int sig);
+   km_infox(KM_TRACE_HC, "Ignoring tgid %ld", arg->arg1);
+   arg->hc_ret = km_tkill(vcpu, arg->arg2, arg->arg3);
+   return HC_CONTINUE;
+}
+
 static km_hc_ret_t tkill_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
    // int tkill(pid_t tid, int sig)
+   // From man(3): "tkill() is an obsolete predecessor to tgkill().  It allows only the target
+   // thread ID to be specified, which may result in the wrong thread being signaled if a thread
+   // terminates and its thread  ID is recycled.Avoid using this system call"
+   km_infox(KM_TRACE_HC, "tkill usage is not recommended, %ld can be reused", arg->arg1);
    arg->hc_ret = km_tkill(vcpu, arg->arg1, arg->arg2);
    return HC_CONTINUE;
 }
@@ -1705,6 +1717,7 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_sigaltstack] = sigaltstack_hcall;
    km_hcalls_table[SYS_kill] = kill_hcall;
    km_hcalls_table[SYS_tkill] = tkill_hcall;
+   km_hcalls_table[SYS_tgkill] = tgkill_hcall;
 
    km_hcalls_table[SYS_getpid] = getpid_hcall;
    km_hcalls_table[SYS_getppid] = getppid_hcall;

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -741,8 +741,9 @@ fi
 }
 
 @test "signals($test_type): signals in the guest (signals)" {
-   run km_with_timeout signal_test$ext -v
+   run km_with_timeout -Vhyper signal_test$ext -v
    assert_success
+   assert_line --partial "Ignoring tgid 100"
 }
 
 @test "pthread_cancel($test_type): (pthread_cancel_test$ext)" {

--- a/tests/signal_test.c
+++ b/tests/signal_test.c
@@ -227,6 +227,11 @@ TEST test_tkill()
    ASSERT_EQ(-1, syscall(SYS_tkill, 2, SIGUSR1));
    ASSERT_EQ(EINVAL, errno);
 
+   // sanity check for tgkill - same 'unused KM vcpu' as for tkill.
+   // group id (100) is supposed to be ignored, we will check in in bats
+   ASSERT_EQ(-1, syscall(SYS_tgkill, 100, 2, SIGUSR1));
+   ASSERT_EQ(EINVAL, errno);
+
    // bad signal numbers
    ASSERT_EQ(-1, syscall(SYS_tkill, 0, 0));
    ASSERT_EQ(EINVAL, errno);


### PR DESCRIPTION
knative go pert test uses tgkill so added it , essentially the same as tkill  - a quick hack  ignoring the group id in the hope that thread id won't be reused. 

The manual says 
```
       tgkill() sends the signal sig to the thread with the thread ID tid in the thread group tgid.  (By contrast, kill(2) can be used to send a signal only to a process (i.e., thread group) as a whole, and
       the signal will be delivered to an arbitrary thread within that process.)

       tkill() is an obsolete predecessor to tgkill().  It allows only the target thread ID to be specified, which may result in the wrong thread being signaled if a thread terminates and its thread  ID  is
       recycled.  Avoid using this system call.
```

At any rate, if we merge this I'll open a tracking issue for missing gid

basic sanity test included
