### PR TITLE
Fixed java-validate-runenv and made mounts more specific [TRIVIAL]

### DIFF
--- a/make/images.mk
+++ b/make/images.mk
@@ -144,8 +144,8 @@ RUNENV_VALIDATE_EXPECTED ?= Hello
 # We use km from ${KM_BIN} here from the build tree instead of what's on the host under ${KM_OPT_BIN}.
 validate-runenv-image: $(RUNENV_VALIDATE_DEPENDENCIES) ## Validate runtime image
 	${DOCKER_RUN_TEST} \
-		-v ${KM_OPT_BIN}:${KM_OPT_BIN}:z \
-		-v ${KM_OPT_RT}:${KM_OPT_RT}:z \
+		-v ${KM_OPT_KM}:${KM_OPT_KM}:z \
+		-v ${KM_OPT_LDSO}:${KM_OPT_LDSO}:z \
 		${SCRIPT_MOUNT} \
 		${RUNENV_IMG}:${IMAGE_VERSION} \
 		${RUNENV_VALIDATE_CMD} | grep "${RUNENV_VALIDATE_EXPECTED}"

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -45,6 +45,7 @@ KM_OPT_BIN := ${KM_OPT}/bin
 KM_OPT_RT := ${KM_OPT}/runtime
 KM_OPT_ALPINELIB := ${KM_OPT}/alpine-lib
 KM_OPT_LDSO := ${KM_OPT_RT}/libc.so
+KM_OPT_KM := ${KM_OPT_BIN}/km
 KM_LDSO := ${BLDTOP}/runtime/libc.so
 KM_LDSO_PATH := ${KM_OPT_RT}:${KM_OPT_ALPINELIB}/usr/lib
 

--- a/payloads/java/runenv.dockerfile
+++ b/payloads/java/runenv.dockerfile
@@ -18,8 +18,10 @@ ARG FROM=jdk-11.0.6+10/build/linux-x86_64-normal-server-release/images/jdk
 ARG JAVA_DIR=/opt/kontain/java
 ENV LD_LIBRARY_PATH ${JAVA_DIR}/lib/server:${JAVA_DIR}/lib/jli:${JAVA_DIR}/lib:/opt/kontain/runtime:/lib64
 
-COPY jdk-11.0.6+10/build/linux-x86_64-normal-server-release/images/jdk/ ${JAVA_DIR}/
-RUN mkdir /lib64; ln -s /opt/kontain/runtime/libc.so /lib64/ld-linux-x86-64.so.2 ; \
-   ln -s /opt/kontain/bin/km  ${JAVA_DIR}/bin/java
+COPY ${FROM}/ ${JAVA_DIR}/
+# Java is looking for /lib64/ld-linux-x86-64.so.2 so below is the hack to shortcut investigation
+RUN mkdir /lib64; ln -s /opt/kontain/runtime/libc.so /lib64/ld-linux-x86-64.so.2
+RUN ln -s /opt/kontain/bin/km  ${JAVA_DIR}/bin/java; \
+   ln -s  ${JAVA_DIR}/bin/java.kmd ${JAVA_DIR}/bin/java.km
 
 ENTRYPOINT [ "/opt/kontain/java/bin/java" ]


### PR DESCRIPTION
runenv-image in java missed java.km link so validate failed. 
Fixed, and also made mounts for validate more specific

Tested manually