### PR TITLE
Change sigsuspend test to log the contents of the output files.

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -389,9 +389,7 @@ fi
    wait $pid
    status=$?
    if [ $status -ne 0 ] ; then
-      echo "# === Begin $km_trace_file for km, status=$status =====" >&3
-      sed -e "s/^/# /" <$km_trace_file >&3
-      echo "# === End   $km_trace_file =====" >&3
+      file_contents_to_bats_log $km_trace_file $status
    else
       rm -f $km_trace_file
    fi
@@ -990,9 +988,7 @@ fi
       if test `expr $now - $start` -ge $WAIT
       then
          # Put the km trace in the TAP stream
-         echo "# === Begin $KMTRACE =====" >&3
-         sed -e "s/^/# /" <$KMTRACE >&3
-         echo "# === End   $KMTRACE =====" >&3
+         file_contents_to_bats_log $KMTRACE
          fail "$FLAGFILE does not exist after $WAIT seconds!"
       fi
    done
@@ -1004,7 +1000,12 @@ fi
 
    # Debug.
    diff $LINUXOUT $KMOUT
-   assert_success
+   if [ $? -ne 0 ]; then
+      # Put the 2 output files into the TAP stream to help debug this.
+      file_contents_to_bats_log $LINUXOUT
+      file_contents_to_bats_log $KMOUT
+      fail "output differs between sigsuspend_test.fedora and sigsuspend_test$ext"
+   fi
 
    rm -f $KMTRACE $LINUXOUT $KMOUT
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -286,3 +286,11 @@ skip_if_needed() {
 check_kmcore() {
    readelf -l $1 | awk '/LOAD/ {if (substr($2, length($2)-2) != substr($3, length($3)-2)) exit 1}'
 }
+
+# Stream the contents of the file passed as arg1 into the bats log file.
+# Also put the value of arg2 into the header message.  arg2 has no defined meaning.
+file_contents_to_bats_log() {
+      echo "# === Begin contents of $1, arg2=$2 =====" >&3
+      sed -e "s/^/# /" <$1 >&3
+      echo "# === End contents of $1 =====" >&3
+}


### PR DESCRIPTION
To debug problems where the output from the fedora and km versions of sigsuspend_test differ
dump the contents of the logs to see what happened.

Tested by running the bats tests.  We really only see the sigsuspend test failures intermittently on azure.