### PR TITLE
Ensure 64 byte alignment for signal handler stack

### DIFF
--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -428,7 +428,6 @@ typedef struct km_signal_frame {
    uint64_t return_addr;   // return address for guest handler. See runtime/x86_sigaction.s
    km_hc_args_t hcargs;    // HC argument array for __km_sigreturn.
    uint64_t rflags;        // saved rflags
-   uint64_t pad;           // ABI alignment for 16 byte alignment (ABI)
    siginfo_t info;         // Passed to guest signal handler
    ucontext_t ucontext;    // Passed to guest signal handler
 } km_signal_frame_t;
@@ -497,7 +496,11 @@ static inline void do_guest_handler(km_vcpu_t* vcpu, siginfo_t* info, km_sigacti
    } else {
       sframe_gva = vcpu->regs.rsp - RED_ZONE;
    }
-   sframe_gva -= sizeof(km_signal_frame_t);
+   /*
+    * This ensures that the first local variable of a signal handler is aligned
+    * so it could support a x86_64 __m512 (64 bytes)
+    */
+   sframe_gva = rounddown(sframe_gva - (sizeof(km_signal_frame_t) + 8), 64) + 8;
    km_signal_frame_t* frame = km_gva_to_kma_nocheck(sframe_gva);
 
    frame->info = *info;

--- a/tests/signal_test.c
+++ b/tests/signal_test.c
@@ -47,7 +47,7 @@ TEST test_simple_signal()
    ASSERT_EQ(1, signal_seen);
    // check stack alignment.
    ASSERT_NOT_EQ(0, (uintptr_t)stack_addr);
-   ASSERT_EQ(0, ((uintptr_t)stack_addr) % 16);
+   ASSERT_EQ(0, ((uintptr_t)stack_addr) % 64);
    signal(SIGTERM, SIG_DFL);
    PASS();
 }
@@ -61,6 +61,7 @@ TEST test_sigpending()
    sigset_t pending;
 
    signal_seen = 0;
+   stack_addr = NULL;
    signal(SIGUSR1, signal_handler);
    signal(SIGUSR2, signal_handler);
    sigemptyset(&ss);
@@ -75,6 +76,9 @@ TEST test_sigpending()
    ASSERT_EQ(0, signal_seen);
    ASSERT_EQ(0, sigprocmask(SIG_UNBLOCK, &ss, NULL));
    ASSERT_EQ(2, signal_seen);
+   // check stack alignment.
+   ASSERT_NOT_EQ(0, (uintptr_t)stack_addr);
+   ASSERT_EQ(0, ((uintptr_t)stack_addr) % 64);
    signal(SIGUSR1, SIG_DFL);
    signal(SIGUSR2, SIG_DFL);
 
@@ -96,6 +100,7 @@ TEST test_sigqueued()
    sigset_t pending;
 
    signal_seen = 0;
+   stack_addr = NULL;
    signal(SIGRTMIN, signal_handler);
    sigemptyset(&ss);
    sigaddset(&ss, SIGRTMIN);
@@ -107,6 +112,9 @@ TEST test_sigqueued()
    ASSERT_EQ(0, signal_seen);
    ASSERT_EQ(0, sigprocmask(SIG_UNBLOCK, &ss, NULL));
    ASSERT_EQ(2, signal_seen);
+   // check stack alignment.
+   ASSERT_NOT_EQ(0, (uintptr_t)stack_addr);
+   ASSERT_EQ(0, ((uintptr_t)stack_addr) % 64);
    signal(SIGRTMIN, SIG_DFL);
    PASS();
 }
@@ -120,6 +128,7 @@ TEST test_sigconsolodated()
    sigset_t pending;
 
    signal_seen = 0;
+   stack_addr = NULL;
    signal(SIGUSR1, signal_handler);
    sigemptyset(&ss);
    sigaddset(&ss, SIGUSR1);
@@ -131,6 +140,9 @@ TEST test_sigconsolodated()
    ASSERT_EQ(0, signal_seen);
    ASSERT_EQ(0, sigprocmask(SIG_UNBLOCK, &ss, NULL));
    ASSERT_EQ(1, signal_seen);
+   // check stack alignment.
+   ASSERT_NOT_EQ(0, (uintptr_t)stack_addr);
+   ASSERT_EQ(0, ((uintptr_t)stack_addr) % 64);
    signal(SIGUSR1, SIG_DFL);
    PASS();
 }
@@ -143,12 +155,16 @@ void first_signal_handler(int signo)
 TEST test_nested_signal()
 {
    signal_seen = 0;
+   stack_addr = NULL;
    signal(SIGUSR1, first_signal_handler);
    signal(SIGUSR2, signal_handler);
 
    ASSERT_EQ(0, signal_seen);
    kill(0, SIGUSR1);
    ASSERT_EQ(1, signal_seen);
+   // check stack alignment.
+   ASSERT_NOT_EQ(0, (uintptr_t)stack_addr);
+   ASSERT_EQ(0, ((uintptr_t)stack_addr) % 64);
 
    signal(SIGUSR1, SIG_DFL);
    signal(SIGUSR2, SIG_DFL);


### PR DESCRIPTION
Srini points out that we need that for _m512 data
defined for X86_64 SIMD instructions.