### PR TITLE
Multiple fixes and cleanup in python and symlinks

### DIFF
--- a/payloads/python/.gitignore
+++ b/payloads/python/.gitignore
@@ -1,2 +1,3 @@
 cpython
 cpython.*
+python

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -19,7 +19,7 @@ PYTHONTOP ?= cpython
 # component id for docker images
 COMPONENT := python
 
-# this is how we run python,km tests in container
+# this is how we run python.km tests in container
 CONTAINER_TEST_CMD := ./scripts/test-run.sh ./python
 
 # KM file name, relative to currentdir. Note that the same will be absolute in the container
@@ -62,6 +62,7 @@ ifneq ($(FROMSRC),yes)
 	${DOCKER_RUN_BUILD} \
 		-v ${TOP}:${TOP}:Z \
 		-v ${KM_OPT_RT}:${KM_OPT_RT}:Z \
+		-v ${KM_OPT_BIN}:${KM_OPT_BIN}:Z \
 		-w ${TOP}/payloads/python \
 		${BUILDENV_IMG}:${BUILDENV_IMAGE_VERSION} \
 		make in-blank-container EXTRA_LINKFILES="${EXTRA_LINKFILES}" CUSTOM_KM="${CUSTOM_KM}"
@@ -119,12 +120,14 @@ test-modules: ## Basic test pass - rebuilds python, rebuilds and pushes all modu
 	@echo TODO: run test over custom KM, including new modules test
 
 clean:
-	rm -rf $(PYTHONTOP)/*.km $(PYTHONTOP)/python $(foreach m,${ALL_MODULES},$(PYTHONTOP)/Modules/$m)
+	rm -rf $(PYTHONTOP)/*.km ./python $(PYTHONTOP)/python $(foreach m,${ALL_MODULES},$(PYTHONTOP)/Modules/$m)
 	rm -rf $(RUNENV_PATH)
 	@echo -e "${GREEN}Note: use 'make clobber' to clean up cpython build.${NOCOLOR}"
 
+# test locally same way as in container
 test test-all: ${PAYLOAD_KM} ${TEST_KM}
-	scripts/test-run.sh ${KM_BIN} ${PAYLOAD_KM}
+	ln -sf cpython/python .
+	${CONTAINER_TEST_CMD}
 
 clobber: ## Clobber cpython build by removing cpython dir
 	rm -rf cpython
@@ -134,7 +137,7 @@ clobber-modules:
 
 # Set info for runenv-image build
 RUNENV_VALIDATE_DIR := scripts
-RUNENV_VALIDATE_CMD := scripts/hello_again.py
+RUNENV_VALIDATE_CMD := scripts/sanity_test.py
 export define runenv_prep
 	tar -cf - ${PAYLOAD_FILES} | tar -C $(RUNENV_PATH) -xf -
 	cp ${PAYLOAD_KM} ${RUNENV_PATH}

--- a/payloads/python/buildenv-fedora.dockerfile
+++ b/payloads/python/buildenv-fedora.dockerfile
@@ -20,6 +20,10 @@ ARG BUILDENV_IMAGE_VERSION=latest
 FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} AS buildenv-cpython
 ARG VERS
 
+USER root
+RUN dnf install libffi-devel xz-devel -y && dnf clean all && rm -rf /var/cache/{dnf,yum}
+USER $USER
+
 RUN git clone https://github.com/python/cpython.git -b $VERS
 RUN cd cpython && ./configure && make -j`expr 2 \* $(nproc)` | tee bear.out
 
@@ -44,7 +48,8 @@ RUN mkdir -p ${BUILD_LOC} && chown $USER ${BUILD_LOC}
 COPY --from=buildenv-cpython --chown=appuser:appuser /home/$USER/cpython/builtins cpython/
 COPY --from=buildenv-cpython --chown=appuser:appuser /home/$USER/cpython/Lib/ cpython/Lib/
 COPY --from=buildenv-cpython --chown=appuser:appuser /home/$USER/cpython/Modules/ cpython/Modules/
-COPY --from=buildenv-cpython --chown=appuser:appuser /home/$USER/cpython/build/lib.linux-x86_64-3.7/_sysconfigdata_m_linux_x86_64-linux-gnu.py \
+COPY --from=buildenv-cpython --chown=appuser:appuser \
+   /home/$USER/cpython/build/lib.linux-x86_64-3.7/_sysconfigdata_m_linux_x86_64-linux-gnu.py \
    cpython/build/lib.linux-x86_64-3.7/_sysconfigdata_m_linux_x86_64-linux-gnu.py
 COPY --from=buildenv-cpython --chown=appuser:appuser /home/$USER/cpython/build/temp.linux-x86_64-3.7 cpython/build/temp.linux-x86_64-3.7/
 COPY --from=buildenv-cpython --chown=appuser:appuser /home/$USER/cpython/Programs/python.o cpython/Programs/python.o

--- a/payloads/python/runenv.dockerfile
+++ b/payloads/python/runenv.dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 
-ENV PYTHONPATH=/cpython/Lib:/cpython/build/lib.linux-x86_64-3.7 
+ENV PYTHONPATH=/cpython/Lib:/cpython/build/lib.linux-x86_64-3.7
 ENV PYTHONHOME=foo:bar
 
 COPY . /
-ENTRYPOINT [ "/opt/kontain/bin/km", "--copyenv", "python.km" ]
+ENTRYPOINT [ "/opt/kontain/bin/km","python.km" ]

--- a/payloads/python/scripts/sanity_test.py
+++ b/payloads/python/scripts/sanity_test.py
@@ -1,0 +1,13 @@
+# Very basic sanity checks for python in KM
+import os
+import _ctypes
+
+# If we are here, we run ok-ish
+if os.uname().sysname != "kontain-runtime":
+   raise BaseException(f"We don't seem to be running under Kontain Monitor.\n{os.uname()}")
+
+# make sure embedded modules (at least _ctypes)
+if '_objects' not in dir(_ctypes.Union):
+   raise BaseException(f"Error in built-in load: _objects not found in _ctypes.Union.\n{dir(_ctypes.Union)}")
+
+print("Hello from python in Kontain VM: sanity check passed")

--- a/payloads/python/scripts/test-run.sh
+++ b/payloads/python/scripts/test-run.sh
@@ -1,18 +1,11 @@
-#!/usr/bin/bash -ex
+#!/usr/bin/bash -e
 #
-# wrapper/entrypoint for running tests
+# Wrapper/entrypoint for running tests.
+#   test-run.sh PYTHON
+#   where PYTHON could be path to python->km symlink, or "km_path python.km_path"
 #
+PYTHON=${1:-Please_pass_python_interpreter}
 
-usage() {
-   cat <<EOF
-Run python tests. Usually called from Makefile or Docker Entry with proper params
-Usage: test-run.sh KM_BIN PAYLOAD_KM
-EOF
-   exit 1
-}
-
-KM_BIN=$1
-PAYLOAD_KM=$2
-
-${KM_BIN} ${PAYLOAD_KM} ./test_unittest.py
-${KM_BIN} ${PAYLOAD_KM} ./cpython/Lib/unittest/test/
+${PYTHON} ./scripts/sanity_test.py
+${PYTHON} ./test_unittest.py
+${PYTHON} ./cpython/Lib/unittest/test/


### PR DESCRIPTION
they were all done when chasing proper python invocation via symlinks and images cleanup, so they are bundled in the same PR

* Added handling of nested symlinks - we look for payload.km only at the last step, where symlinks points to KM
* Added python virtualenv cfg file so python selects correct libs without PYTHONPATH env
* added missing lib-ffl in Fedora buildenv - otherwise python configures to NOT use it and that excludes widely used _ctypes module
* corrected python images to use the above
* added sanity-check to python - validates we run in kontain and can load __ctypes which checks multiple steps in build
* made python container and on-the-box test use the same command

virtualenv cfg file info:

If python sees it' argv[0] as a symlink, it traverses to the target and tries to find
virtual env config file there. We use that by giving it virtenv file pointing back to the original cpython libs
It makes python->km approach work when KM and python are in different locations.

Tests included