### PR TITLE
runenv-python uses /usr/local/bin/python3

### DIFF
--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -43,7 +43,7 @@ PAYLOAD_KM := cpython/python.km
 PAYLOAD_NAME := ${COMPONENT}
 
 # a list to be passed to tar to be packed into container image by 'make runenv-image'.
-PAYLOAD_FILES := --exclude='*/test/*' --exclude='*/__pycache__/*' --exclude '*.exe' --exclude '*.whl' \
+PAYLOAD_FILES := --exclude='*/test' --exclude='*/__pycache__' --exclude '*.exe' --exclude '*.whl' \
 	cpython/Lib \
 	cpython/Modules/Setup
 PAYLOAD_STUBS := $(shell find cpython/build/lib.linux-x86_64-${VERS} -name '*.so')
@@ -153,10 +153,23 @@ clobber-modules:
 RUNENV_VALIDATE_DIR := scripts
 RUNENV_VALIDATE_CMD := scripts/sanity_test.py
 export define runenv_prep
+	rm -rf ${RUNENV_PATH}/*
+
+	# Install python.km into usr/local/bin inside the container. Note, rootfs
+	# will map from RUNENV_PATH
+	mkdir -p ${RUNENV_PATH}/usr/local/bin
+	install -s ${PAYLOAD_KM} ${RUNENV_PATH}/usr/local/bin/python3.km
+	ln -s /opt/kontain/bin/km ${RUNENV_PATH}/usr/local/bin/python3 
+
+	# Install rest of python payload files
 	tar -cf - ${PAYLOAD_FILES} | tar -C $(RUNENV_PATH) -xf -
-	install -s ${PAYLOAD_KM} ${RUNENV_PATH}
+
+	# Install .so thumb stone files into RUNENV_PATH
 	mkdir -p $(addprefix ${RUNENV_PATH}/,$(dir ${PAYLOAD_STUBS}))
 	touch $(addprefix ${RUNENV_PATH}/,${PAYLOAD_STUBS})
+
+	# Install pyvenv.cfg into where python will be located.
+	cp runenv/pyvenv.cfg ${RUNENV_PATH}/usr/local/bin/pyvenv.cfg
 endef
 
 include ${TOP}/make/images.mk

--- a/payloads/python/runenv.dockerfile
+++ b/payloads/python/runenv.dockerfile
@@ -7,4 +7,4 @@ ENV PYTHONPATH=/cpython/Lib:/cpython/build/lib.linux-x86_64-${VERS}
 ENV PYTHONHOME=foo:bar
 
 COPY . /
-ENTRYPOINT [ "/opt/kontain/bin/km","python.km" ]
+ENTRYPOINT [ "/usr/local/bin/python3" ]

--- a/payloads/python/runenv/pyvenv.cfg
+++ b/payloads/python/runenv/pyvenv.cfg
@@ -1,0 +1,2 @@
+home = /cpython
+include-system-site-packages = false


### PR DESCRIPTION
This is to mimic the real python base image.