### PR TITLE
Fix size calculation errors in coredump

### DIFF
--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -127,6 +127,11 @@ km_core_write_load_header(int fd, off_t offset, km_gva_t base, size_t size, int 
    km_core_write(fd, &phdr, sizeof(Elf64_Phdr));
 }
 
+size_t km_note_header_size(char* owner)
+{
+   return sizeof(Elf64_Nhdr) + strlen(owner);
+}
+
 // TODO padding?
 int km_add_note_header(char* buf, size_t length, char* owner, int type, size_t descsz)
 {
@@ -536,19 +541,19 @@ static inline size_t km_core_notes_length(km_vcpu_t* vcpu)
     * At the beginning ats the default and again in position.
     */
    size_t alloclen =
-       (sizeof(Elf64_Nhdr) + strlen(KM_NT_NAME) + sizeof(struct elf_prstatus)) * (nvcpu + nvcpu_inc);
+       (km_note_header_size(KM_NT_NAME) + sizeof(struct elf_prstatus)) * (nvcpu + nvcpu_inc);
    alloclen += km_mappings_size(NULL, NULL) + strlen(KM_NT_NAME) + sizeof(Elf64_Nhdr);
-   alloclen += machine.auxv_size + sizeof(Elf64_Nhdr) + strlen(KM_NT_NAME);
+   alloclen += machine.auxv_size + km_note_header_size(KM_NT_NAME);
 
    // Kontain specific per CPU info (for snapshot restore)
-   alloclen += (sizeof(Elf64_Nhdr) + strlen(KM_NT_NAME) + sizeof(struct km_nt_vcpu)) * nvcpu;
+   alloclen += (km_note_header_size(KM_NT_NAME) + sizeof(struct km_nt_vcpu)) * nvcpu;
 
    // Kontain specific guest info(for snapshot restore)
-   alloclen += sizeof(Elf64_Nhdr) + strlen(KM_NT_NAME) + sizeof(km_nt_guest_t) +
+   alloclen += km_note_header_size(KM_NT_NAME) + sizeof(km_nt_guest_t) +
                km_guest.km_ehdr.e_phnum * sizeof(Elf64_Phdr) +
                km_nt_file_padded_size(km_guest.km_filename);
    if (km_dynlinker.km_filename != NULL) {
-      alloclen += sizeof(Elf64_Nhdr) + strlen(KM_NT_NAME) + sizeof(km_nt_guest_t) +
+      alloclen += km_note_header_size(KM_NT_NAME) + sizeof(km_nt_guest_t) +
                   km_dynlinker.km_ehdr.e_phnum * sizeof(Elf64_Phdr) +
                   km_nt_file_padded_size(km_dynlinker.km_filename);
    }

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -89,6 +89,7 @@ static inline size_t km_nt_file_padded_size(char* str)
 void km_dump_core(char* filename, km_vcpu_t* vcpu, x86_interrupt_frame_t* iframe);
 void km_set_coredump_path(char* path);
 char* km_get_coredump_path();
+size_t km_note_header_size(char* owner);
 int km_add_note_header(char* buf, size_t length, char* owner, int type, size_t descsz);
 
 #endif

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1238,7 +1238,7 @@ size_t km_fs_core_notes_length()
    for (int i = 0; i < km_fs()->nfdmap; i++) {
       km_file_t* file = &km_fs()->guest_files[i];
       if (file->inuse != 0) {
-         ret += sizeof(Elf64_Nhdr) + strlen(KM_NT_NAME) + sizeof(km_nt_file_t) +
+         ret += km_note_header_size(KM_NT_NAME) + sizeof(km_nt_file_t) +
                 km_nt_file_padded_size(file->name);
       }
    }


### PR DESCRIPTION
There where a number of errors calculating the size of the PT_NOTES
section of KM core dumps. These where hidden most of the time because
we round the computed size up to the next page boundary.

Added support for no current VCPU (will be used by externally generated snapshot code).