### PR TITLE
fix error checking in guest address. Use == FAILED_GA instead of < 0

### DIFF
--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -59,7 +59,7 @@ km_gva_t km_init_main(km_vcpu_t* vcpu, int argc, char* const argv[], int envc, c
 {
    km_gva_t map_base;
 
-   if ((map_base = km_guest_mmap_simple(GUEST_STACK_SIZE)) < 0) {
+   if ((map_base = km_guest_mmap_simple(GUEST_STACK_SIZE)) == FAILED_GA) {
       km_err(1, "Failed to allocate memory for main stack");
    }
    km_gva_t stack_top = map_base + GUEST_STACK_SIZE;

--- a/km/km_intr.c
+++ b/km/km_intr.c
@@ -72,7 +72,7 @@ void km_init_guest_idt(void)
    /*
     * Create a GDT. Allocate a page. We only need entry 1 for the IDT.
     */
-   if ((gdt_base = km_guest_mmap_simple_monitor(KM_PAGE_SIZE)) < 0) {
+   if ((gdt_base = km_guest_mmap_simple_monitor(KM_PAGE_SIZE)) == FAILED_GA) {
       km_err(1, "Failed to allocate guest IDT memory");
    }
    gdt = (x86_seg_d_t*)km_gva_to_kma_nocheck(gdt_base);
@@ -89,7 +89,7 @@ void km_init_guest_idt(void)
    /*
     * Create the IDT.
     */
-   if ((idt_base = km_guest_mmap_simple_monitor(X86_IDT_SIZE)) < 0) {
+   if ((idt_base = km_guest_mmap_simple_monitor(X86_IDT_SIZE)) == FAILED_GA) {
       km_err(1, "Failed to allocate guest IDT memory");
    }
    idte = (x86_idt_entry_t*)km_gva_to_kma_nocheck(idt_base);

--- a/km/km_mmap.c
+++ b/km/km_mmap.c
@@ -879,9 +879,8 @@ km_mremap_grow(km_mmap_reg_t* ptr, km_gva_t old_addr, size_t old_size, size_t si
    // No free space to grow, alloc new
    km_gva_t ret;
    if (may_move == 0 ||
-       (ret = km_syscall_ok(
-            km_guest_mmap_nolock(0, size, ptr->protection, ptr->flags, -1, 0, MMAP_ALLOC_GUEST))) ==
-           -1) {
+       km_syscall_ok(
+           ret = km_guest_mmap_nolock(0, size, ptr->protection, ptr->flags, -1, 0, MMAP_ALLOC_GUEST)) < 0) {
       km_info(KM_TRACE_MMAP, "Failed to get mmap for growth (may_move = %d)", may_move);
       return -ENOMEM;
    }
@@ -889,7 +888,7 @@ km_mremap_grow(km_mmap_reg_t* ptr, km_gva_t old_addr, size_t old_size, size_t si
    void* from = km_gva_to_kma(old_addr);
    assert(from != NULL);         // should have been checked before, in hcalls
    memcpy(to, from, old_size);   // WARNING: this may be slow, see issue #198
-   if (km_syscall_ok(km_guest_munmap_nolock(old_addr, old_size)) == -1) {
+   if (km_syscall_ok(km_guest_munmap_nolock(old_addr, old_size)) < 0) {
       km_err(1, "Failed to unmap after remapping");
    }
    return ret;
@@ -900,7 +899,7 @@ static km_gva_t km_mremap_shrink(km_mmap_reg_t* ptr, km_gva_t old_addr, size_t o
 {
    assert(old_addr >= ptr->start && old_addr < ptr->start + ptr->size &&
           old_addr + old_size <= ptr->start + ptr->size);
-   if (km_syscall_ok(km_guest_munmap_nolock(old_addr + size, old_size - size)) == -1) {
+   if (km_syscall_ok(km_guest_munmap_nolock(old_addr + size, old_size - size)) < 0) {
       return -EFAULT;
    }
    return old_addr;


### PR DESCRIPTION
No change in normal functionality. But if things like mmap fail make error work.

Regular tests pass.

I had mmap failing in my huge pages experiment. The old code would miss the failure and continue, failing later trying to dereference -1ul pointer. New code reports the error as expected.