### PR TITLE
pass fileops into execed process

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1850,13 +1850,6 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
    return 0;
 }
 
-// types for file names conversion
-typedef struct {
-   char* pattern;
-   km_file_ops_t ops;
-   regex_t regex;
-} km_filename_table_t;
-
 // return filename to open for the request for /proc/`getpid()`/sched
 static int proc_sched_open(const char* guest_fn, char* host_fn, size_t host_fn_sz)
 {
@@ -1988,6 +1981,26 @@ static km_filename_table_t km_filename_table[] = {
     },
     {},
 };
+
+// Given pointer to ops field from the table above, return line # in that table, or -1
+
+#define container_of(ptr, type, member) ((type*)((char*)(ptr) - __builtin_offsetof(type, member)))
+int km_filename_table_line(km_file_ops_t* o)
+{
+   if (o == NULL) {
+      return -1;
+   }
+   return container_of(o, km_filename_table_t, ops) - km_filename_table;
+}
+
+// given line # retreive ops
+km_file_ops_t* km_file_ops(int i)
+{
+   if (i < 0) {
+      return NULL;
+   }
+   return &km_filename_table[i].ops;
+}
 
 /*
  * For now every entry in the table starts with "/proc". Most files wont match, so we check for

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -45,12 +45,22 @@ typedef int (*km_file_readlink_t)(const char* guest_fn, char* buf, size_t buf_sz
 typedef int (*km_file_read_t)(int fd, char* buf, size_t buf_sz);
 typedef int (*km_file_getdents_t)(int fd, /* struct linux_dirent64 */ void* buf, size_t buf_sz);
 
+// types for file names conversion
 typedef struct {
    km_file_open_t open_g2h;
    km_file_read_t read_g2h;
    km_file_getdents_t getdents_g2h;
    km_file_readlink_t readlink_g2h;
 } km_file_ops_t;
+
+typedef struct {
+   char* pattern;
+   km_file_ops_t ops;
+   regex_t regex;
+} km_filename_table_t;
+
+int km_filename_table_line(km_file_ops_t* o);
+km_file_ops_t* km_file_ops(int i);
 
 /*
  * maps a host fd to a guest fd. Returns a negative error number if mapping does

--- a/tests/filesys_test.c
+++ b/tests/filesys_test.c
@@ -159,7 +159,7 @@ TEST test_getdents()
             printf("name <%s> is <%s>\n", tmp, buf);
          }
          ino64_t ino = atol(entry->d_name);
-         ASSERT(0 <= ino && ino <= 5);
+         ASSERT(0 <= ino && ino <= 6);
       }
    }
    ASSERT_NOT_EQ(-1, rc);

--- a/tests/fs_exec_test.c
+++ b/tests/fs_exec_test.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2020 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+extern char** environ;
+
+int main(int argc, char** argv)
+{
+   int fd = open("/proc/self/cmdline", O_RDONLY);
+
+   if (argc > 1 && strcmp(argv[1], "parent") == 0) {
+      char parent_buf[256];
+      int parent_rc = read(fd, parent_buf, sizeof(parent_buf));
+      lseek(fd, SEEK_SET, 0);
+      printf("parent cmdline:");
+      for (int i = 0; i < parent_rc;) {
+         i += printf(" %s", parent_buf + i);
+      }
+      printf("\n");
+      char* testargv[] = {"fs_exec_test", "child", NULL};
+      int rc = execve("fs_exec_test", testargv, environ);
+      printf("exec %d %s\n", rc, strerror(errno));
+   } else {
+      char buf[256];
+      int child_rc = read(fd, buf, sizeof(buf));
+      printf("child  cmdline:");
+      for (int i = 0; i < child_rc;) {
+         i += printf(" %s", buf + i);
+      }
+      printf("\n");
+   }
+}

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -35,7 +35,7 @@ todo_dynamic='mem_mmap exception cpp_ctors dl_iterate_phdr monitor_maps '
 
 todo_so=''
 not_needed_so='km_main_argv0 km_main_shebang km_main_symlink linux_exec setup_load cli mem_* file* gdb_* mmap_1 km_many hc_check \
-    exception cpp_ctors dl_iterate_phdr monitor_maps pthread_cancel mutex vdso threads_mutex sigsuspend semaphore'
+    exception cpp_ctors dl_iterate_phdr monitor_maps pthread_cancel mutex vdso threads_mutex sigsuspend semaphore files_on_exec'
 
 # make sure it does not leak in from the outer shell, it can mess out the output
 unset KM_VERBOSE
@@ -1077,4 +1077,11 @@ fi
    assert_line --partial 'fail: 0'
    refute_line --partial "Couldn't turn off MAP_SHARED at kma"
    refute_line "Warning: Ignoring map counts. Please run this test in gdb to validate mmap counts"
+}
+
+@test "files_on_exec($test_type): passing /proc and such to execed process (fs_exec_test$ext)" {
+   run km_with_timeout --timeout 5s fs_exec_test$ext parent
+   assert_success
+   assert_line --regexp "parent cmdline: fs_exec_test$ext parent"
+   assert_line --regexp "child  cmdline: /[^[:space:]]*/tests/fs_exec_test.km child"
 }


### PR DESCRIPTION
Missing part of the filesys virtualization. The ops pointer used to modify operation on virtualized files such as /proc/self family need to be passed to the execed process along with the file itself. The g2h mapping isn't needed any more as it is now one to one, so that is omitted.

The vector is passed as an index into the `km_filename_table`.

Not sure what to do about tests. 