### PR TITLE
more robust pthread_cancel test

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -749,6 +749,9 @@ fi
 @test "pthread_cancel($test_type): (pthread_cancel_test$ext)" {
    run km_with_timeout pthread_cancel_test$ext -v
    assert_success
+   assert_line --partial "thread_func(): end of DISABLE_CANCEL_TEST"
+   refute_line --partial "PTHREAD_CANCEL_ASYNCHRONOUS"
+   assert_line --partial "PTHREAD_CANCEL_DEFERRED"
 }
 
 # C++ tests


### PR DESCRIPTION
Make `pthread_cancel()` more robust - don't rely on timing, check the logic flow instead.