### PR TITLE
km_parse_args() needs to redirect stderr even when km is invoked by symlink

### DIFF
--- a/km/km_main.c
+++ b/km/km_main.c
@@ -524,6 +524,9 @@ km_parse_args(int argc, char* argv[], int* argc_p, char** argv_p[], int* envc_p,
             km_errx(1, "cannot set payload arguments when resuming a snapshot");
          }
       }
+   }
+   if (km_called_via_exec() == 0) {
+      // km_exec_recover_kmstate() has already setup km_log_file in the case of entry by execve().
       km_redirect_msgs(km_log_to);
    }
 


### PR DESCRIPTION

In km was invoked by a path that symlinked to km, then km doesn't process km command line args.
In addition it skipped calling km_redirect_msgs() which prevented messages from km_info() and the like from
being displayed.

The fix is to have km_parse_args() call km_redirect_msgs() if km was not entered by exec from another payload.
exec from another payload causes message redirection to be handled in km_exec_recover_kmstate() by calling
km_redirect_msgs_after_exec().

Tested by running the bats tests.