### PR TITLE
Have hc_socket test use retry params on curl command.

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -265,14 +265,12 @@ fi
    local address="http://127.0.0.1:$port"
 
    (./hello_html_test.fedora $port &)
-   sleep 0.5s
-   run curl -s $address
+   run curl -s $address --retry-connrefused  --retry 3 --retry-delay 1
    assert_success
    linux_out="${output}"
 
    (km_with_timeout hello_html_test$ext $port &)
-   sleep 0.5s
-	run curl -s $address
+   run curl -s $address --retry-connrefused  --retry 3 --retry-delay 1
    assert_success
    diff <(echo -e "$linux_out") <(echo -e "$output")
 }


### PR DESCRIPTION
The curl command in the hc_socket bats test would sometimes start before the test program would.
Then curl would fail because nothing was listening on the desired port.
So, change curl to retry the connection to the test program.

Tested with the bats tests.