### PR TITLE
Fixed test by forcing full paths in LD_LIBRARY_PATH

### DIFF
--- a/payloads/java/Makefile
+++ b/payloads/java/Makefile
@@ -91,7 +91,7 @@ in-blank-container: ## invoked in blank container by ``make all''. DO NOT invoke
 
 
 JAVA_DIR := ${JDK_BUILD_DIR}/images/jdk
-JAVA_LD_PATH := ${JAVA_DIR}/lib/server:${JAVA_DIR}/lib/jli:${JAVA_DIR}/lib:/opt/kontain/runtime:/lib64
+JAVA_LD_PATH := ${CURDIR}/${JAVA_DIR}/lib/server:${CURDIR}/${JAVA_DIR}/lib/jli:${CURDIR}/${JAVA_DIR}/lib:/opt/kontain/runtime:/lib64
 test: ${RUNENV_VALIDATE_DEPENDENCIES} ## Basic test run
 	${KM_BIN} --putenv=LD_LIBRARY_PATH=${JAVA_LD_PATH} \
 		${JDK_BUILD_DIR}/images/jdk/bin/java.kmd -cp ${RUNENV_VALIDATE_DIR} Hello | grep "${RUNENV_VALIDATE_EXPECTED}"


### PR DESCRIPTION
tested manually 

before: 
```sh
[msterin@msterin-p330 java]$ make test 
/home/msterin/workspace/km/build/km/km --putenv=LD_LIBRARY_PATH=jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/lib/server:jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/lib/jli:jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/lib:/opt/kontain/runtime:/lib64 \
        jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/bin/java.kmd -cp scripts Hello | grep "Hello, World!"
Exec format error
Error: trying to exec /home/msterin/workspace/km/payloads/java/jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/bin/java.kmd.
Check if file exists and permissions are set correctly.
make: *** [Makefile:96: test] Error 1
```

after:
```sh
[msterin@msterin-p330 java]$ make test
/home/msterin/workspace/km/build/km/km --putenv=LD_LIBRARY_PATH=/home/msterin/workspace/km/payloads/java/jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/lib/server:/home/msterin/workspace/km/payloads/java/jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/lib/jli:/home/msterin/workspace/km/payloads/java/jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/lib:/opt/kontain/runtime:/lib64 \
        jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk/bin/java.kmd -cp scripts Hello | grep "Hello, World!"
Hello, World!
```