### PR TITLE
Fix gdb remote lib list qXfer to use the correct length of the list.

### DIFF
--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -1473,6 +1473,9 @@ static int km_gdb_linkmap_visit(link_map_t* kmap, link_map_t* gvap, void* argp)
 
 /*
  * The current list of libraries.
+ * Note that gdb_libsvr4_listl is the length of the memory region pointed to by
+ * gdb_libsvr4_listp, not the size of the useful data in the memory region.
+ * The library list is a nul terminated string.
  */
 static char* gdb_libsvr4_listp;
 static size_t gdb_libsvr4_listl;
@@ -1518,11 +1521,12 @@ static void handle_qxfer_librariessvr4_read(const char* packet, char* obuf)
    }
 
    // Send a chunk of the library list.
-   if (offset >= gdb_libsvr4_listl) {   // asking for beyond the end of the list
+   uint32_t liblistlen = strlen(gdb_libsvr4_listp);
+   if (offset >= liblistlen) {   // asking for beyond the end of the list
       obuf[0] = 'l';
       obuf[1] = 0;
    } else {
-      bytes_to_deliver = gdb_libsvr4_listl - offset;
+      bytes_to_deliver = liblistlen - offset;
       if (bytes_to_deliver > length) {
          bytes_to_deliver = length;
          obuf[0] = 'm';


### PR DESCRIPTION
Serge found this problem while debugging tensor flow. Apparently the library list request from the gdb client was causing gdb stub to reply with an 'm' reply that contained no data which is a gdb remote protocol violation.

This code builds the entire library list and then feeds the list back to the gdb client in chunks at the client's request.
The code was formerly using the length of the memory region holding the lib list reply,
not the actual length of the reply to decide how much to send back to the gdb client.
Since the reply memory region is almost always longer than the actual reply, gdb stub would send back more than was there.
Eventually the last chunk of the library list would be requested and we would send back an 'm' reply with no body.
If there is no body, we should be sending back an 'l' reply.
The empty 'm' reply caused the gdb client to issue this error "Remote qXfer reply contained no data."

I don't understand how the empty 'm' reply is being generated.
