### PR TITLE
Fixed python fromsrc build and runenv validation

### DIFF
--- a/payloads/python/runenv.dockerfile
+++ b/payloads/python/runenv.dockerfile
@@ -1,7 +1,13 @@
-FROM scratch
+FROM alpine
 
 # Python version must be passed on build
 ARG VERS
 
 COPY . /
+
+#
+# In python.km, we look for lib64 (to comply with Fedora layout), so we need to
+# make sure the python files which we MAY get from other containers, are found
+RUN ln -s /usr/local/lib /usr/local/lib64
+
 ENTRYPOINT [ "/usr/local/bin/python3" ]

--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -22,7 +22,7 @@
 FROM alpine:3.13.0 as alpine-lib-image
 ENV PREFIX=/opt/kontain
 
-RUN apk add bash make git g++ gcc musl-dev libffi-dev sqlite-static
+RUN apk add bash make git g++ gcc musl-dev libffi-dev sqlite-static util-linux-dev
 
 # Prepare $PREFIX/alpine-lib while trying to filter out irrelevant stuff
 RUN mkdir -p $PREFIX/alpine-lib
@@ -41,8 +41,8 @@ FROM fedora:31 AS buildenv-early
 # Some of the packages needed only for payloads and /or faktory, but we land them here for convenience.
 #
 # Also, this list is used on generating local build environment, so we explicitly add
-# some packages which are always present on Fedora32 but may be missing on Fedora31 (e.g. python3-markupsafe).
-# We have also added packages needed by python.km extensions json generation (jq, googler) and crun's build:
+# some packages which are always present on Fedora32 but may be missing on Fedora31 (e.g. python3-markupsafe)
+# We have also added packages needed by python.km extensions json generation (jq, googler), by python configuration (libffi-devel)  and crun's build:
 #   automake autoconf libcap-devel yajl-devel libseccomp-devel
 #   python3-libmount libtool
 RUN dnf install -y \
@@ -52,7 +52,7 @@ RUN dnf install -y \
    elfutils-libelf-devel bzip2-devel \
    zlib-static bzip2-static xz-static \
    openssl-devel openssl-static jq googler \
-   python3-markupsafe parallel \
+   python3-markupsafe libffi-devel parallel \
    automake autoconf libcap-devel yajl-devel libseccomp-devel \
    python3-libmount libtool \
    && dnf upgrade -y && dnf clean all && rm -rf /var/cache/{dnf,yum}


### PR DESCRIPTION
We need libffi-devel in buildenv so python properly configures (need it
for ctypes module). We also need to rebuild all images for the above,
and correct runenv for python so it finds files in proper places (we
added a special patch to redirect searched to lib64 - see commit
"tensorflow test-app using custom TF build "

Notes: 
- new builenv are backward compatible so **they are already pushed to Azure**
- new PRs may fail in Python test (due to runenv mismatch) until this PR merges and other PRs rebases due to runenv fix


Test: local run and CI 