### PR TITLE
Largely cosmetic: km_vcpu_apply_all to use void* instead of uint64 for data

### DIFF
--- a/km/gdb_kvm_x86_64.c
+++ b/km/gdb_kvm_x86_64.c
@@ -192,7 +192,7 @@ static int kvm_arch_remove_sw_breakpoint(struct breakpoint_t* bp)
 }
 
 // Sets VCPU Debug registers to match current breakpoint list.
-int km_gdb_update_vcpu_debug(km_vcpu_t* vcpu, uint64_t unused)
+int km_gdb_update_vcpu_debug(km_vcpu_t* vcpu, void* unused)
 {
    struct kvm_guest_debug dbg = {0};
    static const uint8_t bp_condition_code[] = {
@@ -245,7 +245,7 @@ int km_gdb_update_vcpu_debug(km_vcpu_t* vcpu, uint64_t unused)
 static int km_gdb_update_guest_debug(void)
 {
    int count;
-   if ((count = km_vcpu_apply_all(km_gdb_update_vcpu_debug, 0)) != 0) {
+   if ((count = km_vcpu_apply_all(km_gdb_update_vcpu_debug, NULL)) != 0) {
       km_warnx("Failed update guest debug info for %d VCPU(s)", count);
       return -1;
    }

--- a/km/km.h
+++ b/km/km.h
@@ -380,12 +380,12 @@ int km_vcpu_set_to_run(km_vcpu_t* vcpu, km_gva_t start, uint64_t arg);
 int km_vcpu_clone_to_run(km_vcpu_t* vcpu, km_vcpu_t* new_vcpu);
 void km_vcpu_detach(km_vcpu_t* vcpu);
 
-typedef int (*km_vcpu_apply_cb)(km_vcpu_t* vcpu, uint64_t data);   // return 0 if all is good
-int km_vcpu_apply_used(km_vcpu_apply_cb func, uint64_t data);
-int km_vcpu_apply_all(km_vcpu_apply_cb func, uint64_t data);
+typedef int (*km_vcpu_apply_cb)(km_vcpu_t* vcpu, void* data);
+int km_vcpu_apply_all(km_vcpu_apply_cb func, void* data);
 int km_vcpu_count(void);
 void km_vcpu_pause_all(void);
 km_vcpu_t* km_vcpu_fetch_by_tid(int tid);
+
 static inline void km_vcpu_sync_rip(km_vcpu_t* vcpu)
 {
    /*

--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -206,9 +206,9 @@ typedef struct {
    size_t pr_remain;
 } km_core_list_context_t;
 
-static int km_core_dump_threads(km_vcpu_t* vcpu, uint64_t arg)
+static int km_core_dump_threads(km_vcpu_t* vcpu, void* arg)
 {
-   km_core_list_context_t* ctx = (km_core_list_context_t*)arg;
+   km_core_list_context_t* ctx = arg;
    if (vcpu == ctx->pr_vcpu) {
       return 0;
    }
@@ -220,7 +220,7 @@ static int km_core_dump_threads(km_vcpu_t* vcpu, uint64_t arg)
 }
 
 // Dump KM specific data
-static inline int km_core_dump_vcpu(km_vcpu_t* vcpu, uint64_t arg)
+static inline int km_core_dump_vcpu(km_vcpu_t* vcpu, void* arg)
 {
    struct km_nt_vcpu vnote = {.vcpu_id = vcpu->vcpu_id,
                               .stack_top = vcpu->stack_top,
@@ -234,7 +234,7 @@ static inline int km_core_dump_vcpu(km_vcpu_t* vcpu, uint64_t arg)
                               .mapself_size = vcpu->mapself_size,
                               .hcarg = (Elf64_Addr)km_hcargs[HC_ARGS_INDEX(vcpu->vcpu_id)]};
 
-   km_core_list_context_t* ctx = (km_core_list_context_t*)arg;
+   km_core_list_context_t* ctx = arg;
    char* cur = ctx->pr_cur;
    size_t remain = ctx->pr_remain;
    cur += km_add_note_header(cur, remain, KM_NT_NAME, NT_KM_VCPU, sizeof(struct km_nt_vcpu));
@@ -442,7 +442,7 @@ static inline int km_core_write_notes(km_vcpu_t* vcpu, int fd, off_t offset, cha
    }
 
    km_core_list_context_t ctx = {.pr_vcpu = vcpu, .pr_cur = cur, .pr_remain = remain};
-   km_vcpu_apply_all(km_core_dump_threads, (uint64_t)&ctx);
+   km_vcpu_apply_all(km_core_dump_threads, &ctx);
    cur = ctx.pr_cur;
    remain = ctx.pr_remain;
 
@@ -460,7 +460,7 @@ static inline int km_core_write_notes(km_vcpu_t* vcpu, int fd, off_t offset, cha
    ctx.pr_vcpu = NULL;
    ctx.pr_cur = cur;
    ctx.pr_remain = remain;
-   ret = km_vcpu_apply_all(km_core_dump_vcpu, (uint64_t)&ctx);
+   ret = km_vcpu_apply_all(km_core_dump_vcpu, &ctx);
    cur = ctx.pr_cur;
    remain = ctx.pr_remain;
 
@@ -543,7 +543,7 @@ static inline void km_guestmem_write(int fd, km_gva_t base, size_t length)
    }
 }
 
-static int km_count_vcpu(km_vcpu_t* vcpu, uint64_t unused)
+static int km_count_vcpu(km_vcpu_t* vcpu, void* unused)
 {
    return 1;
 }
@@ -554,7 +554,7 @@ static int km_count_vcpu(km_vcpu_t* vcpu, uint64_t unused)
  */
 static inline size_t km_core_notes_length(km_vcpu_t* vcpu)
 {
-   int nvcpu = km_vcpu_apply_all(km_count_vcpu, 0);
+   int nvcpu = km_vcpu_apply_all(km_count_vcpu, NULL);
    int nvcpu_inc = (vcpu == NULL) ? 0 : 1;
    /*
     * nvcpu is incremented because the current vcpu is wrtten twice.

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1966,7 +1966,7 @@ static int proc_sched_open(const char* guest_fn, char* host_fn, size_t host_fn_s
    return snprintf(host_fn, host_fn_sz, "%s%s", PROC_SELF, guest_fn + proc_pid_length);
 }
 
-static inline int km_vcpu_count_running(km_vcpu_t* vcpu, uint64_t unused)
+static inline int km_vcpu_count_running(km_vcpu_t* vcpu, void* unused)
 {
    return vcpu->state != PARKED_IDLE;
 }
@@ -1993,7 +1993,7 @@ static int proc_sched_read(int fd, char* buf, size_t buf_sz)
                       "%s (%u, #threads: %u)\n",
                       km_guest.km_filename,
                       machine.pid,
-                      km_vcpu_apply_all(km_vcpu_count_running, 0));
+                      km_vcpu_apply_all(km_vcpu_count_running, NULL));
    ret += fread(buf + ret, 1, buf_sz - ret, fp);
    fclose(fp);
    return ret;

--- a/km/km_gdb.h
+++ b/km/km_gdb.h
@@ -360,7 +360,7 @@ extern char* mem2hex(const unsigned char* mem, char* buf, size_t count);
 extern int km_guest_mem2hex(km_gva_t addr, km_kma_t kma, char* obuf, int len);
 extern unsigned char* hex2mem(const char* buf, unsigned char* mem, size_t count);
 extern int km_guest_hex2mem(const char* buf, size_t count, km_kma_t mem);
-extern int km_gdb_update_vcpu_debug(km_vcpu_t* vcpu, uint64_t unused);
+extern int km_gdb_update_vcpu_debug(km_vcpu_t* vcpu, void* unused);
 extern void km_empty_out_eventfd(int fd);
 extern int km_gdb_setup_listen(void);
 extern void km_gdb_destroy_listen(void);

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -460,12 +460,13 @@ int km_snapshot_restore(const char* file)
 
    return 0;
 }
-static int km_vcpu_count_not_paused(km_vcpu_t* vcpu, uint64_t unused)
+
+static int km_vcpu_count_not_paused(km_vcpu_t* vcpu, void* unused)
 {
    return (vcpu->state != PAUSED) ? 1 : 0;
 }
 
-static int km_vcpu_snapshot_kick(km_vcpu_t* vcpu, uint64_t unused)
+static int km_vcpu_snapshot_kick(km_vcpu_t* vcpu, void* unused)
 {
    if (vcpu->state != PAUSED) {
       km_pkill(vcpu->vcpu_thread, KM_SIGVCPUSTOP);
@@ -506,12 +507,12 @@ int km_snapshot_create(km_vcpu_t* vcpu, int live)
       vcpu->state = PAUSED;
    }
    for (;;) {
-      if (km_vcpu_apply_all(km_vcpu_count_not_paused, 0) == 0) {
+      if (km_vcpu_apply_all(km_vcpu_count_not_paused, NULL) == 0) {
          break;
       }
       nanosleep(&_1ms, NULL);
       // kick any lagging threads.
-      km_vcpu_apply_all(km_vcpu_snapshot_kick, 0);
+      km_vcpu_apply_all(km_vcpu_snapshot_kick, NULL);
    }
 
    km_dump_core(km_get_snapshot_path(), vcpu, NULL);


### PR DESCRIPTION
Looking at the code for vcpu stopping I noticed we always pass some address as data parameter to `km_vcpu_apply_all(func, **data**)`. Which causes casting to and from uint64. This changes the prototype to `void*` which helps to avoid the casting.

The changes are somewhat extensive but mechanical. I think it makes things more readable, it does for me. 

Let me know if this makes sense. We can certainly leave things the way they are, functionality doesn't change.