### PR TITLE
Add termination reason message.

### DIFF
--- a/tests/gdb_lots_of_threads_test.c
+++ b/tests/gdb_lots_of_threads_test.c
@@ -76,6 +76,7 @@ void* do_nothing_thread(void* instance)
       do_random_sleep((uint64_t)instance, &depth);
       iteration++;
       if (stop_running != 0) {
+         printf("Terminating instance %ld because stop_running is set\n", (uint64_t)instance);
          break;
       }
       if (stop_after_seconds != 0 && (time(NULL) - starttime) > stop_after_seconds) {


### PR DESCRIPTION
This may help understand what the bats gdb_attach test seems to terminate to soon.

Tested to ensure the message prints by manual testing.
Also ran the bats tests.