### PR TITLE
Added Vagrantfile and cosmetic fixes to packer and doc

### DIFF
--- a/demo/spring-boot/README.md
+++ b/demo/spring-boot/README.md
@@ -28,19 +28,25 @@ is available in /opt/kontain/bin.
 
 ```bash
 docker run --name=KM_SpringBoot_Demo --privileged --rm -it --device=/dev/kvm \
- -v /opt/kontain/bin/km:/opt/kontain/bin/km:z \
- -v /opt/kontain/runtime/libc.so:/opt/kontain/runtime/libc.so:z \
- -v /opt/kontain/bin/km_cli:/opt/kontain/bin/km_cli:z \
+ -v /opt/kontain/bin:/opt/kontain/bin:z \
+ -v /opt/kontain/runtime:/opt/kontain/runtime:z \
  -v ${WORKSPACE}/km/payloads/java/scripts:/scripts:z \
  --entrypoint /bin/sh -p8080:8080 kontainapp/spring-boot-demo
 ```
 
 ### Step 3 Measure Base Startup Time
 
-Outside of the container run
+Outside of the container run `test.sh`. If in the source tree, it is available here:
 
 ```sh
 demo/spring-boot/test/test.sh
+```
+
+Or, you can extract it from a running container: and then run :
+
+```sh
+docker cp KM_SpringBoot_Demo:/test.sh /tmp/test.sh
+/tmp/test.sh
 ```
 
 This program will get the time when the server first responds.

--- a/demo/spring-boot/kontain.dockerfile
+++ b/demo/spring-boot/kontain.dockerfile
@@ -2,6 +2,7 @@ FROM kontain/runenv-jdk-11.0.8:latest
 RUN apk add --update coreutils
 RUN echo 'date +%s%N >& /tmp/start_time; /opt/kontain/bin/km --mgtpipe /tmp/km.sock /opt/kontain/java/bin/java.kmd -XX:-UseCompressedOops -jar /app.jar' > /run.sh
 RUN echo 'date +%s%N >& /tmp/start_time; /opt/kontain/bin/km --resume kmsnap' > /run_snap.sh
+COPY test/test.sh /test.sh
 ARG TARGET_JAR_PATH
 COPY ${TARGET_JAR_PATH} /app.jar
 EXPOSE 8080/tcp

--- a/docs/aws_regression.md
+++ b/docs/aws_regression.md
@@ -3,14 +3,14 @@
 ## Notes
 
 Regression test in aws is part of kontainapp.km-kkm test.
-After the regression test with kkm on azure is complete, aws kkm test is triggered from templates/kkm.yaml. 
+After the regression test with kkm on azure is complete, aws kkm test is triggered from templates/kkm.yaml.
 
-amazon access key id, secret access key as well as instace password are saved in azure pipeline as secret variables.
+amazon access key id, secret access key as well as instance password are saved in azure pipeline as secret variables.
 
 There are 3 components to this test
 
 1. templates/kkm.yaml - This copies the secret variables to env before running cloud/aws/kkm-regression.bash
-2. cloud/aws/kkm-regression.bash - This script does instance management. This script provisions a new aws ec2 instance and copies cloud/aws/kkm-test.bash to the newly creates instance and run the test. Upon successfull completion of test instance is terminated, otherwise the instance is shutdown. we can restart the instance to debug the problem. Instance ID is logged as part of azure pipeline logs.
+2. cloud/aws/kkm-regression.bash - This script does instance management. This script provisions a new aws ec2 instance and copies cloud/aws/kkm-test.bash to the newly creates instance and run the test. Upon successful completion of test instance is terminated, otherwise the instance is shutdown. we can restart the instance to debug the problem. Instance ID is logged as part of azure pipeline logs.
 3. cloud/aws/kkm-test.bash - This script checkout source code, builds and runs the test. Each step logs the output to a separate file in /home/fedora/src/log directory.
 
 

--- a/km_cli/Makefile
+++ b/km_cli/Makefile
@@ -21,4 +21,4 @@ LOCAL_LDOPTS := -Wl,--script=${TOP}/km/km_guest_ldcmd
 include ${TOP}/make/actions.mk
 
 install: ${BLDEXEC} ## Install into /opt/kontain
-	sudo cp ${BLDEXEC} ${KM_OPT_BIN}/${EXEC}
+	cp ${BLDEXEC} ${KM_OPT_BIN}/${EXEC}

--- a/packer/.gitignore
+++ b/packer/.gitignore
@@ -1,1 +1,1 @@
-packer-manifest.json
+.vagrant

--- a/packer/Vagrantfile
+++ b/packer/Vagrantfile
@@ -1,0 +1,58 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+#  Vagrant-managed VM with Kontain KM / KKM preinstalled.
+#
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "bento/ubuntu-20.10"
+
+  config.vm.provision "file", source: "../build/kkm.run", destination: "~/kontain/"
+  config.vm.provision "file", source: "./daemon.json", destination: "~/kontain/"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+
+  config.vm.provision "shell", inline: <<-SHELL
+
+   # Install KKM... it will also validate hardware.
+   sudo  apt-get install linux-headers-$(uname -r) -y 2>&1
+   ./kontain/kkm.run 2>&1
+
+   # Install Docker
+   sudo apt-get install -q -y \
+         apt-transport-https ca-certificates \
+         curl gnupg-agent software-properties-common
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -  2>&1
+
+   sudo add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+   sudo apt-get update -y -q
+   sudo apt-get install -y -q docker-ce docker-ce-cli containerd.io
+
+   # Install Kontain. Version is passed to kontain-install.sh
+   sudo mkdir -p /opt/kontain ; sudo chown -R $(whoami) /opt/kontain
+   wget https://raw.githubusercontent.com/kontainapp/km-releases/master/kontain-install.sh -q
+   chmod a+x ./kontain-install.sh; ./kontain-install.sh v0.1-beta2
+
+   # Configure Docker and restart
+   sudo  usermod -aG docker vagrant
+   sudo cp ./kontain/daemon.json /etc/docker/daemon.json
+   sudo systemctl reload-or-restart docker.service
+
+  SHELL
+
+   l=ENV['KM_VAGRANT_PRELOAD_IMAGES']
+   if l != nil then
+      l.split.each do |image|
+         config.vm.provision "shell", inline: "docker pull #{image}"
+      end
+   end
+
+   config.vm.provider "virtualbox" do |v|
+      v.memory = 8182
+      v.cpus = 4
+   end
+
+   config.vm.post_up_message = "Welcome to Ubuntu with Kontain / KKM preinstalled."
+end

--- a/packer/daemon.json
+++ b/packer/daemon.json
@@ -1,0 +1,11 @@
+{
+    "default-runtime": "runc",
+    "runtimes": {
+      "krun": {
+        "path": "/opt/kontain/bin/krun"
+      },
+      "crun": {
+        "path": "/opt/kontain/bin/crun"
+      }
+    }
+} 

--- a/packer/readme.md
+++ b/packer/readme.md
@@ -1,6 +1,16 @@
-HashiCorp Packer templates to build VM images for different  targets (e.g. AWS, Azure, Vagrant, etc).
+# Build VMs with KM and KKM installed
+
+Provides HashiCorp Packer templates and vagrant `Vagrantfile` to build VM images for different  targets (e.g. AWS, Azure, Vagrant, etc).
 
 Assumes:
-1. hashicorp Packer installed (https://learn.hashicorp.com/tutorials/packer/getting-started-install) 
-2. AWS access is configured in ~/.aws credentials file (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 
+1. Packer & Vagrant are installed (see https://learn.hashicorp.com/tutorials)
+2. For Packer: AWS access is configured in ~/.aws credentials file (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+3. For Vagrant: VirtualBox is installed (https://www.virtualbox.org/)
+
+**Warning** whan a vagrant/virtualbox VM is running on a host (i.e. after `vagrant up`) , KM (or QEMU) on the same host will fail with 'EBUSY', This is because VirtualBox uses it's own kernel module which takes exclusive ownership of CPU virtualization facility in Linux kernel, and thus /dev/kvm is not avaiable for monitors other than VirtualBox itself.
+
+* To build vagrant VM with KKM and KM installed: `vagrant up`
+  * To pre-load extra docker images, set env var KM_VAGRANT_PRELOAD_IMAGES, eg. `export KM_VAGRANT_PRELOAD_IMAGES="kontainapp/spring-boot-demo kontainapp/runenv-python kontainapp/runenv-node"`
+* To build AMI wirh KKM and KM installed: `make`. Note that this will also build kkm.run in top-level KM
+* To create AWS instances based on the above AMI `make run-instance`

--- a/packer/ubuntu-20.04-aws.json
+++ b/packer/ubuntu-20.04-aws.json
@@ -58,7 +58,8 @@
          "inline": [
             "echo ===== Installing and verifying Kontain... ",
             "sudo mkdir -p /opt/kontain ; sudo chown -R $(whoami) /opt/kontain",
-            "wget https://raw.githubusercontent.com/kontainapp/km-releases/master/kontain-install.sh -O - -q | bash"
+            "wget https://raw.githubusercontent.com/kontainapp/km-releases/master/kontain-install.sh -q",
+            "chmod a+x ./kontain-install.sh; ./kontain-install.sh v0.1-beta1"
          ]
       }
    ],


### PR DESCRIPTION
Allows to run 'vagrant up' in ./packer, and get full Ubuntu 20.10 with KKM and KM  and KRUN installed. 
See readme.md for more details

Also a few small fixes to spring boot demo
and removed sudo from install in km_cli

tested manually by following demo/spring-boot/README.md 

No impact on regular build/CI