### PR TITLE
Fix fork_test to exec to a symlink named for the payload

### DIFF
--- a/km/km_exec.c
+++ b/km/km_exec.c
@@ -536,10 +536,10 @@ char** km_exec_build_argv(char* filename, char** argv, char** envp)
       nargv[0] = km_get_self_name();                               // km exec
       return nargv;
    }
-   // not shebang, see if it is a symlink
+   // not shebang, got to be symlink
    if ((pl_name = km_traverse_payload_symlinks(filename)) == NULL) {
-      // not a symlink, just use the filename
-      pl_name = filename;
+      freevector(argv, shell);
+      return NULL;
    }
 
    if ((nargv = calloc(1 + argc + 1, sizeof(char*))) == NULL) {   // km exec, cnt, and NULL

--- a/tests/fork_test.c
+++ b/tests/fork_test.c
@@ -32,7 +32,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#define HELLO_WORLD_TEST "hello_test.kmd"
+#define HELLO_WORLD_TEST "hello_test"
 
 static char* args[] = {HELLO_WORLD_TEST, "one", "two", "three", "four", NULL};
 static char* env[] = {"ONE=one", "TWO=two", "THREE=three", "FOUR=four", "FIVE=five", NULL};


### PR DESCRIPTION
Also fix the fork_test to detect exec errors in the child processes it creates.