### PR TITLE
Added test start/end timing output, and made individual test timeout longer [trivial]

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -206,13 +206,13 @@ check_optional_mem_size_failure() {
 
 function setup() {
   skip_if_needed "$BATS_TEST_DESCRIPTION"
-  echo $(date): timing start: "$BATS_TEST_DESCRIPTION"
+  echo start: $(date --rfc-3339=ns) $BATS_TEST_DESCRIPTION
   echo --- Test script output:
 }
 
 teardown() {
    cat <<EOF
-$(date): timing end: "$BATS_TEST_DESCRIPTION"
+  end: $(date --rfc-3339=ns) $BATS_TEST_DESCRIPTION
 
 --- Command line:
 ${command}


### PR DESCRIPTION
In parallel tests, there was no way to know when individual test started and stopped, so added it. It is only printed on test failures 

Also made timeout to 250 sec per test - we still limit job time so this is just relaxing limits for
coverage test and slow cloud instance

tested by making a test fail and running grep on the output, here is an example

```
[msterin@dacha tests]$ egrep '(start|end):' x
   start: 2020-11-04 17:35:27.898904110-08:00 unused_memory_protection(static): check that unused memory is protected (mprotect_test.km)
     end: 2020-11-04 17:35:28.065396127-08:00 unused_memory_protection(static): check that unused memory is protected (mprotect_test.km)
   start: 2020-11-04 17:35:27.895910302-08:00 unused_memory_protection(dynamic): check that unused memory is protected (mprotect_test.kmd)
     end: 2020-11-04 17:35:28.042627305-08:00 unused_memory_protection(dynamic): check that unused memory is protected (mprotect_test.kmd)
   start: 2020-11-04 17:35:28.026096517-08:00 unused_memory_protection(so): check that unused memory is protected (mprotect_test.km.so)
     end: 2020-11-04 17:35:28.198277716-08:00 unused_memory_protection(so): check that unused memory is protected (mprotect_test.km.so)
   start: 2020-11-04 17:35:27.887696873-08:00 unused_memory_protection(alpine_static): check that unused memory is protected (mprotect_test.alpine.km)
     end: 2020-11-04 17:35:28.047874761-08:00 unused_memory_protection(alpine_static): check that unused memory is protected (mprotect_test.alpine.km)
   start: 2020-11-04 17:35:28.030225366-08:00 unused_memory_protection(glibc_static): check that unused memory is protected (mprotect_test.fedora)
     end: 2020-11-04 17:35:28.188009606-08:00 unused_memory_protection(glibc_static): check that unused memory is protected (mprotect_test.fedora)

```