### PR TITLE
Steps to make glibc work

### DIFF
--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1776,6 +1776,9 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_times] = times_hcall;
    km_hcalls_table[SYS_getpgrp] = getpgrp_hcall;
 
+   km_hcalls_table[SYS_set_robust_list] = dummy_hcall;
+   km_hcalls_table[SYS_get_robust_list] = dummy_hcall;
+
    km_hcalls_table[SYS_uname] = uname_hcall;
 
    km_hcalls_table[SYS_setitimer] = setitimer_hcall;

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -568,7 +568,7 @@ km_parse_args(int argc, char* argv[], int* argc_p, char** argv_p[], int* envc_p,
           * ourselves as payload.
           */
          if (km_check_for_km(argv[0]) == 0) {
-            pl_name = strdup(argv[0]);
+            pl_name = realpath(argv[0], NULL);
          }
       }
    }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1096,7 +1096,7 @@ fi
 @test "files_on_exec($test_type): passing /proc and such to execed process (fs_exec_test$ext)" {
    run km_with_timeout --timeout 5s fs_exec_test$ext parent
    assert_success
-   assert_line --regexp "parent exe: fs_exec_test$ext parent"
+   assert_line --regexp "parent exe: /[^[:space:]]*/tests/fs_exec_test$ext parent"
    assert_line --regexp "child  exe: /[^[:space:]]*/tests/fs_exec_test.km child"
 }
 


### PR DESCRIPTION
Two little changes:

- fake robust_list. Need to think how to deal with robust futex calls. Should at least fail them if they happen. Not really sure how to do that yet
- readlink("/proc/self/exe") always gets absolute path/ Turns out glibc checks for the fist char in the return and bails if it isn't '/'

The glibc support isn't complete with this, but the changes are benign for musl.