### PR TITLE
Trivial: Added test for execve() ENOEXEC errno

### DIFF
--- a/tests/exec_test.c
+++ b/tests/exec_test.c
@@ -28,6 +28,7 @@
  * Flags:
  * -f to test fexecve().
  * -e to test ENOENT errno
+ * -E flag to test ENOEXEC errno
  * -k flags to test exec into '.km' file
  * -s to tests /bin/sh parse
  * -X to test exec into realpath of /proc/self/exe
@@ -43,6 +44,7 @@
 #define EXEC_TEST_EXE_KM "hello_test.km"
 
 #define EXEC_TEST_EXE_ENOENT "this_file_should_not_exist.ever"
+#define EXEC_TEST_EXE_ENOEXEC "test_helper.bash"   // existing file but not an ELF
 
 int main(int argc, char** argv)
 {
@@ -79,6 +81,15 @@ int main(int argc, char** argv)
               errno,
               strerror(errno),
               EXEC_TEST_EXE_ENOENT);
+      return rc;
+   } else if (strcmp(argv[1], "-E") == 0) {
+      rc = execve(EXEC_TEST_EXE_ENOEXEC, testargv, testenvp);
+      fprintf(stderr,
+              "Expected failure: execve()  rc %d, errno %d, %s: %s\n",
+              rc,
+              errno,
+              strerror(errno),
+              EXEC_TEST_EXE_ENOEXEC);
       return rc;
    } else if (strcmp(argv[1], "-k") == 0) {   // exec into '.km' file
       if (KM_PAYLOAD() == 0) {

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1166,10 +1166,13 @@ fi
    assert_line --partial "env[0] = 'ONE=one'"
    assert_line --partial "env[3] = 'FOUR=four'"
 
-   # test correct stderr for non-existing files
+   # test correct stderr for ENOENT and ENOEXEC
    run km_with_timeout exec_test$ext -e
    assert_failure
    assert_output --partial "errno 2,"
+   run km_with_timeout exec_test$ext -E
+   assert_failure
+   assert_output --partial "errno 8,"
 
    # test exec into shebang
    KM_EXEC_TEST_EXE=shebang_test.sh run km_with_timeout exec_test$ext


### PR DESCRIPTION
Node returns `'Unknown system error -8',` when it fails to execute thing like `system("ls")`, I wanted to check we are doing fine and this test validates it 
