### PR TITLE
Suppress km sympathetic coredumps

### DIFF
--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -585,6 +585,11 @@ static inline void do_guest_handler(km_vcpu_t* vcpu, siginfo_t* info, km_sigacti
  * Handled signals result in the guest being setup to run the signal handler
  * on the next VM_RUN call.
  */
+#ifndef SUID_DUMP_DISABLE
+// This symbol is defined in the kernel source in file include/linux/sched/coredump.h
+// There don't seem to be any user header files that define the symbol.
+#define SUID_DUMP_DISABLE 0
+#endif
 void km_deliver_signal(km_vcpu_t* vcpu, siginfo_t* info)
 {
    km_sigaction_t* act = &machine.sigactions[km_sigindex(info->si_signo)];
@@ -625,7 +630,7 @@ void km_deliver_signal(km_vcpu_t* vcpu, siginfo_t* info)
          km_warn("failed to set default signal handling for signo %d", info->si_signo);
       }
       // Suppress the km coredump but still return the proper exit status.
-      if (prctl(PR_SET_DUMPABLE, 0) != 0) {
+      if (prctl(PR_SET_DUMPABLE, SUID_DUMP_DISABLE) != 0) {
          km_warn("prctl(PR_SET_DUMPABLE, SUID_DUMP_DISABLE) failed");
       }
       if (kill(getpid(), info->si_signo) != 0) {


### PR DESCRIPTION
This change suppresses the km coredump that happens when km arranges for its exit status
to match the payload's exit status.
Instead of using setrlimit()/prlimit() to restrict the size of the core file to zero, we use
prctl(PR_SET_DUMPABLE, SUID_DUMP_DISABLE) to disable the coredump but still return
the correct process exit status signifying the payload terminated with a signal.
prlimit() would suppress the coredump but would leave an entry in the coredumpctl
database for the empty core.
Note that SUID_DUMP_DISABLE seems to only be defined in the kernel source in
include/linux/sched/coredump.h.  I couldn't find the package containing a copy
of that source file, so we hard code this value to 0.

FYI:
Making a process not core dumpable makes the process also not ptrace()able unless the
tracing process has CAP_SYS_PTRACE capability.  Since we are setting the process not core dumpable
just before it is about to exit, I don't think this will be harmful.
We also need to be aware that marking a process as not core dumpable also makes the files
in its /proc/$pid/ directory owned by root.
"man 2 prctl", "man 5 proc", and "man 2 ptrace" give the details about these retrictions.

Tested with bats on my workstation.