### PR TITLE
Doubled CI timeout for node test-all (30min->60min) TRIVIAL

### DIFF
--- a/templates/ci_nightly.yaml
+++ b/templates/ci_nightly.yaml
@@ -17,7 +17,7 @@ steps:
 
   - bash: make -C payloads/node test-all-withk8s
     displayName: Node.km tests - run on Kubernetes
-    timeoutInMinutes: 30
+    timeoutInMinutes: 60
 
   - bash: make -C payloads validate-runenv-withk8s
     displayName: payloads runenv validation - run on Kubernetes


### PR DESCRIPTION
We use a cheaper VM there and with current load we run out of the allocated
time often. Since it's nightly run , extra time does not impact PRs
so doubling it