### PR TITLE
Change crun makefile to put crun/krun in /opt/kontain/bin

### DIFF
--- a/container-runtime/Makefile
+++ b/container-runtime/Makefile
@@ -32,17 +32,16 @@ include ${TOP}/make/actions.mk
 # so force single threading the make.
 all:	$(CRUNDIR)/Makefile .makefile_check
 	make -j1 -C $(CRUNDIR) all
+	cp $(CRUNDIR)/crun ${KM_OPT_BIN_PATH}
+	ln -f ${KM_OPT_BIN_PATH}/crun ${KM_OPT_BIN_PATH}/krun
 
 $(CRUNDIR)/Makefile:
 	cd $(CRUNDIR); ./autogen.sh; ./configure --disable-systemd
 
-$(CURDIR)/$(CRUNDIR)/krun:
-	cd $(CURDIR)/$(CRUNDIR); ln -s crun krun
-
 # Run crun's tests
-test:	all $(CURDIR)/$(CRUNDIR)/krun
-	OCI_RUNTIME=$(CURDIR)/$(CRUNDIR)/krun make -C $(CRUNDIR) check-TESTS
-	OCI_RUNTIME=$(CURDIR)/$(CRUNDIR)/crun make -C $(CRUNDIR) check-TESTS
+test:	all
+	OCI_RUNTIME=${KM_OPT_BIN_PATH}/krun make -C $(CRUNDIR) check-TESTS
+	OCI_RUNTIME=${KM_OPT_BIN_PATH}/crun make -C $(CRUNDIR) check-TESTS
 
 TEST_REMOTE_SCRIPT := $(CURDIR)/test_remote.py
 test-remote:	
@@ -53,7 +52,6 @@ else
 endif
 
 clean::
-	rm -f $(CURDIR)/$(CRUNDIR)/krun
 	-$(MAKE) MAKEFLAGS="$(MAKEFLAGS)" -C $(CRUNDIR) clean
 	@# crun's clean removes this file, so git sees it as a change. Restore back to clean
 	cd $(CRUNDIR) && git checkout crun.1

--- a/tools/bin/create_release.sh
+++ b/tools/bin/create_release.sh
@@ -13,7 +13,7 @@ readonly OPT_KONTAIN_TMP=${BLDTOP}/opt_kontain
 
 rm -fr $TARBALL $TARBALL.gz $OPT_KONTAIN_TMP
 # we may need to modify all obj file so make sure we work on a copy
-cp -rf /opt/kontain $OPT_KONTAIN_TMP
+cp -rf --preserve=links /opt/kontain $OPT_KONTAIN_TMP
 
 # package by doing `tar -C locations[i] files[i]`
 declare -a locations; locations=($OPT_KONTAIN_TMP ../..        ../..              ../../tools ../../tools/faktory )


### PR DESCRIPTION
Fixes #916

The container-runtime Makefile is being changed to put krun and crun in /opt/kontain/bin
and the crun tests now look for crun/krun there.

Also changed the create_release.sh script to preserve hard links when copied into
$(BUILD)/opt_kontain/bin/

Tested by running the krun build and verifying that krun and crun are in /opt/kontain/bin.
Also tried running the krun and crun tests which get krun/crun from /opt/kontain/bin.
Verified that "make release" copies krun and crun into build/opt_kontain/bin and they
are hardlinked togther.  Verified that krun and crun are in build/kontain.tar.gz