### PR TITLE
Add sigtimedwait() support in km.

### DIFF
--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -251,7 +251,13 @@ static int km_vcpu_init(km_vcpu_t* vcpu)
    vcpu->sigpending = (km_signal_list_t){.head = TAILQ_HEAD_INITIALIZER(vcpu->sigpending.head)};
    vcpu->thr_mtx = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
    vcpu->thr_cv = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
-   vcpu->signal_wait_cv = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
+
+   // Since we may do timed wait on signal_wait_cv, we must specify which clock to use.
+   pthread_condattr_t condattr;
+   pthread_condattr_init(&condattr);
+   pthread_condattr_setclock(&condattr, CLOCK_MONOTONIC);
+   pthread_cond_init(&vcpu->signal_wait_cv, &condattr);
+   pthread_condattr_destroy(&condattr);
    return 0;
 }
 

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -296,7 +296,7 @@ static int km_gdb_vcpu_disengage(km_vcpu_t* vcpu, void* unused)
 /*
  * Initialize gdb's per vcpu state.
  * Called when a vcpu (a thread) comes to life.
- * You do want to called this when a parked vcpu is reused.
+ * You do want to call this when a parked vcpu is reused.
  */
 void km_gdb_vcpu_state_init(km_vcpu_t* vcpu)
 {
@@ -1817,7 +1817,7 @@ static void km_gdb_handle_vcontpacket(char* packet, char* obuf, int* resume)
                                        tid);
                               info.si_signo = linuxsigno;
                               info.si_code = SI_USER;
-                              km_deliver_signal(vcpu, &info);
+                              km_deliver_signal_from_gdb(vcpu, &info);
                            }
                         }
                      } else {
@@ -2639,7 +2639,7 @@ static void gdb_handle_remote_commands(gdb_event_t* gep)
 
                info.si_signo = linux_signo(signo);
                info.si_code = SI_USER;
-               km_deliver_signal(vcpu, &info);
+               km_deliver_signal_from_gdb(vcpu, &info);
             } else {
                // The signal number is bad or missing
                send_error_msg();
@@ -2687,7 +2687,7 @@ static void gdb_handle_remote_commands(gdb_event_t* gep)
 
                info.si_signo = linux_signo(signo);
                info.si_code = SI_USER;
-               km_deliver_signal(vcpu, &info);
+               km_deliver_signal_from_gdb(vcpu, &info);
             } else {
                // The signal number is bad or missing
                send_error_msg();

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1161,6 +1161,22 @@ static km_hc_ret_t rt_sigsuspend_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
+static km_hc_ret_t rt_sigtimedwait(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   // int rt_sigtimedwait(const sigset_t *set, const siginfo_t *info, const struct timespec *timeout, size_t setlen);
+   km_sigset_t* set = km_gva_to_kma(arg->arg1);
+   siginfo_t* info = NULL;
+   struct timespec* timeout = NULL;
+
+   if ((arg->arg2 != 0 && (info = km_gva_to_kma(arg->arg2)) == NULL) ||
+       (arg->arg3 != 0 && (timeout = km_gva_to_kma(arg->arg3)) == NULL)) {
+      arg->hc_ret = -EFAULT;
+      return HC_CONTINUE;
+   }
+   arg->hc_ret = km_rt_sigtimedwait(vcpu, set, info, timeout, arg->arg4);
+   return HC_CONTINUE;
+}
+
 static km_hc_ret_t epoll1_create_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
    // int epoll_create(int size);
@@ -1922,6 +1938,7 @@ void km_hcalls_init(void)
    km_hcalls_table[SYS_rt_sigaction] = rt_sigaction_hcall;
    km_hcalls_table[SYS_rt_sigreturn] = rt_sigreturn_hcall;
    km_hcalls_table[SYS_rt_sigpending] = rt_sigpending_hcall;
+   km_hcalls_table[SYS_rt_sigtimedwait] = rt_sigtimedwait;
    km_hcalls_table[SYS_rt_sigsuspend] = rt_sigsuspend_hcall;
    km_hcalls_table[SYS_sigaltstack] = sigaltstack_hcall;
    km_hcalls_table[SYS_kill] = kill_hcall;

--- a/km/km_signal.h
+++ b/km/km_signal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 Kontain Inc. All rights reserved.
+ * Copyright © 2019-2021 Kontain Inc. All rights reserved.
  *
  * Kontain Inc CONFIDENTIAL
  *
@@ -24,6 +24,7 @@ void km_deliver_signal(km_vcpu_t* vcpu, siginfo_t* info);
 void km_deliver_next_signal(km_vcpu_t* vcpu);
 int km_dequeue_signal(km_vcpu_t* vcpu, siginfo_t* info);
 int km_signal_ready(km_vcpu_t*);
+void km_deliver_signal_from_gdb(km_vcpu_t* vcpu, siginfo_t* info);
 
 uint64_t
 km_rt_sigprocmask(km_vcpu_t* vcpu, int how, km_sigset_t* set, km_sigset_t* oldset, size_t sigsetsize);
@@ -39,6 +40,7 @@ void km_wait_for_signal(int sig);
 typedef void (*sa_action_t)(int, siginfo_t*, void*);
 void km_install_sighandler(int signum, sa_action_t hander_func);
 uint64_t km_rt_sigsuspend(km_vcpu_t* vcpu, km_sigset_t* mask, size_t masksize);
+uint64_t km_rt_sigtimedwait(km_vcpu_t* vcpu, km_sigset_t* set, siginfo_t* info, struct timespec* timeout, size_t setlen);
 
 static inline int km_sigindex(int signo)
 {
@@ -48,6 +50,11 @@ static inline int km_sigindex(int signo)
 static inline void km_sigemptyset(km_sigset_t* set)
 {
    *set = 0L;
+}
+
+static inline void km_sigfillset(km_sigset_t *set)
+{
+   *set = ~0L;
 }
 
 static inline void km_sigaddset(km_sigset_t* set, int signo)

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -822,6 +822,9 @@ fi
    run km_with_timeout -Vhyper signal_test$ext -v
    assert_success
    assert_line --partial "Ignoring tgid 100"
+
+   # Try out the sigtimedwait() hypercall
+   run km_with_timeout sigtimedwait_test$ext
 }
 
 @test "pthread_cancel($test_type): (pthread_cancel_test$ext)" {

--- a/tests/sigtimedwait_test.c
+++ b/tests/sigtimedwait_test.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2021 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ */
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <signal.h>
+#include <pthread.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include "greatest/greatest.h"
+#include "syscall.h"
+
+/*
+ * Test basic sigtimedwait() functionality.
+ */
+
+// Convert a timespec to nanosecond value
+static inline uint64_t ts2ns(struct timespec* ts)
+{
+   return (ts->tv_sec * 1000000000ul) + ts->tv_nsec;
+}
+
+// Return the difference between 2 timespecs in nanoseconds
+uint64_t timespec_delta(struct timespec *this, struct timespec* minusthis)
+{
+   return ts2ns(this) - ts2ns(minusthis);
+}
+
+/*
+ * A thread that pauses briefly and then sends a SIGUSR1 signal that the main
+ * thread should be waiting for.
+ */
+void* signal_sender(void* arg)
+{
+   int rc;
+
+   // pause
+   struct timespec sleeptime = { 1, 0 };
+   rc = nanosleep(&sleeptime, NULL);
+   if (rc != 0) {
+      fprintf(stderr, "%s: nanosleep failed, %s\n", __FUNCTION__, strerror(errno));
+   }
+   fprintf(stdout, "Sending SIGUSR1 to main thread\n");
+
+   // send signal to the main thread
+   pid_t threadid = (pid_t)(uint64_t)arg;
+   rc = syscall(SYS_tkill, threadid, SIGUSR1);
+   if (rc != 0) {
+      fprintf(stderr, "%s: SYS_tkill failed, %s\n", __FUNCTION__, strerror(errno));
+   }
+
+   return NULL;
+}
+
+
+TEST sigtimedwait_test(void)
+{
+   struct timespec start, end;
+   struct timespec thislong;
+   int signo;
+   sigset_t set;
+   sigset_t oldset;
+   siginfo_t info;
+   int rc;
+
+   // Call sigtimedwait() with an invalid wait time.  Should fail with EINVAL.
+   fprintf(stdout, "Testing sigtimedwait() with invalid wait time\n");
+   sigemptyset(&set);
+   sigaddset(&set, SIGUSR1);
+   thislong.tv_sec = 0;
+   thislong.tv_nsec = 10L * 1000 * 1000 * 1000;   // 10 seconds in nanoseconds
+   signo = sigtimedwait(&set, &info, &thislong);
+   ASSERT_EQ(-1, signo);
+   ASSERT_EQ(EINVAL, errno);
+
+   // wait for a signal that never arrives with a timeout of 0
+   fprintf(stdout, "Testing sigtimedwait() with wait time of 0\n");
+   sigemptyset(&set);
+   sigaddset(&set, SIGUSR1);
+   thislong.tv_sec = 0;
+   thislong.tv_nsec = 0;
+   clock_gettime(CLOCK_MONOTONIC, &start);
+   signo = sigtimedwait(&set, &info, &thislong);
+   ASSERT_EQ(-1, signo);
+   ASSERT_EQ(EAGAIN, errno);
+   clock_gettime(CLOCK_MONOTONIC, &end);
+   ASSERTm("sigtimedwait() with no wait took too long", timespec_delta(&end, &start) < 100000000ul);
+
+   /*
+    * wait for a signal that never arrives with a short timeout, verify that timeout is approximately
+    * correct.  I will guess that this test may fail on azure during high load periods.
+    */
+   fprintf(stdout, "Testing sigtimedwait() with a short wait time\n");
+   sigemptyset(&set);
+   sigaddset(&set, SIGUSR1);
+   thislong.tv_sec = 0;
+   thislong.tv_nsec = 250000000;   // .25 seconds
+   clock_gettime(CLOCK_MONOTONIC, &start);
+   signo = sigtimedwait(&set, &info, &thislong);
+   ASSERT_EQ(-1, signo);
+   ASSERT_EQ(EAGAIN, errno);
+   clock_gettime(CLOCK_MONOTONIC, &end);
+   uint64_t deltat = timespec_delta(&end, &start);
+   fprintf(stderr, "Should wait for %ld nanoseconds, actually waited %ld nanoseconds\n", thislong.tv_nsec, deltat);
+#define TIME_ERROR_MARGIN 50000000ul
+   ASSERTm("sigtimedwait() didn't wait long enough", deltat > thislong.tv_nsec - TIME_ERROR_MARGIN);
+   ASSERTm("sigtimedwait() waited too long", deltat < thislong.tv_nsec + TIME_ERROR_MARGIN);
+
+
+   // Post a blocked signal and then wait for it
+   fprintf(stdout, "Testing sigtimedwait() waiting for a blocked signal\n");
+   sigemptyset(&set);
+   sigaddset(&set, SIGUSR1);
+   rc = sigprocmask(SIG_BLOCK, &set, &oldset);
+   ASSERT_EQ(0, rc);
+   rc = kill(getpid(), SIGUSR1);
+   ASSERT_EQ(0, rc);
+   memset(&info, 0, sizeof(info));
+   thislong.tv_sec = 0;
+   thislong.tv_nsec = 0;
+   signo = sigtimedwait(&set, &info, &thislong);
+   fprintf(stderr, "signo %d, info.si_signo %d, errno %d, %s\n", signo, info.si_signo, errno, strerror(errno));
+   ASSERT_EQ(SIGUSR1, signo);
+   ASSERT_EQ(SIGUSR1, info.si_signo);
+   rc = sigprocmask(SIG_SETMASK, &oldset, NULL);
+   ASSERT_EQ(0, rc);
+
+
+   /*
+    * Have this thread block indefinitely waiting for SIGUSR1 and spawn a thread that will
+    * send SIGUSR1.
+    * This test may fail on heavily loaded systems if this thread (main) is stalled
+    * and the signal sender thread sends SIGUSR1 before this thread has blocked waiting for
+    * it.
+    */
+   fprintf(stdout, "Testing sigtimedwait() waiting indefinitely for a signal\n");
+   memset(&info, 0, sizeof(info));
+   sigemptyset(&set);
+   sigaddset(&set, SIGUSR1);
+   rc = sigprocmask(SIG_BLOCK, &set, &oldset);
+   ASSERT_EQ(0, rc);
+
+   pthread_t thread;
+   void* arg = (void*)(uint64_t)syscall(SYS_gettid);
+   rc = pthread_create(&thread, NULL, signal_sender, arg);
+   ASSERT_EQ(0, rc);
+
+   // Wait for a signal from the thread
+   fprintf(stdout, "About to call sigtimedwait()\n");
+   signo = sigtimedwait(&set, &info, NULL);
+   ASSERT_EQ(SIGUSR1, signo);
+   ASSERT_EQ(SIGUSR1, info.si_signo);
+   // wait for signal sender thread to terminate
+   void* voidrv;
+   rc = pthread_join(thread, &voidrv);
+   ASSERT_EQ(0, rc);
+   rc = sigprocmask(SIG_SETMASK, &oldset, NULL);
+   ASSERT_EQ(0, rc);
+
+   PASS();
+}
+
+GREATEST_MAIN_DEFS();
+
+int main(int argc, char* argv[])
+{
+   GREATEST_MAIN_BEGIN();
+
+   RUN_TEST(sigtimedwait_test);
+   GREATEST_PRINT_REPORT();
+   return greatest_info.failed;
+}


### PR DESCRIPTION
This change is modeled after the sigtimedwait() code in the linux kernel.
Look at the file kernel/signal.c in your linux kernel source tree.
The function do_sigtimedwait() seemed to be doing the real work.
Also add a bats test for sigtimedwait().

Passed the bats tests on my workstation.

John: your participation in this review is mandatory.