### PR TITLE
use correct hcargs in interrupt handler

### DIFF
--- a/km/km_guest_asmcode.s
+++ b/km/km_guest_asmcode.s
@@ -89,7 +89,7 @@ handler\name :
     push %rbx
     push %rax
     mov $\num, %rbx
-    mov %rsp, %rax          # KM Setup km_hc_args_t on stack for us to use
+    mov %rsp, %gs:0         # KM Setup km_hc_args_t on stack for us to use
     mov $0x81fd, %dx        # HC_guest_interrupt
     outl %eax, (%dx)        # Enter KM
     hlt                     # Should never hit here.


### PR DESCRIPTION
Stepped on this debugging raw clone test with glibc. Turns out we don't put the hcargs structure address in correct place when handling interrupts. As a result KM would see NULL for hcargs address and drop kmcore.

We have no good tests for user interrupts. I'll think of one, in the meantime, I'd like to merge that anyways.