### PR TITLE
Using Packer to build AMI with KKM and Kontain pre-loaded

### DIFF
--- a/packer/.gitignore
+++ b/packer/.gitignore
@@ -1,0 +1,1 @@
+packer-manifest.json

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -1,0 +1,47 @@
+# Copyright © 2021 Kontain Inc. All rights reserved.
+#
+# Kontain Inc CONFIDENTIAL
+#
+#  This file includes unpublished proprietary source code of Kontain Inc. The
+#  copyright notice above does not evidence any actual or intended publication of
+#  such source code. Disclosure of this source code or any related proprietary
+#  information is strictly prohibited without the express written permission of
+#  Kontain Inc.
+#
+# Build a kkm-based VM images using packer
+
+# TODO
+# --------
+# setenv or pass credentials as argument, currently ~/.aws is assumed
+# add to nightly CI as a final step. Add info on how to use to km-releases; update AWS stuff there
+
+TOP := $(shell git rev-parse --show-toplevel)
+include ${TOP}/make/actions.mk
+
+all: packer
+
+packer:   ## Create AWS AMI with Ubuntu 20 + KOntain using Packer
+	$(MAKE) MAKEFLAGS="$(MAKEFLAGS)" -C ${TOP} kkm-pkg
+	packer build \
+		-var 'kkm_installer=${BLDTOP}/kkm.run' \
+		-var 'summary_manifest=${BLDDIR}/packer-manifest.json' \
+		ubuntu-20.04-aws.json
+
+
+# Helpers to run , find and terminate test instances, for manual work
+
+INSTANCE_TYPE ?= t2.micro
+KEY_PAIR ?= aws-kkm
+run-instance: ## helper to run an instance and print out ssh string when ready. Use KEY_PAIR and INSTANCE_TYPE to change default
+	./scripts/run-instance.sh $(INSTANCE_TYPE) $(KEY_PAIR)
+
+# Note: name is set in run-instance-sh
+describe-instances: ## helper to kill all instances with a given mame
+	@aws ec2 describe-instances \
+		--filters \
+				'Name=tag:Name,Values=test-Kontain_ubuntu_20.04' \
+				'Name=instance-state-name,Values=running' \
+		--query 'Reservations[].Instances[].InstanceId' --output text
+
+terminate-instances: describe-instances
+	@echo Manually run: 'aws ec2 terminate-instances --instance-ids <ids>'

--- a/packer/readme.md
+++ b/packer/readme.md
@@ -1,0 +1,6 @@
+HashiCorp Packer templates to build VM images for different  targets (e.g. AWS, Azure, Vagrant, etc).
+
+Assumes:
+1. hashicorp Packer installed (https://learn.hashicorp.com/tutorials/packer/getting-started-install) 
+2. AWS access is configured in ~/.aws credentials file (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+

--- a/packer/scripts/run-instance.sh
+++ b/packer/scripts/run-instance.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+#  Copyright © 2021 Kontain Inc. All rights reserved.
+#
+# A helper to run AWS instance based on $AMI_name.
+#
+# $1 - instance type
+# $2 - keypair
+set -e ; [ "$TRACE" ] && set -x
+
+[ "$TRACE" ] && set -x
+
+instance_type=$1
+key_pair=$2
+
+AMI_name=Kontain_ubuntu_20.04
+VM_name=test-$AMI_name
+
+echo Fetching AMI id for AMI \"$AMI_name\" ...
+ImageId=$(aws ec2 describe-images  --region us-west-1  \
+		      --filters "Name=name,Values=$AMI_name" \
+		      --output text --query "reverse(sort_by(Images, &CreationDate))[:1].ImageId")
+
+echo Creating an instance \"$VM_name\" from AMI $ImageId...
+InstanceId=$(aws ec2 run-instances --image-id $ImageId \
+		--security-group-ids ssh-access --instance-type  $instance_type \
+      --key-name $key_pair \
+		--tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$VM_name}]" \
+		--output text --query "Instances[:1].InstanceId")
+
+echo Waiting for instance \"$VM_name\" $InstanceId to become ready and expose an IP...
+aws ec2 wait instance-running --instance-ids $InstanceId && \
+IP=$(aws ec2 describe-instances --instance-ids $InstanceId \
+		 --output text --query 'Reservations[*].Instances[*].PublicIpAddress')
+
+echo "Connect to instance when sshd is up: ssh -i ~/.ssh/$key_pair.pem ubuntu@$IP"
+

--- a/packer/ubuntu-20.04-aws.json
+++ b/packer/ubuntu-20.04-aws.json
@@ -1,0 +1,71 @@
+{
+   "variables": {
+      "ami_label": "Ubuntu 20.04 LTS with Kontain and KKM",
+      "aws_region": "us-west-1",
+      "ssh_user": "ubuntu",
+      "kkm_installer": "should-be-passed-from-caller",
+      "kkm_installer_local": "/tmp/kkm.run",
+      "summary_manifest": "packer-manifest.json"
+   },
+   "builders": [
+      {
+         "type": "amazon-ebs",
+         "region": "{{user `aws_region`}}",
+         "source_ami_filter": {
+            "filters": {
+               "virtualization-type": "hvm",
+               "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210129",
+               "root-device-type": "ebs"
+            },
+            "owners": [
+               "099720109477"
+            ],
+            "most_recent": true
+         },
+         "instance_type": "t2.micro",
+         "ssh_username": "{{user `ssh_user`}}",
+         "ssh_pty": true,
+         "force_deregister": "true",
+         "ami_name": "Kontain_ubuntu_20.04",
+         "ami_description": "{{user `ami_label`}}",
+         "ami_groups": "all",
+         "associate_public_ip_address": "true",
+         "tags": {
+            "Name": "{{user `ami_label`}}",
+            "OS_Version": "Ubuntu",
+            "Release": "20.04",
+            "Base_AMI_Name": "{{ .SourceAMIName }}",
+            "Timestamp": "{{timestamp}}"
+         }
+      }
+   ],
+   "provisioners": [
+      {
+         "type": "file",
+         "source": "{{user `kkm_installer`}}",
+         "destination": "{{user `kkm_installer_local`}}"
+      },
+      {
+         "type": "shell",
+         "inline": [
+            "echo ===== Installing Kontain Kernel Monitor module...",
+            "{{user `kkm_installer_local`}}"
+         ],
+         "execute_command": "/usr/bin/cloud-init status --wait && chmod +x {{.Path}}; {{.Path}}"
+      },
+      {
+         "type": "shell",
+         "inline": [
+            "echo ===== Installing and verifying Kontain... ",
+            "sudo mkdir -p /opt/kontain ; sudo chown -R $(whoami) /opt/kontain",
+            "wget https://raw.githubusercontent.com/kontainapp/km-releases/master/kontain-install.sh -O - -q | bash"
+         ]
+      }
+   ],
+   "post-processors": [
+      {
+         "type": "manifest",
+         "output": "{{user `summary_manifest`}}"
+      }
+   ]
+}

--- a/tests/perf_test.c
+++ b/tests/perf_test.c
@@ -35,7 +35,7 @@
 #define NSEC_PER_SEC (1000 * 1000 * 1000ULL)
 #define NSEC_PER_MILLI_SEC (1000 * 1000ULL)
 
-typedef struct {
+    typedef struct {
    struct timespec start;
    struct timespec end;
    u_int64_t nsec_consumed;


### PR DESCRIPTION
a simple Packer template that builds AWS AMi with KKM and KM preinstatalled and runs basic validation (during KM install from km-releases) 

Also a couple of helper targets for manually creating and deleting VMs based on the above AWS

does not currently impact build and is a pre-req for pipeline automation of all AWS and VM image-related 

Please take a look at json file - it is trivial and will get you the idea on Packer

