### PR TITLE
WIP: Floating point support for signals and snapshots

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -44,6 +44,7 @@ typedef struct kvm_cpuid2 kvm_cpuid2_t;
 typedef struct kvm_segment kvm_seg_t;
 typedef struct kvm_sregs kvm_sregs_t;
 typedef struct kvm_regs kvm_regs_t;
+typedef struct kvm_fpu kvm_fpu_t;
 typedef struct kvm_vcpu_events kvm_vcpu_events_t;
 
 typedef uint64_t km_gva_t;   // guest virtual address (i.e. address in payload space)
@@ -135,6 +136,7 @@ typedef struct km_vcpu {
    uint8_t is_running;        // 1 means the vcpu is in guest, aka ioctl (KVM_RUN)
    uint8_t regs_valid;        // Are registers valid?
    uint8_t sregs_valid;       // Are segment registers valid?
+   uint8_t fpu_valid;         // Is FPU state valid?
    uint8_t in_sigsuspend;     // if true thread is running in the sigsuspend() hypercall
                               //
    km_gva_t stack_top;        // also available in guest_thr
@@ -145,6 +147,7 @@ typedef struct km_vcpu {
                               //
    kvm_regs_t regs;           // Cached register values.
    kvm_sregs_t sregs;         // Cached segment register values.
+   kvm_fpu_t fpu;             // FPU state
    km_sigset_t sigmask;       // blocked signals for thread
    km_signal_list_t sigpending;        // List of signals sent to thread
    pthread_cond_t signal_wait_cv;      // wait for signals with this cv
@@ -210,6 +213,8 @@ void km_read_registers(km_vcpu_t* vcpu);
 void km_write_registers(km_vcpu_t* vcpu);
 void km_read_sregisters(km_vcpu_t* vcpu);
 void km_write_sregisters(km_vcpu_t* vcpu);
+void km_read_fpu(km_vcpu_t* vcpu);
+void km_write_fpu(km_vcpu_t* vcpu);
 
 void km_hcalls_init(void);
 void km_hcalls_fini(void);

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1644,7 +1644,9 @@ static km_hc_ret_t snapshot_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    km_warnx("SNAPSHOT");
    km_vcpu_sync_rip(vcpu);
    ((km_vcpu_t*)vcpu)->regs_valid = 0;   // force register reread after the sync_rip
+   ((km_vcpu_t*)vcpu)->fpu_valid = 0;    // force fpu reread after the sync_rip
    km_read_registers(vcpu);
+   km_read_fpu(vcpu);
    km_vcpu_pause_all();
    km_dump_core(km_get_snapshot_path(), vcpu, NULL);
    return HC_ALLSTOP;

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -260,7 +260,7 @@ static int km_ss_recover_vcpu_info(char* ptr, size_t length)
     * This is a compile time check to remind developers to check
     * for snapshot implications when km_vcpu_t changes.
     */
-   static_assert(sizeof(km_vcpu_t) == 960,
+   static_assert(sizeof(km_vcpu_t) == 1376,
                  "sizeof(km_vcpu_t) changed. Check for snapshot implications");
 
    if (length < sizeof(km_nt_vcpu_t)) {


### PR DESCRIPTION
Step 1.
Signals. Add floating point state to signal call frame.
Save fpstate when going into a signal handler and restore when leaving.

Fix bug in sigaltstack_test where the addresses of the user defined
stack were mprotect'ed erroneously.

No snapshot support yet.