### PR TITLE
Fix the bats itimer test.

### DIFF
--- a/tests/itimer_test.c
+++ b/tests/itimer_test.c
@@ -21,10 +21,13 @@
 #include <unistd.h>
 #include <sys/time.h>
 
+int itimer_fire_count;
+
 void signal_itimer_real(int signo, siginfo_t* sinfo, void* ucontext)
 {
    char message[] = "In SIGALRM signal handler\n";
    write(1, message, strlen(message));
+   itimer_fire_count++;
 }
 
 int main(int argc, char* argv[])
@@ -39,10 +42,10 @@ int main(int argc, char* argv[])
       return 1;
    }
 
-   // Setup and ITIMER_REAL interval timer
+   // Setup an ITIMER_REAL interval timer
    struct itimerval new = {
-       { 0, 0 },
-       { 0, 20000 }
+       { 0, 50000 },		// interval (50ms)
+       { 0, 20000 }             // time to next expiration
    };
    if (setitimer(ITIMER_REAL, &new, NULL) < 0) {
       fprintf(stderr, "setitimer( ITIMER_REAL ) failed, %s\n", strerror(errno));
@@ -59,9 +62,24 @@ int main(int argc, char* argv[])
            current.it_interval.tv_sec, current.it_interval.tv_usec,
            current.it_value.tv_sec, current.it_value.tv_usec);
 
-   // wait for the timer to fire
+   /*
+    * wait for the timer to fire.  Note that azure can block this process/thread for
+    * a long time.  Long enough so that the interval timer can fire before we ever
+    * get to the call to sigsuspend().  So, we let the timer run as a real interval
+    * timer to keep getting signals until this thread finally does run.
+    */
    sigset_t blockme;
    sigemptyset(&blockme);
    sigsuspend(&blockme);
+
+   // cancel the interval timer
+   memset(&new, 0, sizeof(new));
+   if (setitimer(ITIMER_REAL, &new, NULL) < 0) {
+      fprintf(stderr, "canceling itimer( ITIMER_REAL ) failed, %s\n", strerror(errno));
+      return 1;
+   }
+
+   fprintf(stdout, "itimer_fire_count = %d\n", itimer_fire_count);
+
    return 0;
 }


### PR DESCRIPTION
Our good buddy "azure the thread stall generator" has exposed a problem with the
bats itimer test.
The test blocks in sigsuspend() to await the signal that the interval timer has fired.
The timer is run in one shot mode so if the timer fires before the code gets to the call
to sigsuspend(), it waits until the test times out.  And then the test fails.
To fix this, the test now runs the timer in interval mode, so the timer keeps firing until
it is canceled at the end of the test.  That way if we suspend late, there will always be
another signal at the next interval expiration.

Tested by running the complete bats test suite.