### PR TITLE
Add support for the getdents hypercall

### DIFF
--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -45,11 +45,13 @@ typedef int (*km_file_open_t)(const char* guest_fn, char* host_fn, size_t host_f
 typedef int (*km_file_readlink_t)(const char* guest_fn, char* buf, size_t buf_sz);
 typedef int (*km_file_read_t)(int fd, char* buf, size_t buf_sz);
 typedef int (*km_file_getdents_t)(int fd, /* struct linux_dirent64 */ void* buf, size_t buf_sz);
+typedef int (*km_file_getdents32_t)(int fd, /* struct linux_dirent */ void* buf, size_t buf_sz);
 
 // types for file names conversion
 typedef struct {
    km_file_open_t open_g2h;
    km_file_read_t read_g2h;
+   km_file_getdents32_t getdents32_g2h;
    km_file_getdents_t getdents_g2h;
    km_file_readlink_t readlink_g2h;
 } km_file_ops_t;
@@ -115,6 +117,8 @@ uint64_t km_fs_chmod(km_vcpu_t* vcpu, char* pathname, mode_t mode);
 uint64_t km_fs_fchmod(km_vcpu_t* vcpu, int fd, mode_t mode);
 // int unlink(const char *path);
 uint64_t km_fs_unlink(km_vcpu_t* vcpu, char* pathname);
+// int getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count);
+uint64_t km_fs_getdents(km_vcpu_t* vcpu, int fd, void* dirp, unsigned int count);
 // int getdents64(unsigned int fd, struct linux_dirent64 *dirp, unsigned int count);
 uint64_t km_fs_getdents64(km_vcpu_t* vcpu, int fd, void* dirp, unsigned int count);
 // int link(const char *oldpath, const char *newpath);

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -397,6 +397,18 @@ static km_hc_ret_t fstat_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
+// int getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count);
+static km_hc_ret_t getdents_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   void* dirp = km_gva_to_kma(arg->arg2);
+   if (dirp == NULL) {
+      arg->hc_ret = -EFAULT;
+      return HC_CONTINUE;
+   }
+   arg->hc_ret = km_fs_getdents(vcpu, arg->arg1, dirp, arg->arg3);
+   return HC_CONTINUE;
+}
+
 static km_hc_ret_t getdirents_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
    // int getdents64(unsigned int fd, struct linux_dirent64 *dirp, unsigned int count);
@@ -1754,6 +1766,7 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_lstat] = lstat_hcall;
    km_hcalls_table[SYS_statx] = statx_hcall;
    km_hcalls_table[SYS_fstat] = fstat_hcall;
+   km_hcalls_table[SYS_getdents] = getdents_hcall;
    km_hcalls_table[SYS_getdents64] = getdirents_hcall;
    km_hcalls_table[SYS_getcwd] = getcwd_hcall;
    km_hcalls_table[SYS_close] = close_hcall;

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -40,6 +40,7 @@ static const_string_t fx = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
 #define __run_err(vcpu, __s, __f, ...)                                                                 \
    do {                                                                                                \
       char fmt[strlen(__f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];                        \
+      fmt[0] = 0;                                                                                      \
       strcat(fmt, __f);                                                                                \
       strcat(fmt, fx);                                                                                 \
       km_err(__s, fmt, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2); \
@@ -48,6 +49,7 @@ static const_string_t fx = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
 #define __run_errx(vcpu, __s, __f, ...)                                                                 \
    do {                                                                                                 \
       char fmt[strlen(__f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];                         \
+      fmt[0] = 0;                                                                                       \
       strcat(fmt, __f);                                                                                 \
       strcat(fmt, fx);                                                                                  \
       km_errx(__s, fmt, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2); \
@@ -59,6 +61,7 @@ static const_string_t fx = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
 #define __run_warn(vcpu, __f, ...)                                                                  \
    do {                                                                                             \
       char fmt[strlen(__f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];                     \
+      fmt[0] = 0;                                                                                   \
       strcat(fmt, __f);                                                                             \
       strcat(fmt, fx);                                                                              \
       km_warnx(fmt, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2); \


### PR DESCRIPTION
Basically copied what we currently do for getdents64() and changed it to support getdents.
Added a getdents test to the filesys test.  Note that the test for getdents64 was
formerly called getdents.  Renamed that to getdents64 and the getdents test now
tests the older getdents hypercall.

Also fixed a bug in the __run_err() (et al) macros where the message buffer is not initially null terminated so sometimes
you get garbage on the front of a message.

Ran the bats tests to be sure nothing was broken by this change.