### PR TITLE
Fixed node runenv [TRIVIAL]

### DIFF
--- a/payloads/node/Makefile
+++ b/payloads/node/Makefile
@@ -91,6 +91,7 @@ RUNENV_VALIDATE_CMD := scripts/hello.js
 # define this function
 export define runenv_prep
 	cp ${PAYLOAD_KM} ${RUNENV_PATH}
+	cd ${RUNENV_PATH} ; ln -sf /opt/kontain/bin/km node
 endef
 
 RELEASE_TAG := node node-12

--- a/payloads/node/runenv.dockerfile
+++ b/payloads/node/runenv.dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 COPY . /
-ENTRYPOINT [ "/opt/kontain/bin/km", "--copyenv", "node.km" ]
+ENTRYPOINT [ "/node" ]


### PR DESCRIPTION
node runenv fall behind and did not reflect the way we do runenv now.
It caused conflict and confusion with building Kontainers on top of it

    tested: manual (with customer example) and CI