### PR TITLE
Alternative: Hacked nightly build to mute node test failure (issue #1027) [TRIVIAL] 

### DIFF
--- a/payloads/node/skip_avx2
+++ b/payloads/node/skip_avx2
@@ -1,0 +1,10 @@
+parallel/test-crypto-binary-default.js
+parallel/test-crypto-domains.js
+parallel/test-crypto-pbkdf2.js
+parallel/test-crypto-scrypt.js
+parallel/test-crypto-keygen.js
+parallel/test-domain-crypto.js
+parallel/test-worker-message-port-wasm-module.js
+parallel/test-worker-stdio.js
+async-hooks/test-crypto-pbkdf2.js
+sequential/test-async-wrap-getasyncid.js


### PR DESCRIPTION
skip failing node tests to enable nightly