### PR TITLE
Add handling for SIGCANCEL signal used by musl for pthread_cancel.

### DIFF
--- a/km/km_gdb.h
+++ b/km/km_gdb.h
@@ -81,16 +81,144 @@ typedef enum {
    GDB_SIGNAL_USR2 = 31,     // SIGUSR2
    GDB_SIGNAL_PWR = 32,      // SIGPWR
    GDB_SIGNAL_POLL = 33,     // SIGPOLL
+   GDB_SIGNAL_WIND = 34,         // SIGWIND not available on linux
+   GDB_SIGNAL_PHONE = 35,         // SIGPHONE not available on linux
+   GDB_SIGNAL_WAITING = 36,       // SIGWAITING not available on linux
+   GDB_SIGNAL_LWP = 37,           // SIGLWP not available on linux
+   GDB_SIGNAL_DANGER = 38,        // SIGDANGER not available on linux
+   GDB_SIGNAL_GRANT = 39,         // SIGGRANT not available on linux
+   GDB_SIGNAL_RETRACT = 40,       // SIGRETRACT not available on linux
+   GDB_SIGNAL_MSG = 41,           // SIGMSG not available on linux
+   GDB_SIGNAL_SOUND = 42,         // SIGSOUND not available on linux
+   GDB_SIGNAL_SAK = 43,           // SIGSAK not available on linux
+   GDB_SIGNAL_PRIO = 44,          // SIGPRIO not available on linux
+   GDB_SIGNAL_REALTIME_33 = 45,   // SIG33, "Real-time event 33"
+   GDB_SIGNAL_REALTIME_34 = 46,   // SIG34, "Real-time event 34"
+   GDB_SIGNAL_REALTIME_35 = 47,   // SIG35, "Real-time event 35"
+   GDB_SIGNAL_REALTIME_36 = 48,   // SIG36, "Real-time event 36"
+   GDB_SIGNAL_REALTIME_37 = 49,   // SIG37, "Real-time event 37"
+   GDB_SIGNAL_REALTIME_38 = 50,   // "SIG38", "Real-time event 38"
+   GDB_SIGNAL_REALTIME_39 = 51,   // "SIG39", "Real-time event 39"
+   GDB_SIGNAL_REALTIME_40 = 52,   // "SIG40", "Real-time event 40"
+   GDB_SIGNAL_REALTIME_41 = 53,   // "SIG41", "Real-time event 41"
+   GDB_SIGNAL_REALTIME_42 = 54,   // "SIG42", "Real-time event 42"
+   GDB_SIGNAL_REALTIME_43 = 55,   // "SIG43", "Real-time event 43"
+   GDB_SIGNAL_REALTIME_44 = 56,   // "SIG44", "Real-time event 44"
+   GDB_SIGNAL_REALTIME_45 = 57,   // "SIG45", "Real-time event 45"
+   GDB_SIGNAL_REALTIME_46 = 58,   // "SIG46", "Real-time event 46"
+   GDB_SIGNAL_REALTIME_47 = 59,   // "SIG47", "Real-time event 47"
+   GDB_SIGNAL_REALTIME_48 = 60,   // "SIG48", "Real-time event 48"
+   GDB_SIGNAL_REALTIME_49 = 61,   // "SIG49", "Real-time event 49"
+   GDB_SIGNAL_REALTIME_50 = 62,   // "SIG50", "Real-time event 50"
+   GDB_SIGNAL_REALTIME_51 = 63,   // "SIG51", "Real-time event 51"
+   GDB_SIGNAL_REALTIME_52 = 64,   // "SIG52", "Real-time event 52"
+   GDB_SIGNAL_REALTIME_53 = 65,   // "SIG53", "Real-time event 53"
+   GDB_SIGNAL_REALTIME_54 = 66,   // "SIG54", "Real-time event 54"
+   GDB_SIGNAL_REALTIME_55 = 67,   // "SIG55", "Real-time event 55"
+   GDB_SIGNAL_REALTIME_56 = 68,   // "SIG56", "Real-time event 56"
+   GDB_SIGNAL_REALTIME_57 = 69,   // "SIG57", "Real-time event 57"
+   GDB_SIGNAL_REALTIME_58 = 70,   // "SIG58", "Real-time event 58"
+   GDB_SIGNAL_REALTIME_59 = 71,   // "SIG59", "Real-time event 59"
+   GDB_SIGNAL_REALTIME_60 = 72,   // "SIG60", "Real-time event 60"
+   GDB_SIGNAL_REALTIME_61 = 73,   // "SIG61", "Real-time event 61"
+   GDB_SIGNAL_REALTIME_62 = 74,   // "SIG62", "Real-time event 62"
+   GDB_SIGNAL_REALTIME_63 = 75,   // "SIG63", "Real-time event 63"
+
+   GDB_SIGNAL_CANCEL = 76,        // SIGCANCEL musl signal
+
+   GDB_SIGNAL_REALTIME_32 = 77,   // SIG32, "Real-time event 32"
+   GDB_SIGNAL_REALTIME_64 = 78,   // "SIG64", "Real-time event 64"
+   GDB_SIGNAL_REALTIME_65 = 79,   // "SIG65", "Real-time event 65"
+   GDB_SIGNAL_REALTIME_66 = 80,   // "SIG66", "Real-time event 66"
+   GDB_SIGNAL_REALTIME_67 = 81,   // "SIG67", "Real-time event 67"
+   GDB_SIGNAL_REALTIME_68 = 82,   // "SIG68", "Real-time event 68"
+   GDB_SIGNAL_REALTIME_69 = 83,   // "SIG69", "Real-time event 69"
+   GDB_SIGNAL_REALTIME_70 = 84,   // "SIG70", "Real-time event 70"
+   GDB_SIGNAL_REALTIME_71 = 85,   // "SIG71", "Real-time event 71"
+   GDB_SIGNAL_REALTIME_72 = 86,   // "SIG72", "Real-time event 72"
+   GDB_SIGNAL_REALTIME_73 = 87,   // "SIG73", "Real-time event 73"
+   GDB_SIGNAL_REALTIME_74 = 88,   // "SIG74", "Real-time event 74"
+   GDB_SIGNAL_REALTIME_75 = 89,   // "SIG75", "Real-time event 75"
+   GDB_SIGNAL_REALTIME_76 = 90,   // "SIG76", "Real-time event 76"
+   GDB_SIGNAL_REALTIME_77 = 91,   // "SIG77", "Real-time event 77"
+   GDB_SIGNAL_REALTIME_78 = 92,   // "SIG78", "Real-time event 78"
+   GDB_SIGNAL_REALTIME_79 = 93,   // "SIG79", "Real-time event 79"
+   GDB_SIGNAL_REALTIME_80 = 94,   // "SIG80", "Real-time event 80"
+   GDB_SIGNAL_REALTIME_81 = 95,   // "SIG81", "Real-time event 81"
+   GDB_SIGNAL_REALTIME_82 = 96,   // "SIG82", "Real-time event 82"
+   GDB_SIGNAL_REALTIME_83 = 97,   // "SIG83", "Real-time event 83"
+   GDB_SIGNAL_REALTIME_84 = 98,   // "SIG84", "Real-time event 84"
+   GDB_SIGNAL_REALTIME_85 = 99,   // "SIG85", "Real-time event 85"
+   GDB_SIGNAL_REALTIME_86 = 100,  // "SIG86", "Real-time event 86"
+   GDB_SIGNAL_REALTIME_87 = 101,  // "SIG87", "Real-time event 87"
+   GDB_SIGNAL_REALTIME_88 = 102,  // "SIG88", "Real-time event 88"
+   GDB_SIGNAL_REALTIME_89 = 103,  // "SIG89", "Real-time event 89"
+   GDB_SIGNAL_REALTIME_90 = 104,  // "SIG90", "Real-time event 90"
+   GDB_SIGNAL_REALTIME_91 = 105,  // "SIG91", "Real-time event 91"
+   GDB_SIGNAL_REALTIME_92 = 106,  // "SIG92", "Real-time event 92"
+   GDB_SIGNAL_REALTIME_93 = 107,  // "SIG93", "Real-time event 93"
+   GDB_SIGNAL_REALTIME_94 = 108,  // "SIG94", "Real-time event 94"
+   GDB_SIGNAL_REALTIME_95 = 109,  // "SIG95", "Real-time event 95"
+   GDB_SIGNAL_REALTIME_96 = 110,  // "SIG96", "Real-time event 96"
+   GDB_SIGNAL_REALTIME_97 = 111,  // "SIG97", "Real-time event 97"
+   GDB_SIGNAL_REALTIME_98 = 112,  // "SIG98", "Real-time event 98"
+   GDB_SIGNAL_REALTIME_99 = 113,  // "SIG99", "Real-time event 99"
+   GDB_SIGNAL_REALTIME_100 = 114, // "SIG100", "Real-time event 100"
+   GDB_SIGNAL_REALTIME_101 = 115, // "SIG101", "Real-time event 101"
+   GDB_SIGNAL_REALTIME_102 = 116, // "SIG102", "Real-time event 102"
+   GDB_SIGNAL_REALTIME_103 = 117, // "SIG103", "Real-time event 103"
+   GDB_SIGNAL_REALTIME_104 = 118, // "SIG104", "Real-time event 104"
+   GDB_SIGNAL_REALTIME_105 = 119, // "SIG105", "Real-time event 105"
+   GDB_SIGNAL_REALTIME_106 = 120, // "SIG106", "Real-time event 106"
+   GDB_SIGNAL_REALTIME_107 = 121, // "SIG107", "Real-time event 107"
+   GDB_SIGNAL_REALTIME_108 = 122, // "SIG108", "Real-time event 108"
+   GDB_SIGNAL_REALTIME_109 = 123, // "SIG109", "Real-time event 109"
+   GDB_SIGNAL_REALTIME_110 = 124, // "SIG110", "Real-time event 110"
+   GDB_SIGNAL_REALTIME_111 = 125, // "SIG111", "Real-time event 111"
+   GDB_SIGNAL_REALTIME_112 = 126, // "SIG112", "Real-time event 112"
+   GDB_SIGNAL_REALTIME_113 = 127, // "SIG113", "Real-time event 113"
+   GDB_SIGNAL_REALTIME_114 = 128, // "SIG114", "Real-time event 114"
+   GDB_SIGNAL_REALTIME_115 = 129, // "SIG115", "Real-time event 115"
+   GDB_SIGNAL_REALTIME_116 = 130, // "SIG116", "Real-time event 116"
+   GDB_SIGNAL_REALTIME_117 = 131, // "SIG117", "Real-time event 117"
+   GDB_SIGNAL_REALTIME_118 = 132, // "SIG118", "Real-time event 118"
+   GDB_SIGNAL_REALTIME_119 = 133, // "SIG119", "Real-time event 119"
+   GDB_SIGNAL_REALTIME_120 = 134, // "SIG120", "Real-time event 120"
+   GDB_SIGNAL_REALTIME_121 = 135, // "SIG121", "Real-time event 121"
+   GDB_SIGNAL_REALTIME_122 = 136, // "SIG122", "Real-time event 122"
+   GDB_SIGNAL_REALTIME_123 = 137, // "SIG123", "Real-time event 123"
+   GDB_SIGNAL_REALTIME_124 = 138, // "SIG124", "Real-time event 124"
+   GDB_SIGNAL_REALTIME_125 = 139, // "SIG125", "Real-time event 125"
+   GDB_SIGNAL_REALTIME_126 = 140, // "SIG126", "Real-time event 126"
+   GDB_SIGNAL_REALTIME_127 = 141, // "SIG127", "Real-time event 127"
+
+   GDB_SIGNAL_INFO = 142,         // SIGINFO, "Information request"
+
+   GDB_SIGNAL_UNKNOWN = 143,      // NULL, "Unknown signal"
+
+   GDB_SIGNAL_DEFAULT = 144,      // NULL, "Internal error: printing GDB_SIGNAL_DEFAULT"
+
+   GDB_EXC_BAD_ACCESS = 145,      // "EXC_BAD_ACCESS", "Could not access memory"
+   GDB_EXC_BAD_INSTRUCTION = 146, // "EXC_BAD_INSTRUCTION", "Illegal instruction/operand"
+   GDB_EXC_ARITHMETIC = 147,      // "EXC_ARITHMETIC", "Arithmetic exception"
+   GDB_EXC_EMULATION = 148,       // "EXC_EMULATION", "Emulation instruction"
+   GDB_EXC_SOFTWARE = 149,        // "EXC_SOFTWARE", "Software generated exception"
+   GDB_EXC_BREAKPOINT = 150,      // "EXC_BREAKPOINT", "Breakpoint"
+
+   GDB_SIGNAL_LIBRT = 151,        // "SIGLIBRT", "librt internal signal"
+
+   GDB_SIGNAL_LAST = 152,         // none
+
 } gdb_signal_number_t;
 
 #define GDB_SIGNONE (-1)
 #define GDB_SIGFIRST 0   // the guest hasn't run yet
 
 // Some pseudo signals that will be beyond the range of valid gdb signals.
-#define GDB_SIGNAL_LAST 1000   // arbitarily chosen large value
-#define GDB_KMSIGNAL_KVMEXIT (GDB_SIGNAL_LAST + 20)
-#define GDB_KMSIGNAL_THREADEXIT (GDB_SIGNAL_LAST + 21)
-#define GDB_KMSIGNAL_DOFORK (GDB_SIGNAL_LAST + 22)
+#define GDB_KMSIGNAL_BASE 1000   // arbitarily chosen large value
+#define GDB_KMSIGNAL_KVMEXIT (GDB_KMSIGNAL_BASE + 20)
+#define GDB_KMSIGNAL_THREADEXIT (GDB_KMSIGNAL_BASE + 21)
+#define GDB_KMSIGNAL_DOFORK (GDB_KMSIGNAL_BASE + 22)
 
 #define KM_TRACE_GDB "gdb"
 


### PR DESCRIPTION
Also added symbols for all of the GDB_SIGNAL_* signal numbers in case we need
them in the future.

We ran into a problem debugging the pthread_cancel_test where the SIGCANCEL signal was
scrambled by gdb's signal number translation applied when the signal goes to the gdb client
and then again when the signal comes back to gdb stub.
SIGCANCEL was not in the table of signals that gdb stub knew how to translate so it when
through unchanged on the way to the client but did get changed when the signal came back.

All of the bats tests on a local workstation passed.
