### PR TITLE
Java build w/o internal debug symbols

### DIFF
--- a/payloads/java/Makefile
+++ b/payloads/java/Makefile
@@ -66,7 +66,7 @@ fromsrc: .check ${JDK_VERSION} jtreg ${KM_BIN} ${KM_LDSO}
 		fail; \
 	fi
 	cd ${JDK_VERSION} && bash configure \
-		--disable-warnings-as-errors --with-native-debug-symbols=internal \
+		--disable-warnings-as-errors --with-native-debug-symbols=none \
 		--with-jvm-variants=server --with-zlib=bundled --with-jtreg=$(realpath jtreg) \
 		--enable-jtreg-failure-handler
 	make -C ${JDK_VERSION} images


### PR DESCRIPTION
Saves 1GB runenv-image size: Before: 1.39GB, After 329MB