### PR TITLE
Remove messages from bats tests

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -878,7 +878,6 @@ fi
    LINUXOUT=/tmp/sigsuspend_linuxout.$$
    KMOUT=/tmp/sigsuspend_kmout.$$
 
-   echo "# === start linux sigsuspend === " >&3
    rm -f $FLAGFILE $KMTRACE
    ./sigsuspend_test.fedora $FLAGFILE >$LINUXOUT &
    pid=$!
@@ -887,7 +886,6 @@ fi
    do
       sleep .1
       now=`date +%s`
-      echo "# === now $now ===" >&3
       test `expr $now - $start` -lt $WAIT
       assert_success
    done
@@ -896,7 +894,6 @@ fi
    kill -SIGUSR2 $pid
    wait $pid
 
-   echo "# === start km sigsuspend ===" >&3
    rm -f $FLAGFILE $KMTRACE
    $KM_BIN -V sigsuspend_test$ext $FLAGFILE >$KMOUT 2>$KMTRACE &
 #   km_with_timeout sigsuspend_test$ext $FLAGFILE >$KMOUNT 2>$KMTRACE &
@@ -906,7 +903,6 @@ fi
    do
       sleep .1
       now=`date +%s`
-      echo "# === now $now ===" >&3
       if test `expr $now - $start` -ge $WAIT
       then
          # Put the km trace in the TAP stream
@@ -921,7 +917,6 @@ fi
    kill -SIGUSR2 $pid
    wait $pid
    rm -f $FLAGFILE
-   echo "# === done with km sigsuspend test ===" >&3
 
    # Debug.
    diff $LINUXOUT $KMOUT
@@ -1041,7 +1036,6 @@ fi
    assert_success
 
    # now test with full path to pipetarget_test and no PATH var
-echo " === last test ===" >&3
    run km_with_timeout -V --putenv TESTPROG=`pwd`/pipetarget_test.kmd -V popen_test$ext /etc/group /tmp/f1 /tmp/f2 2>/tmp/xx
    assert_success
 }


### PR DESCRIPTION
The sigsuspend and popen tests had some extra messages that we don't need anymore.

Tested by running the bats tests on my workstation.