### PR TITLE
stubs and hypercalls to make tensorflow run

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -363,6 +363,20 @@ uint64_t km_fs_close(km_vcpu_t* vcpu, int fd)
    return ret;
 }
 
+// int flock(int fd, int operation);
+uint64_t km_fs_flock(km_vcpu_t* vcpu, int fd, int op)
+{
+   km_infox(KM_TRACE_FILESYS, "flock(%d, %d)", fd, op);
+   if (km_fs_g2h_fd(fd, NULL) < 0) {
+      return -EBADF;
+   }
+   int ret = __syscall_2(SYS_flock, fd, op);
+   if (ret != 0) {
+      km_warn(" error return from flock of guest fd %d", fd);
+   }
+   return ret;
+}
+
 // int shutdown(int sockfd, int how);
 int km_fs_shutdown(km_vcpu_t* vcpu, int sockfd, int how)
 {

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -84,6 +84,8 @@ uint64_t km_fs_open(km_vcpu_t* vcpu, char* pathname, int flags, mode_t mode);
 uint64_t km_fs_openat(km_vcpu_t* vcpu, int dirfd, char* pathname, int flags, mode_t mode);
 // int close(fd)
 uint64_t km_fs_close(km_vcpu_t* vcpu, int fd);
+// int flock(int fd, int operation);
+uint64_t km_fs_flock(km_vcpu_t* vcpu, int fd, int op);
 // int shutdown(int sockfd, int how);
 int km_fs_shutdown(km_vcpu_t* vcpu, int sockfd, int how);
 // ssize_t read(int fd, void *buf, size_t count);

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -436,8 +436,14 @@ static km_hc_ret_t getcwd_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 
 static km_hc_ret_t close_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
-   // arg->hc_ret = __syscall_1(hc, arg->arg1);
    arg->hc_ret = km_fs_close(vcpu, arg->arg1);
+   return HC_CONTINUE;
+}
+
+static km_hc_ret_t flock_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   // int flock(int fd, int operation);
+   arg->hc_ret = km_fs_flock(vcpu, arg->arg1, arg->arg2);
    return HC_CONTINUE;
 }
 
@@ -2038,6 +2044,9 @@ void km_hcalls_init(void)
 
    km_hcalls_table[SYS_set_robust_list] = dummy_hcall;
    km_hcalls_table[SYS_get_robust_list] = dummy_hcall;
+
+   km_hcalls_table[SYS_mbind] = dummy_hcall;
+   km_hcalls_table[SYS_flock] = flock_hcall;
 
    km_hcalls_table[SYS_uname] = uname_hcall;
 

--- a/runtime/strtoll_l_km.c
+++ b/runtime/strtoll_l_km.c
@@ -9,3 +9,13 @@ unsigned long long strtoull_l(const char* nptr, char** endptr, size_t base, void
 {
    return strtoull(nptr, endptr, base);
 }
+
+double __strtof_internal(const char* nptr, char** endptr, int group, void* unused)
+{
+   return strtof(nptr, endptr);
+}
+
+double __strtod_internal(const char* nptr, char** endptr, int group, void* unused)
+{
+   return strtod(nptr, endptr);
+}


### PR DESCRIPTION
These changes still don't allow standard unmodified TF to run. There are mainly two issues remaining:

- standard TF uses `PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP`. However TF compiled with this disabled works
- https url is reported unsupported, seemingly because of issues with libssl, requires more investigation. I ran regular TF first to allow it to fetch all of the necessary urls and cache them locally. Then KM tenfsorflow with the above change runs to completion

Note that neither of the above is captured by this PR. This one is just about additional functionality in KM and runtime needed for TF.

Added these: 

- flock hypercall
- jnk and ynl -- long double Bessel functions. Stubs that core
- register_printf_* family -- gnu libc extensions to register new types with printf. Error returning stubs.
- __strto{d,f}_internal -- ignoring locale

The only test performed was the TF inference app
