### PR TITLE
make vdso_test not depend on time intervals

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -901,11 +901,11 @@ fi
 }
 
 @test "vdso($test_type): use function verion of some syscalls (vdso_test$ext)" {
-   run km_with_timeout vdso_test$ext
+   run km_with_timeout -S vdso_test$ext
    assert_success
    refute_line --partial "auxv[AT_SYSINFO_EHDR] not available"
-   refute_line --partial "expected sleep duration between"
-   refute_line --regexp "exceeds .* the time of SYS"
+   refute_line --partial "clock_gettime(228) called"
+   refute_line --regexp "getcpu(309) called"
 }
 
 @test "syscall($test_type): test SYSCALL instruction emulation" {

--- a/tests/vdso_test.c
+++ b/tests/vdso_test.c
@@ -18,27 +18,28 @@
  */
 
 #define _GNU_SOURCE
-#include <stdio.h>
-#include <time.h>
 #include <assert.h>
-#include <unistd.h>
 #include <sched.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
 #include <sys/auxv.h>
 #include "syscall.h"
 
-void timespec_sub(struct timespec *result, struct timespec *subfrom, struct timespec *subme)
+void timespec_sub(struct timespec* result, struct timespec* subfrom, struct timespec* subme)
 {
-  if (subme->tv_nsec > subfrom->tv_nsec) {
-     result->tv_nsec = (subfrom->tv_nsec + 1000000000ul) - subme->tv_nsec;
-     result->tv_sec = subfrom->tv_sec - subme->tv_sec - 1;
-  } else {
-     result->tv_nsec = subfrom->tv_nsec - subme->tv_nsec;
-     result->tv_sec = subfrom->tv_sec - subme->tv_sec;
-  }
+   if (subme->tv_nsec > subfrom->tv_nsec) {
+      result->tv_nsec = (subfrom->tv_nsec + 1000000000ul) - subme->tv_nsec;
+      result->tv_sec = subfrom->tv_sec - subme->tv_sec - 1;
+   } else {
+      result->tv_nsec = subfrom->tv_nsec - subme->tv_nsec;
+      result->tv_sec = subfrom->tv_sec - subme->tv_sec;
+   }
 }
 
 // 1 million iterations times out on azure
-#define NTIMES	10000
+#define NTIMES 10000
 
 int main(int argc, char* argv[])
 {
@@ -50,12 +51,16 @@ int main(int argc, char* argv[])
    struct timespec syscall_duration;
    struct timespec funccall_duration;
    struct timespec sleep_duration;
-   struct timespec sleep_this_long = { 1, 0 };
+   struct timespec sleep_this_long = {1, 0};
    double sysdur_float;
    double funcdur_float;
    double sleepdur_float;
    uint64_t vdso_base;
+   int compare_time = 0;
 
+   if (argc == 2 && strcmp(argv[1], "-c") == 0) {
+      compare_time = 1;
+   }
    vdso_base = getauxval(AT_SYSINFO_EHDR);
    if (vdso_base == 0) {
       printf("auxv[AT_SYSINFO_EHDR] not available?\n");
@@ -81,81 +86,97 @@ int main(int argc, char* argv[])
              sleepdur_float);
    }
 
-   // Run syscall(SYS_clock_gettime,...) a few times
-   r = clock_gettime(CLOCK_REALTIME, &start);
-   assert(r == 0);
-   for (i = 0; i < NTIMES; i++) {
-      long ts32[2];
-      r = syscall(SYS_clock_gettime, CLOCK_REALTIME, ts32);
+   if (compare_time) {   // Run syscall(SYS_clock_gettime,...) a few times
+      r = clock_gettime(CLOCK_REALTIME, &start);
       assert(r == 0);
-      ts.tv_sec = ts32[0];
-      ts.tv_nsec = ts32[1];
-   }
-   r = clock_gettime(CLOCK_REALTIME, &end);
-   assert(r == 0);
-   timespec_sub(&syscall_duration, &end, &start);
-   sysdur_float = (double)syscall_duration.tv_sec + ((double)syscall_duration.tv_nsec / 1000000000.);
+      for (i = 0; i < NTIMES; i++) {
+         long ts32[2];
+         r = syscall(SYS_clock_gettime, CLOCK_REALTIME, ts32);
+         assert(r == 0);
+         ts.tv_sec = ts32[0];
+         ts.tv_nsec = ts32[1];
+      }
+      r = clock_gettime(CLOCK_REALTIME, &end);
+      assert(r == 0);
+      timespec_sub(&syscall_duration, &end, &start);
+      sysdur_float =
+          (double)syscall_duration.tv_sec + ((double)syscall_duration.tv_nsec / 1000000000.);
 
-   // Run clock_gettime(...) a few times
-   r = clock_gettime(CLOCK_REALTIME, &start);
-   assert(r == 0);
+      // Run clock_gettime(...) a few times
+      r = clock_gettime(CLOCK_REALTIME, &start);
+      assert(r == 0);
+   }
    for (i = 0; i < NTIMES; i++) {
       r = clock_gettime(CLOCK_REALTIME, &ts);
       assert(r == 0);
    }
-   r = clock_gettime(CLOCK_REALTIME, &end);
-   assert(r == 0);
-   timespec_sub(&funccall_duration, &end, &start);
-   funcdur_float = (double)funccall_duration.tv_sec + ((double)funccall_duration.tv_nsec / 1000000000.);
+   if (compare_time) {
+      r = clock_gettime(CLOCK_REALTIME, &end);
+      assert(r == 0);
+      timespec_sub(&funccall_duration, &end, &start);
+      funcdur_float =
+          (double)funccall_duration.tv_sec + ((double)funccall_duration.tv_nsec / 1000000000.);
 
-   // Compare the duration of the runs to see if clock_gettime() is faster
-   printf("\n");
-   printf("SYS_clock_gettime syscall duration %ld.%09ld seconds for %d iterations\n",
-          syscall_duration.tv_sec, syscall_duration.tv_nsec,
-          NTIMES);
-   printf("clock_gettime() func call duration %ld.%09ld seconds for %d iterations\n",
-          funccall_duration.tv_sec,
-          funccall_duration.tv_nsec, NTIMES);
+      // Compare the duration of the runs to see if clock_gettime() is faster
+      printf("\n");
+      printf("SYS_clock_gettime syscall duration %ld.%09ld seconds for %d iterations\n",
+             syscall_duration.tv_sec,
+             syscall_duration.tv_nsec,
+             NTIMES);
+      printf("clock_gettime() func call duration %ld.%09ld seconds for %d iterations\n",
+             funccall_duration.tv_sec,
+             funccall_duration.tv_nsec,
+             NTIMES);
 #define VDSO_CG_FACTOR 10.0
-   if (funcdur_float * VDSO_CG_FACTOR > sysdur_float) {
-      printf("clock_gettime() %f exceeds 1/%f the time of SYS_clock_gettime %f\n", funcdur_float, VDSO_CG_FACTOR, sysdur_float);
+      if (funcdur_float * VDSO_CG_FACTOR > sysdur_float) {
+         printf("clock_gettime() %f exceeds 1/%f the time of SYS_clock_gettime %f\n",
+                funcdur_float,
+                VDSO_CG_FACTOR,
+                sysdur_float);
+      }
    }
-
-
    // Run sched_getcpu() a few times.
    r = clock_gettime(CLOCK_REALTIME, &start);
    assert(r == 0);
    for (i = 0; i < NTIMES; i++) {
       cpu = sched_getcpu();
    }
-   r = clock_gettime(CLOCK_REALTIME, &end);
-   assert(r == 0);
-   timespec_sub(&funccall_duration, &end, &start);
-   funcdur_float = (double)funccall_duration.tv_sec + ((double)funccall_duration.tv_nsec / 1000000000.);
-
-   // Run syscall(SYS_getcpu, .. ) a few times
-   r = clock_gettime(CLOCK_REALTIME, &start);
-   assert(r == 0);
-   for (i = 0; i < NTIMES; i++) {
-      r = syscall(SYS_getcpu, &cpu, 0, 0);
+   if (compare_time) {
+      r = clock_gettime(CLOCK_REALTIME, &end);
       assert(r == 0);
-   }
-   r = clock_gettime(CLOCK_REALTIME, &end);
-   assert(r == 0);
-   timespec_sub(&syscall_duration, &end, &start);
-   sysdur_float = (double)syscall_duration.tv_sec + ((double)syscall_duration.tv_nsec / 1000000000.);
+      timespec_sub(&funccall_duration, &end, &start);
+      funcdur_float =
+          (double)funccall_duration.tv_sec + ((double)funccall_duration.tv_nsec / 1000000000.);
 
-   printf("\n");
-   printf("SYS_getcpu syscall duration %ld.%09ld seconds for %d iterations\n",
-          syscall_duration.tv_sec,
-          syscall_duration.tv_nsec, NTIMES);
-   printf("sched_getcpu() func call duration %ld.%09ld seconds for %d iterations\n",
-          funccall_duration.tv_sec,
-          funccall_duration.tv_nsec, NTIMES);
+      // Run syscall(SYS_getcpu, .. ) a few times
+      r = clock_gettime(CLOCK_REALTIME, &start);
+      assert(r == 0);
+      for (i = 0; i < NTIMES; i++) {
+         r = syscall(SYS_getcpu, &cpu, 0, 0);
+         assert(r == 0);
+      }
+      r = clock_gettime(CLOCK_REALTIME, &end);
+      assert(r == 0);
+      timespec_sub(&syscall_duration, &end, &start);
+      sysdur_float =
+          (double)syscall_duration.tv_sec + ((double)syscall_duration.tv_nsec / 1000000000.);
+
+      printf("\n");
+      printf("SYS_getcpu syscall duration %ld.%09ld seconds for %d iterations\n",
+             syscall_duration.tv_sec,
+             syscall_duration.tv_nsec,
+             NTIMES);
+      printf("sched_getcpu() func call duration %ld.%09ld seconds for %d iterations\n",
+             funccall_duration.tv_sec,
+             funccall_duration.tv_nsec,
+             NTIMES);
 #define VDSO_SGC_FACTOR 9.0
-   if (funcdur_float * VDSO_SGC_FACTOR > sysdur_float) {
-      printf("sched_getcpu() %f exceeds 1/%f the time of SYS_getcpu %f\n", funcdur_float, VDSO_SGC_FACTOR, sysdur_float);
+      if (funcdur_float * VDSO_SGC_FACTOR > sysdur_float) {
+         printf("sched_getcpu() %f exceeds 1/%f the time of SYS_getcpu %f\n",
+                funcdur_float,
+                VDSO_SGC_FACTOR,
+                sysdur_float);
+      }
    }
-
    return 0;
 }


### PR DESCRIPTION
Use -S option to km and check there are no syscalls (hypercalls) made.