### PR TITLE
Support Fedora 33 as a workstation

### DIFF
--- a/cloud/aws/kkm-regression.bash
+++ b/cloud/aws/kkm-regression.bash
@@ -50,7 +50,7 @@ echo "Running regressions on $TEST_BRANCH"
 export AWS_DEFAULT_OUTPUT='text'
 export AWS_DEFAULT_REGION='us-east-2'
 
-readonly TEST_AMI='ami-099c0e6093b0e5bbb'
+readonly TEST_AMI='ami-0d9b5973f0a5fedeb'
 readonly TEST_VM_TYPE='m5.large'
 readonly TEST_SG='sg-0a319ac77d674c77f'
 readonly SSH_OPTIONS='-o StrictHostKeyChecking=no -o ConnectionAttempts=10 -o ConnectTimeout=10'

--- a/docs/VMs.md
+++ b/docs/VMs.md
@@ -162,6 +162,15 @@ It is recommended to install fewer packages to save disk space.
 Once the installation is complete reboot the machine and follow configuration steps.
 Create a user named `fedora`.
 When this is complete login on the console
+and create `.ssh` directory and ssh key using `ssh-keygen`.
+Enable and start `sshd` so you can connect from regular terminal window:
+```bash
+ssh-keygen
+sudo systemctl enable sshd
+sudo systemctl start sshd
+```
+Then follow the steps in `build.md` document to prepare new Fedora machine.
+
 and follow steps in `build.md` document to prepare new Fedora machine.
 Once you enable and start `sshd` you can connect from regular terminal window.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -80,6 +80,8 @@ sudo usermod -aG docker root
 sudo usermod -aG docker $(id -un)
 ```
 
+In order for these changes to take effect you need to exit and login again.
+
 Enable docker start on system boot, and start it:
 
 ```bash
@@ -146,6 +148,9 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" > /etc/yum.repos.d/kubernetes.repo'
 sudo dnf install -y git python3-cffi make azure-cli kubectl
 ```
+
+Don't forget to exit and login again so that the new group membership takes effect.
+Or simply reboot the system and login.
 
 ### Source tree and build environment
 

--- a/docs/image-targets.md
+++ b/docs/image-targets.md
@@ -116,7 +116,7 @@ Each payload also supports the same targets supported for KM, but uses payload-s
 ### Running a CI with custom buildenv images
 
 If a PRs needs changes to buildenv images, it needs to have these new buildenv images built, pushed to Azure
-and then used during CI run for this PR, all without as little impact to other runs as possible.
+and then used during CI run for this PR, all with as little impact to other runs as possible.
 
 Also, the PR may need to change ALL buildenv images if they are impacted by the base one.
 
@@ -130,7 +130,7 @@ If new buildenv image is NOT backward compatible and will break prior builds. Do
 
 1. Make sure the image works by using PR with the custom image and BUILDENV_IMAGE_VERSION set (below)
 2. Merge it as is. This way anyone who rebases will still have working build
-3. Ask everyone to pause (ot submitting and not looking at PRs) .
+3. Ask everyone to pause (not submitting and not looking at PRs) .
 4. Make a small PR which rollbacks custom imagename. Push new image as :latest, merge the PR
 5. Let everyone know to rebase and resume
 .
@@ -147,7 +147,7 @@ So if generic changes to *all* buildenv images is needed, the env variable can b
 If the change is needed for specific buildenv images only, then the variable needs to be passed indivdually to the needed Makefiles. E.g. if the buildenv image for Java has changed , these are the steps to build and push:
 
 ```sh
-tag=myTag  # something uniqie e.g. branch name with no special char`
+tag=myTag  # something unique e.g. branch name with no special char`
 cd payloads/java
 make buildenv-image
 eval $(make  print-BUILDENV_IMG)  # this will place the image name (sans tag) into $BUILDENV_IMG

--- a/make/images.mk
+++ b/make/images.mk
@@ -15,7 +15,7 @@
 #  - testenv-image (all artifacts for running build suites, including KM and payloads)
 #  - runenv-image (minimal image for running KM+payload)
 #
-# The first 2 are explained in docs/build.md and docs/images-targets.md
+# The first 2 are explained in docs/build.md and docs/image-targets.md
 #
 # The runenv-image is a bare bones image for specific payload.
 # 		Can be built with 'make runenv-image'. The following info needs to be defined in Makefile for it to work
@@ -275,6 +275,7 @@ buildenv-local-fedora: .buildenv-local-dnf .buildenv-local-lib ## make local bui
 .buildenv-local-lib: .buildenv-local-check-image | ${KM_OPT_RT} ${KM_OPT_BIN} ${KM_OPT_COVERAGE_BIN}
 	docker create --name tmp_env ${BUILDENV_IMG_TAGGED}
 	sudo docker cp tmp_env:/opt/kontain /opt
+	sudo docker cp tmp_env:/usr/local /usr
 	docker rm tmp_env
 
 .buildenv-local-check-image:

--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -35,7 +35,34 @@ RUN tar cf - -C / lib usr/lib \
 # Save the path to gcc versioned libs for the future
 RUN dirname $(gcc --print-file-name libgcc.a) > $PREFIX/alpine-lib/gcc-libs-path.txt
 
-FROM fedora:31 AS buildenv
+FROM fedora:31 AS buildenv-early
+# Some of the packages needed only for payloads and /or faktory, but we land them here for convenience.
+#
+# Also, this list is used on generating local build environment, so we explicitly add
+# some packages which are always present on Fedora32 but may be missing on Fedora31 (e.g. python3-markupsafe).
+# We have also added packages needed by python.km extensions json generation (jq, googler) and crun's build:
+#   automake autoconf libcap-devel yajl-devel libseccomp-devel
+#   python3-libmount libtool
+RUN dnf install -y \
+   gcc gcc-c++ make gdb git-core gcovr \
+   time patch file findutils diffutils which procps-ng python2 \
+   glibc-devel glibc-static libstdc++-static \
+   elfutils-libelf-devel bzip2-devel \
+   zlib-static bzip2-static xz-static \
+   openssl-devel openssl-static jq googler \
+   python3-markupsafe parallel \
+   automake autoconf libcap-devel yajl-devel libseccomp-devel \
+   python3-libmount libtool \
+   && dnf upgrade -y && dnf clean all && rm -rf /var/cache/{dnf,yum}
+
+FROM buildenv-early AS buildlibelf
+
+RUN dnf install -y flex bison zstd gettext-devel bsdtar xz-devel
+RUN git clone git://sourceware.org/git/elfutils.git -b elfutils-0.182 && cd elfutils && \
+   autoreconf -i -f && \
+   ./configure --enable-maintainer-mode --disable-libdebuginfod --disable-debuginfod && make -j && make install
+
+FROM buildenv-early AS buildenv
 ARG USER=appuser
 # Dedicated arbitrary in-image uid/gid, mainly for file access
 ARG UID=1001
@@ -48,24 +75,7 @@ ENV USER=$USER
 ENV PREFIX=/opt/kontain
 WORKDIR /home/$USER
 
-# Some of the packages needed only for payloads and /or faktory, but we land them here for convenience.
-#
-# Also, this list is used on generating local build environment, so we explicitly add
-# some packages which are always present on Fedora32 but may be missing on Fedora31 (e.g. python3-markupsafe).
-# We have also added packages needed by python.km extensions json generation (jq, googler) and crun's build:
-#   automake autoconf libcap-devel yajl-devel libseccomp-devel
-#   python3-libmount libtool
-RUN dnf install -y \
-   gcc gcc-c++ make gdb git-core gcovr \
-   time patch file findutils diffutils which procps-ng python2 \
-   glibc-devel glibc-static libstdc++-static \
-   elfutils-libelf-devel elfutils-libelf-devel-static bzip2-devel \
-   zlib-static bzip2-static xz-static \
-   openssl-devel openssl-static jq googler \
-   python3-markupsafe parallel \
-   automake autoconf libcap-devel yajl-devel libseccomp-devel \
-   python3-libmount libtool \
-   && dnf upgrade -y && dnf clean all && rm -rf /var/cache/{dnf,yum}
-
+COPY --from=buildlibelf /usr/local /usr/local/
 COPY --from=alpine-lib-image $PREFIX $PREFIX/
+
 USER $USER


### PR DESCRIPTION
This change adds statically built libelf to the base image, that we built from source instead of relying on the system provided one.

Also some docs fixes.