### PR TITLE
Prerequisites for django/gunicorn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #   information is strictly prohibited without the express written permission of
 #   Kontain Inc.
 
-# scan all these and  'make' stuff there
+# scan all these and 'make' stuff there
 SUBDIRS := km runtime tests payloads
 
 # build VMM and runtime library before trying to build tests

--- a/docs/build.md
+++ b/docs/build.md
@@ -74,22 +74,61 @@ cat $file  | jq -r  '"export SP_APPID=\(.appId)",
 
 ### Pull the 'buildenv' image from Azure Container Registry
 
+We maintain docker build environment docker images that contain all build prerequisites.
+There is one build environment image for km, and one for each payload.
+They are called `kontain/buildenv-km-fedora` for km and `kontain/buildenv-`_payload_`-fedora` (e.g. `kontain/buildenv-python-fedora`).
+The km one is maintained by `Makefile` in `tests` directory, the payload ones in corresponding payload directories.
+Top directory goes down the tree recursively.
+
+To fetch a buildenv-image for km only:
+
+
 ```sh
 make -C tests pull-buildenv-image
 ```
 
-#### build the 'buildenv' image locally using Docker
+And for specific payload (e.g. python):
 
-An alternative way is to build 'build environment' images locally:
 
 ```sh
-make -C tests buildenv-image  # this will take VERY LONG time as it builds gcc and C++ libs
+make -C python pull-buildenv-image
 ```
+
+```sh
+make pull-buildenv-image
+```
+
+from the top will getch all of the build environments.
+
+
+#### build the 'buildenv' image locally using Docker
+
+An alternative way is to build 'build environment' images locally. Similarly to the above, this could be done in a specific directory (tests for km), or recursively to build them all.
+
+For km build environment:
+
+```sh
+make -C tests buildenv-image  # this will take VERY LONG time
+```
+
+and so forth.
 
 #### Install dependencies on the local machine (after buildenv image is available)
 
+Build environments also used to install the necessary packages and dependencies on the local system.
+Again it is maintained per directory in the same way as above.
+
+For km only:
+
+
 ```sh
 make -C tests buildenv-local-fedora  # currently supported on fedora only !
+```
+
+Or for all of the payloads and km:
+
+```sh
+make buildenv-local-fedora  # currently supported on fedora only !
 ```
 
 ### Building with Docker
@@ -299,7 +338,7 @@ older reports, checkout the repo and search using the tags.
 
 To see coverage for your tag, run the following:
 ```bash
-cd ~/workspace 
+cd ~/workspace
 git clone -b **your_tag** git@github.com:kontainapp/km-coverage-report.git
 google-chrome   km-coverage-report/index.html
 ```

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -46,6 +46,7 @@ test-all: subdirs ## run extended tests(KM tests full payload tests)
 coverage: subdirs ## build and run tests with code coverage support
 covclean: subdirs ## clean coverage-related build artifacts
 buildenv-image: subdirs ## builds and packages all build environment image
+buildenv-local-fedora: subdirs ## make local build environment for KM
 push-buildenv-image: subdirs ## Push buildenv images to a cloud registry. PROTECTED OPERATION.
 pull-buildenv-image: subdirs ## Pulls buildenv images from a cloud registry
 testenv-image: subdirs ## builds and packages testable image

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -54,6 +54,7 @@ FROMSRC=$(shell test -d $(PYTHONTOP)/.git && echo yes)
 # Compile built-in extensions (if needed) and link python.km
 export define link_cpython_km
 	${MAKE} -C cpython -f dlstatic_km.mk   # compile built-in modules
+	patch -p0 < platform_uname.patch
 	./link-km.sh ${PYTHONTOP} cpython "${EXTRA_LINKFILES}" "${CUSTOM_KM}"
 endef
 

--- a/payloads/python/extensions/skip_builtins.txt
+++ b/payloads/python/extensions/skip_builtins.txt
@@ -9,7 +9,6 @@ _uuid
 _curses
 _curses_panel
 readline
-termios
 xxlimited
 _xxtestfuzz
 _multibytecodec
@@ -21,7 +20,6 @@ _codecs_cn
 _codecs_tw
 _codecs_hk
 _codecs_iso2022
-_sqlite3
 _tkinter
 _dbm
 _gdbm

--- a/payloads/python/platform_uname.patch
+++ b/payloads/python/platform_uname.patch
@@ -1,0 +1,11 @@
+--- /home/serge/platform.py	2020-05-27 17:38:32.970703906 -0700
++++ ./cpython/Lib/platform.py	2020-05-28 11:31:19.083226637 -0700
+@@ -1031,7 +1031,7 @@
+                 processor = 'VAX'
+     if not processor:
+         # Get processor information from the uname system command
+-        processor = _syscmd_uname('-p', '')
++        processor = 'x86_64' if os.uname().machine == 'kontain_VM' else _syscmd_uname('-p', '')
+ 
+     #If any unknowns still exist, replace them with ''s, which are more portable
+     if system == 'unknown':

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -217,33 +217,6 @@ MANUAL_UPLOAD_REPORT_NAME := manual-${USER}-${PROCESSED_IMAGE_VERION}
 upload-coverage-manual: .check_vars
 	${UPLOAD_COVERAGE_SCRIPT} ${COVERAGE_KM_BLDDIR} ${MANUAL_UPLOAD_REPORT_NAME} ${GITHUB_TOKEN}
 
-# install stuff for fedora per docker image info. Assume buildenv-image either built or pulled
-# TODO: maybe make it generic to scan folders
-buildenv-local-fedora:  ${KM_OPT_RT} ## make local build environment for KM
-	@if ! docker image inspect ${BUILDENV_IMG} > /dev/null ; then \
-		echo -e "$(RED)${BUILDENV_IMG} is not available. Use 'make buildenv-image' or 'make pull-buildenv-image' to build or pull$(NOCOLOR)"; false; fi
-	sudo dnf install -y `docker history --format "{{ .CreatedBy }}" --no-trunc ${BUILDENV_IMG} | sed -rn '/dnf install/s/.*dnf install -y([^&]*)(.*)/\1/p'`
-# Install stuff needed for buil, based on docker image info.
-# Assume BUILDENV_IMG either built or pulled
-buildenv-local-fedora: .buildenv-local-dnf .buildenv-local-lib ## make local build environment for KM
-
-# Get a list of DNF packages from buildenv-image and install it on the host
-.buildenv-local-dnf: .buildenv-local-check-image
-	sudo dnf install -y `docker history --format "{{ .CreatedBy }}" --no-trunc ${BUILDENV_IMG}:$(BUILDENV_IMAGE_VERSION) | sed -rn '/dnf install/s/.*dnf install -y([^&]*)(.*)/\1/p'`
-
-# Fetches alpine libs, and preps writeable 'runtime' dir.
-# It'd a prerequisite for all further builds and needs to be called right after building
-# or pull the buildenv-image. Call it via 'make buildenv-local-fedora' or 'make .buildenv-local-lib'
-# so that libs are on the host and can be copied to runenv-image and testenv-image
-.buildenv-local-lib: ${KM_OPT_RT} ${KM_OPT_BIN} .buildenv-local-check-image
-	docker create --name tmp_env $(BUILDENV_IMG):$(BUILDENV_IMAGE_VERSION)
-	sudo docker cp tmp_env:/opt/kontain /opt
-	docker rm tmp_env
-
-.buildenv-local-check-image:
-	@if ! docker image inspect ${BUILDENV_IMG}:$(BUILDENV_IMAGE_VERSION) > /dev/null ; then \
-		echo -e "$(RED)${BUILDENV_IMG}:$(BUILDENV_IMAGE_VERSION) is not available. Use 'make buildenv-image' or 'make pull-buildenv-image' to build or pull$(NOCOLOR)"; false; fi
-
 ${KM_OPT_RT} ${KM_OPT_BIN}: |
 	sudo sh -c "mkdir -p $@ && chgrp users $@ && chmod 777 $@"
 

--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -57,8 +57,7 @@ RUN dnf install -y \
    glibc-devel glibc-static libstdc++-static \
    elfutils-libelf-devel elfutils-libelf-devel-static bzip2-devel \
    zlib-static bzip2-static xz-static \
-   openssl-devel openssl-static \
-   expat-static jq googler python3-jinja2 \
+   openssl-devel openssl-static jq googler \
    && dnf upgrade -y && dnf clean all && rm -rf /var/cache/{dnf,yum}
 
 COPY --from=alpine-lib-image $PREFIX $PREFIX/


### PR DESCRIPTION
rework make buildenv-local-fedora to go recursively into subdirs
rearrange prerequisites for python, add sqlite3 and termios
patch platform.py for uname issues
