### PR TITLE
add java tests to normal ci

### DIFF
--- a/templates/ci_normal.yaml
+++ b/templates/ci_normal.yaml
@@ -14,6 +14,10 @@ steps:
     displayName: Node.km tests - run on Kubernetes
     timeoutInMinutes: 5
 
+  - bash: make -C payloads/java test-withk8s
+    displayName: java tests - run on Kubernetes
+    timeoutInMinutes: 5
+
   - bash: make -C payloads/demo-dweb test-withk8s
     displayName: demo-dweb.km tests - run on Kubernetes
     timeoutInMinutes: 5


### PR DESCRIPTION
noticed that kkm ci runs java tests while ci_normal does not. Add it to ci_normal