### PR TITLE
allow for multiple targets without dependencies

### DIFF
--- a/make/actions.mk
+++ b/make/actions.mk
@@ -147,8 +147,8 @@ clean::
 #
 # do not generate .d file for some targets
 #
-$(shell [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${MAKEFLAGS}" =~ "n" ]] )
-ifneq ($(.SHELLSTATUS),0)
+no_deps := $(shell [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${MAKEFLAGS}" =~ "n" ]] && echo -n match)
+ifneq ($(no_deps),match)
 -include ${DEPS}
 endif
 

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -136,7 +136,8 @@ BUILDENV_IMAGE_VERSION ?= latest
 # Generic support - applies for all flavors (SUBDIR, EXEC, LIB, whatever)
 
 # regexp for targets which should not try to build dependencies (.d)
-NO_DEPS_TARGETS := (clean|clobber|.*-image|.buildenv-local-.*|buildenv-local-.*|print-.*|debugvars|help)
+NO_DEPS_TARGETS := (clean|clobber|.*-image|\.buildenv-local-.*|buildenv-local-.*|print-.*|debugvars|help)
+NO_DEPS_TARGETS := ${NO_DEPS_TARGETS}( ${NO_DEPS_TARGETS})*
 # colors for pretty output. Unless we are in Azure pipelines
 ifeq (${PIPELINE_WORKSPACE},)
 RED := \033[31m

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -159,8 +159,8 @@ clean:
 #
 # do not generate .d file for some targets
 #
-$(shell [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${MAKEFLAGS}" =~ "n" ]] )
-ifneq ($(.SHELLSTATUS),0)
+no_deps := $(shell [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${MAKEFLAGS}" =~ "n" ]] && echo -n match)
+ifneq ($(no_deps),match)
 -include ${DEPS}
 endif
 


### PR DESCRIPTION
Determination whether we need to build .d files assumed there is a single target on make invocation, like `make clean`. When invoked like `make pull-buildenv-image .buildenv-local-lib` the check would fail and dependencies would be built. No big deal, but on the CI system that step is done on a host machine using host tools, some of which are obsolete.