### PR TITLE
Fix 2 bats tests, socket_test gdb_lots_of_threads

### DIFF
--- a/tests/gdb_lots_of_threads_test.c
+++ b/tests/gdb_lots_of_threads_test.c
@@ -145,13 +145,23 @@ int main(int argc, char *argv[])
          printf("Couldn't create thread instance %ld, error %s\n", i, strerror(rc));
          threadid[i] = 0;
       }
+      if (stop_running != 0) {
+         printf("Couldn't start all requested threads before being told to stop\n");
+         break;
+      }
+      if (stop_after_seconds != 0 && (time(NULL) - starttime) > stop_after_seconds) {
+         printf("Couldn't start requested number of threads in the time alotted, %d seconds\n", stop_after_seconds);
+         break;
+      }
    }
+
    // Wait for threads to terminate
-   for (i = 0; i < max_threads; i++) {
-      if (threadid[i] != 0) {
-         rc = pthread_join(threadid[i], &rv);
+   printf("Done starting %ld of %d threads, begin waiting for them to finish\n", i, max_threads);
+   for (int j = 0; j < i; j++) {
+      if (threadid[j] != 0) {
+         rc = pthread_join(threadid[j], &rv);
          if (rc != 0) {
-            printf("Couldn't join thread instance %ld, error %s\n", i, strerror(rc));
+            printf("Couldn't join thread instance %d, error %s\n", j, strerror(rc));
          }
       }
    }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -888,7 +888,10 @@ fi
 }
 
 @test "socket($test_type): guest socket operations (socket_test$ext)" {
-   run km_with_timeout socket_test$ext
+   # This test uses 3 ports, the next free one is 15
+   local port_id=12
+   local socket_test_port=$(( $port_range_start + $port_id))
+   SOCKET_PORT=$socket_test_port run km_with_timeout socket_test$ext
    assert_success
 }
 

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -73,7 +73,7 @@ TEST test_sockopt()
    PASS();
 }
 
-#define TEST_PORT (htons(6565))
+int TEST_PORT;
 void* tcp_server_main(void* arg)
 {
    static int rc = 0;
@@ -158,8 +158,8 @@ TEST test_tcp()
    PASS();
 }
 
-#define TEST_UDP_PORT1 (htons(6566))
-#define TEST_UDP_PORT2 (htons(6567))
+int TEST_UDP_PORT1;
+int TEST_UDP_PORT2;
 
 TEST test_udp()
 {
@@ -339,6 +339,18 @@ GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv)
 {
+   // Get some port numbers that won't interfere with other running instances of this test.
+   char* port = getenv("SOCKET_PORT");
+   uint16_t baseport = 6565;
+   if (port != NULL) {
+      baseport = atoi(port);
+   }
+   TEST_PORT = htons(baseport);
+   baseport++;
+   TEST_UDP_PORT1 = htons(baseport);
+   baseport++;
+   TEST_UDP_PORT2 = htons(baseport);
+
    GREATEST_MAIN_BEGIN();
    greatest_set_verbosity(1);   // needed if we want to pass through | greatest/contrib/greenest,
                                 // especially from KM payload


### PR DESCRIPTION
The socket_test uses fixed network port numbers which will conflict with other instances
of socket_test running concurrently.
The gdb_lots_of_threads test needs to stop creating new threads if the time limit for
the test runs out before all test threads are created.

Tested by running the bats tests.