### PR TITLE
Added utimensat_hcall and fixed ENOENT handling in exec

### DIFF
--- a/km/km_exec.c
+++ b/km/km_exec.c
@@ -24,8 +24,8 @@
 #include "km.h"
 #include "km_exec.h"
 #include "km_filesys.h"
-#include "km_mem.h"
 #include "km_gdb.h"
+#include "km_mem.h"
 
 /*
  * The execve hypercall builds the following environment variables which are appended to
@@ -117,6 +117,7 @@ static char* km_exec_vers_var(void)
          bufp = NULL;
       }
    }
+   km_infox(KM_TRACE_EXEC, "version var: %s", bufp);
    return bufp;
 }
 
@@ -248,11 +249,13 @@ static char* km_exec_pidinfo_var(void)
 }
 
 /*
- * Build "KM_EXEC_GDBINFO=...." environment variable for gdb related values that are passed to the new instance of km.
+ * Build "KM_EXEC_GDBINFO=...." environment variable for gdb related values that are passed to the
+ * new instance of km.
  */
 static char* km_exec_gdbinfo_var(void)
 {
-   int bufl = sizeof(KM_EXEC_GDBINFO) + 1 + (17 * strlen("xxxx,")) + strlen("fs=xxxx,") + (MAX_GDB_VFILE_OPEN_FD * strlen("xxxx,"));
+   int bufl = sizeof(KM_EXEC_GDBINFO) + 1 + (17 * strlen("xxxx,")) + strlen("fs=xxxx,") +
+              (MAX_GDB_VFILE_OPEN_FD * strlen("xxxx,"));
    char* bufp = malloc(bufl);
    if (bufp == NULL) {
       return NULL;
@@ -320,7 +323,7 @@ char** km_exec_build_env(char** envp)
    if (km_verbose != NULL) {
       gdb_vars++;
    }
-   km_infox(KM_TRACE_EXEC, "fork_wait %s, km verbose %s", fork_wait, km_verbose);
+   km_infox(KM_TRACE_EXEC, "ENV: fork_wait %s, km verbose %s", fork_wait, km_verbose);
 
    // Allocate a new env array with space for the exec related vars.
    char** newenvp = malloc((envc + gdb_vars + KM_EXEC_VARS) * sizeof(char*));
@@ -796,7 +799,8 @@ int km_exec_recover_kmstate(void)
 
    // Get the gdb state back.  Not sure if gdb expects us to remember open gdb fd's.
    int wait_for_attach;
-   n = sscanf(gdbinfo, "%d,%d,%d,%hhd,%d,%hhd,%d,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,fs=%d,",
+   n = sscanf(gdbinfo,
+              "%d,%d,%d,%hhd,%d,%hhd,%d,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,%hhd,fs=%d,",
               &gdbstub.port,
               &gdbstub.listen_socket_fd,
               &gdbstub.sock_fd,

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -80,7 +80,7 @@ ifneq (${EXEC},)
 all: ${BLDEXEC}
 ${BLDEXEC}: $(OBJS) | ${KM_OPT_BIN_PATH}
 	$(CC) $(CFLAGS) $(OBJS) $(LDOPTS) $(LOCAL_LDOPTS) $(addprefix -l ,${LLIBS}) -o $@
-	@-cp $@ ${KM_OPT_BIN_PATH}
+	-cp $@ ${KM_OPT_BIN_PATH}
 
 # if VERSION_SRC is defined, force-rebuild these sources on 'git info' changes
 ifneq (${VERSION_SRC},)

--- a/payloads/node/runenv.dockerfile
+++ b/payloads/node/runenv.dockerfile
@@ -1,3 +1,6 @@
-FROM scratch
-COPY . /
-ENTRYPOINT [ "/node" ]
+FROM alpine
+# note: 'alpine' (instead of 'scratch') adds 6MB to Node's 43MB.
+# It helps with troubleshooting and using shell in further dockerfiles
+
+COPY . /usr/local/bin/
+ENTRYPOINT [ "/usr/local/bin/node" ]

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1160,10 +1160,16 @@ fi
    # test execveat() which is fexecve()
    run km_with_timeout exec_test$ext -f
    assert_success
+   assert_output --partial "Checking fexecve"
    assert_line --regexp "argv.0. = .*print_argenv_test"
    assert_line --partial "argv[4] = 'd4'"
    assert_line --partial "env[0] = 'ONE=one'"
    assert_line --partial "env[3] = 'FOUR=four'"
+
+   # test correct stderr for non-existing files
+   run km_with_timeout exec_test$ext -e
+   assert_failure
+   assert_output --partial "errno 2,"
 
    # test exec into shebang
    KM_EXEC_TEST_EXE=shebang_test.sh run km_with_timeout exec_test$ext
@@ -1181,6 +1187,11 @@ fi
 
 @test "clock_gettime($test_type): VDSO clock_gettime, dependency on TSC (clock_gettime$ext)" {
    run km_with_timeout clock_gettime_test$ext -v
+   assert_success
+}
+
+@test "utimensat_test($test_type): set mtime and atime with ns precision (utimensat_test$ext)" {
+   run km_with_timeout utimensat_test$ext
    assert_success
 }
 

--- a/tests/utimensat_test.c
+++ b/tests/utimensat_test.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ *
+ * Basic test for utimensat() call
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+int main()
+{
+   int fd;
+   int ret;
+   struct stat stbuf;
+   char fname[256] = "/tmp/utimens_test_XXXXXX";
+   struct timespec time_to_set[2] = {{1000000000, 111}, {1000000000, 222}};
+
+   if ((fd = mkstemp(fname)) == -1) {
+      fprintf(stderr, "mktemp fd %d %d %s\n", fd, errno, strerror(errno));
+      return -1;
+   }
+
+   fstat(fd, &stbuf);
+   fprintf(stderr,
+           "%s before: atime %ld ns mtime %ld ns\n",
+           fname,
+           stbuf.st_atim.tv_nsec,
+           stbuf.st_mtim.tv_nsec);
+
+   usleep(100);
+   if ((ret = utimensat(0, fname, time_to_set, 0)) == -1) {
+      fprintf(stderr, "utimensat return %d %d %s\n", ret, errno, strerror(errno));
+      return -1;
+   }
+
+   fstat(fd, &stbuf);
+   close(fd);
+   unlink(fname);
+
+   fprintf(stderr,
+           "%s after: atime %ld ns mtime %ld ns\n",
+           fname,
+           stbuf.st_atim.tv_nsec,
+           stbuf.st_mtim.tv_nsec);
+
+   // return 1 if all is good
+   return (stbuf.st_atim.tv_nsec == time_to_set[0].tv_nsec &&
+           stbuf.st_mtim.tv_nsec == time_to_set[1].tv_nsec)
+              ? 0
+              : -1;
+}


### PR DESCRIPTION
Both items were exposed by trying to run node.js with express, and
trying to use npm

tests included


Also 
- small changes to runenv-node to make it more compatible with standasd npm/node locations 
- some auto-formatting by VS