### PR TITLE
fix filename leak in mmap

### DIFF
--- a/km/km_mmap.c
+++ b/km/km_mmap.c
@@ -301,7 +301,6 @@ static inline void km_mmap_move_to_free(km_mmap_reg_t* reg)
                  reg->filename != NULL ? reg->filename : "MAP_SHARED");
       } else {
          reg->flags = new_flags;
-         reg->filename = NULL;
       }
    }
    km_mmap_insert_free(reg);


### PR DESCRIPTION
Found running long haul test with valgrind, after tweaking golang runtime to use true syscalls instead of vsyscalls.

Regular tests pass.

Running long haul before the fix would accumulate gigabytes if resident memory in manner of minutes, or dozens of minutes. After the fix the number is way steadier. 