### PR TITLE
fix apt-get 404 failure

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -24,6 +24,10 @@ For other usages:
 ./release_km.py -h
 ```
 
+Note: version `v0.1-test` is a special tag reserved for testing. The release
+script will try to clean up when this release tag exists. Otherwise, the
+release script will fail to prevent accidental override of existing releases.
+
 ## Github Personal Access Token (PAT)
 
 This tool require a Github PAT to authenticate with Github APIs, and will

--- a/tools/release/tests/test_release_remote.py
+++ b/tools/release/tests/test_release_remote.py
@@ -163,7 +163,8 @@ def test(remote_ip, version):
     ], check=True)
     ssh_execute(
         remote_ip, "sudo mkdir -p /opt/kontain ; sudo chown kontain /opt/kontain")
-    ssh_execute(remote_ip, "sudo apt-get update && sudo apt-get install -y gcc")
+    ssh_execute(remote_ip, "sudo apt-get update")
+    ssh_execute(remote_ip, "sudo apt-get install -y gcc")
     ssh_execute(remote_ip, "sudo chmod 666 /dev/kvm")
 
     if version is None or version == "":


### PR DESCRIPTION
should have `apt-get update` first to update the repo urls.