### PR TITLE
Kick off v0.1-edge release packaging and uploading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,19 @@ kkm-pkg: ## Build KKM module self-extracting package.
 	$(MAKE) MAKEFLAGS="$(MAKEFLAGS)" -C ${TOP}/kkm/kkm clean
 	makeself -q kkm ${BLDTOP}/kkm.run "beta-release" ./installer/build-script.sh
 
+RELEASE_TAG ?= v0.1-edge
+RELEASE_MESSAGE ?= Kontain KM Edge - date: $(shell date) sha: $(shell git rev-parse HEAD)
+REPO_URL := https://${GITHUB_TOKEN}@github.com/kontainapp/km.git
+edge-release: ## Trigger edge-release building pipeline
+	git config user.email "release@kontain.app"
+	git config user.name "Kontain Release Pipeline Bot"
+	@echo Delete the ${RELEASE_TAG} tag. Can fail if there is no such tag yet
+	-git tag -d ${RELEASE_TAG} && git push --delete ${REPO_URL} ${RELEASE_TAG}
+	@echo Now tag the source and push the tag to trigger the pipeline
+	git tag -a ${RELEASE_TAG} --message "${RELEASE_MESSAGE}"
+	git push ${REPO_URL} ${RELEASE_TAG}
+
+
 # Install git hooks, if needed
 GITHOOK_DIR ?= .githooks
 git-hooks-init: ## make git use GITHOOK_DIR (default .githooks) for pre-commit and other hooks

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,6 +26,7 @@ If a payload need to put extra files im a release, it needs to implement `releas
 * `v0.1-beta` for this release name, we also automatically override the existing release
   * This allows us to manually replace beta release as we update the code base.
   * at some point we will start using unique names (e.g. `0.1-beta-rc1`) but for now I do not want to pollute the list of releases on github
+* `v0.1-edge` is created by the nightly run. This is used by other projects (like `kontain-faas`) that want current KM release bits as part of their build. **automatically overrides the prior one with the same tag.**
 * `For any other tag`, if a release with this tag already exists on km-releases repo, publishing of a release will fail.
 
 Also:
@@ -48,8 +49,8 @@ Assuming the product build has succeeded, here are the steps to build a release
 
 Prerequisites
 
-1. Create a github personal token and place it's value in GITHUB_RELEASE_TOKEN env var. (https://github.com/settings/tokens)
-1. Make sure PyGitHub python module is installed `pip3 install --user PyGitGHub`
+1. Create a github personal token and place it's value in GITHUB_RELEASE_TOKEN env var. (https://github.com/settings/tokens). Ensure that the token scopes `write:packages` and `delete:packages` are enabled.
+2. Make sure PyGitHub python module is installed `pip3 install --user PyGitGHub`
 
 Steps
 
@@ -70,8 +71,7 @@ When using a branch to trigger a release, we will create a release name after th
 For example, this will trigger the CI release pipeline and create a unique (and not overridable) `v0.1-test-manual` release:
 
 ```bash
-tag=v0.1-test-manual; git tag -a $tag --message "release note here"; git push --follow-tags
-
+tag=v0.1-test-manual; git tag -a $tag --message "release note here"; git push origin $tag
 ```
 
 We also auto-trigger the same release pipeline for any branch named 'releases/*/*, e.g. `releases/beta/snapshot-api`
@@ -101,6 +101,8 @@ The release pipeline builds, publishes and validates the release. See steps in `
 ### Release names agreement
 
 For dev/test, we will use `0.1-test`. When automation is ready, we will keep `0.n-beta` (e.g. `0.11-beta`) as a release created by the process above and triggered with a new tag creation or manually, and `0.n-daily` (e.g. `0.1-daily`) to be replaced on every master update
+
+The name `1.0-edge` is the last good build of KM. This is useful for other Kontain projects that depend on KM. `make edge-release` updates 1.0-edge in github.
 
 We will also use other suffixes (e.g. `0.10-demo`) as needed
 

--- a/templates/ci_nightly.yaml
+++ b/templates/ci_nightly.yaml
@@ -22,3 +22,7 @@ steps:
   - bash: make -C payloads validate-runenv-withk8s
     displayName: payloads runenv validation - run on Kubernetes
     timeoutInMinutes: 5
+
+  - bash: make edge-release GITHUB_TOKEN=$(GITHUB_TOKEN)
+    displayName: Kick off release pipeline to build and upload release v0.1-edge
+    timeoutInMinutes: 5

--- a/tools/release/release_km.py
+++ b/tools/release/release_km.py
@@ -30,7 +30,7 @@ RELEASE_REPO_FULLNAME = "kontainapp/km-releases"
 # Use this is the version name is not compliant with expectations
 RELEASE_DEFAULT_VERSION = "v0.1-test"
 # Delete these if they already exist
-OVERRIDABLE_RELEASES = [ RELEASE_DEFAULT_VERSION, "v0.1-beta" ]
+OVERRIDABLE_RELEASES = [ RELEASE_DEFAULT_VERSION, "v0.1-beta", "v0.1-edge" ]
 
 def main():
     """ main """
@@ -103,7 +103,7 @@ def main():
         created_ref = release_repo.create_git_ref(
             f"refs/tags/{version}", master_commit_sha)
         created_release = release_repo.create_git_release(
-            version, version, args.message)
+            version, f"Kontain {version}", args.message, draft=False, prerelease=False)
 
         for asset in args.assets:
             uploaded_asset = created_release.upload_asset(asset)

--- a/tools/release/requirements.txt
+++ b/tools/release/requirements.txt
@@ -1,1 +1,1 @@
-PyGithub==1.53
+PyGithub>=1.53


### PR DESCRIPTION
CI nightly to kick of v0.1-edge release packaging and uploading after a successful run

Based on #1114 By @johnmuth81 - but instead of making release directly, it simply sets/pushs v0.1-edge tag to the repo, which triggers the release pipeline.

Tested by running CI.

Will be ready for merge when approved and a nightly CI passes.... I've started it manually  https://dev.azure.com/kontainapp/KontainMonitor/_build/results?buildId=5152&view=results