### PR TITLE
Switched to kontainapp/musl.git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "runtime/musl"]
 	path = runtime/musl
-	url = git://git.musl-libc.org/musl
+	url = ../musl.git
 [submodule "tests/bats"]
 	path = tests/bats
 	url = https://github.com/kontainapp/bats


### PR DESCRIPTION
Switch to our clone (kontainapp/musl) with  v1.2.2 so we can have bug(s) fixes before they (hopefully) make it to the main repo 