### PR TITLE
relax check on vCont packet to allow next over clone()

### DIFF
--- a/container-runtime/Makefile
+++ b/container-runtime/Makefile
@@ -31,7 +31,7 @@ include ${TOP}/make/actions.mk
 # Building crun shows errors indicating generated header files are not built yet,
 # so force single threading the make.
 all:	$(CRUNDIR)/Makefile .makefile_check
-	make -j$$(nproc) -C $(CRUNDIR) all
+	make -j1 -C $(CRUNDIR) all
 
 $(CRUNDIR)/Makefile:
 	cd $(CRUNDIR); ./autogen.sh; ./configure --disable-systemd

--- a/tests/cmd_for_nextclone_test.gdb
+++ b/tests/cmd_for_nextclone_test.gdb
@@ -1,0 +1,16 @@
+br main
+continue
+
+next
+next
+next
+next
+
+# We should be at call to clone()
+next
+
+# we should be on the next line after clone()
+bt
+
+# All done
+continue

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -407,6 +407,15 @@ fi
    # Verify we "step"ed into step_into_this_function()
    assert_line --partial "step_into_this_function () at gdb_nextstep_test.c"
    wait_and_check 0 # expect KM to exit normally
+
+   km_with_timeout -g$km_gdb_port clone_test$ext &
+   run gdb_with_timeout -q -nx --ex="target remote :$km_gdb_port" \
+      --ex="source cmd_for_nextclone_test.gdb" --ex=q clone_test$ext
+   assert_success
+
+   # Verify we "next"ed thru clone()
+   assert_line --regexp "^#0  main.* at clone_test.c:38$"
+   wait_and_check 0 # expect KM to exit normally
 }
 
 #


### PR DESCRIPTION
The check for vCont packet used to allow either exactly one thread stepping and all other stopped, or all run. It appears this assumption is incorrect - next over `clone()` call asks for one thread stepping and all the rest running.

The check was put in before we had correct handling of the queue of gdb events. It appears we can allow very generic sequence of events now, hence removing the check.

Test for next over `clone()` added