### PR TITLE
Rework exiting after snapshot

### DIFF
--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -219,7 +219,7 @@ void km_gdb_accept_stop(void)
    int rc;
 
    km_infox(KM_TRACE_GDB, "Stop accepting new gdb client connections");
-   if (gdbstub.gdb_client_attached == 0) {
+   if (gdbstub.gdb_client_attached == 0 && gdbstub.listen_socket_fd != -1) {
       rc = shutdown(gdbstub.listen_socket_fd, SHUT_RD);
       if (rc != 0) {
          km_info(KM_TRACE_GDB, "shutdown on listening socket failed");

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1726,7 +1726,10 @@ static km_hc_ret_t snapshot_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    km_read_registers(vcpu);
 
    // Create the snapshot.
-   if ((arg->hc_ret = km_snapshot_create(vcpu, label, description, 0)) != 0) {
+   arg->hc_ret = km_snapshot_create(vcpu, label, description, 0);
+   // negative value means EBUSY or other similar condition.
+   // TODO: in case of live (non zero last arg) returning HC_CONTINUE should just work
+   if (arg->hc_ret < 0 /* || live != 0 */) {
       return HC_CONTINUE;
    }
    return HC_ALLSTOP;

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -508,11 +508,13 @@ int km_snapshot_create(km_vcpu_t* vcpu, char* label, char* description, int live
     */
    km_dump_core(km_get_snapshot_path(), vcpu, NULL, label, description);
 
-   if (live != 0) {
-      // TODO: Restart everything for a live snapshot.
+   if (live == 0) {
+      machine.exit_group = 1;
    }
    pthread_mutex_lock(&snap_mutex);
    in_snapshot = 0;
    pthread_mutex_unlock(&snap_mutex);
+
+   km_vcpu_resume_all();
    return 0;
 }


### PR DESCRIPTION
Turns out exiting after snapshot wasn't quite right, as the vcpus weren't stopped properly, just paused.

Now we set `machine.exit_group = 1` and continue. This causes vcpus to exit properly right away.

I suspect simply _not_ setting `machine.exit_group = 1` will make everything continue after the snapshot, but I haven't tested that. Left TODO in the code to that effect.

cleanup couple of messages