### PR TITLE
Have enqueue_signal_nolock() call abort() when there are no free signal entries.

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -528,6 +528,18 @@ extern int km_collect_hc_stats;
       __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                               \
    } while (0)
 
+#define km_abortx(fmt, ...)                                                                        \
+   do {                                                                                            \
+      __km_trace(0, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                                   \
+      abort();                                                                                     \
+   } while (0)
+
+#define km_abort(fmt, ...)                                                                         \
+   do {                                                                                            \
+      __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                               \
+      abort();                                                                                     \
+   } while (0)
+
 #define km_mutex_lock(mutex)                                                                       \
    do {                                                                                            \
       int ret;                                                                                     \

--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -193,7 +193,7 @@ static inline void enqueue_signal_nolock(km_signal_list_t* slist, siginfo_t* inf
    km_signal_t* sig;
 
    if ((sig = TAILQ_FIRST(&machine.sigfree.head)) == NULL) {
-      km_err(1, "No free signal entries");
+      km_abortx("No free signal entries");
    }
    TAILQ_REMOVE(&machine.sigfree.head, sig, link);
    sig->info = *info;


### PR DESCRIPTION
Added 2 new macros km_abort() and km_abortx() that produce a message and then abort km.
Then changed enqueue_signal_nolock() to call km_abortx() when there are no free signal
entries.

Ran the bats tests on my workstation to be sure this change didn't break anything.