### PR TITLE
create ld-linux-x86-64.so in /opt/kontain/runtime

### DIFF
--- a/demo/nokia/kontain-faktory/kontain.dockerfile
+++ b/demo/nokia/kontain-faktory/kontain.dockerfile
@@ -30,10 +30,9 @@ ADD $JDK_VERSION $ORIG_JDK_DIR
 ADD alpine-lib ${KONTAIN_DIR}/alpine-lib
 ADD runtime ${KONTAIN_DIR}/runtime
 
-# Make sure libjvm.so finds the NEEDED ld-linux; and that km is in the right place
-# TODO: remove the need for ld-linux, plus place km & libc.so in the right place - see copy_needed_files.sh
-RUN ln -d /opt/kontain/runtime/libc.so /opt/kontain/runtime/ld-linux-x86-64.so.2 ; \
-   mkdir $KONTAIN_DIR/bin; mv $ORIG_JDK_DIR/bin/km $KONTAIN_DIR/bin/km
+# Make sure that km is in the right place
+# TODO: place km & libc.so in the right place - see copy_needed_files.sh
+RUN mkdir $KONTAIN_DIR/bin; mv $ORIG_JDK_DIR/bin/km $KONTAIN_DIR/bin/km
 
 # Make sure 'shebang' can find /usr/bin/java.km if needed
 RUN ln -s $ORIG_JDK_DIR/bin/java.km /usr/bin/java.km;

--- a/demo/test-app/Dockerfile
+++ b/demo/test-app/Dockerfile
@@ -28,6 +28,8 @@ RUN cp /usr/lib64/libcrypto.so.1.1.1[a-z] /opt/kontain/alpine-lib/lib/libcrypto.
 # switch to 3.8
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python3
 
+# TODO: libc.so and ld-linux-x86-64.so.2 are here only because kontain/test-python-fedora doesn't have
+# /opt/kontain/runtime but dynamic python needs it
 RUN cp ${PHOME}/python.kmd /usr/bin/python3.8.km && \
    mkdir ${PREFIX}/bin && cp ${PHOME}/km ${PREFIX}/bin/ && \
    mkdir ${PREFIX}/runtime/ && cp ${PHOME}/libc.so ${PREFIX}/runtime/ && \

--- a/demo/test-app/Vagrantfile
+++ b/demo/test-app/Vagrantfile
@@ -22,7 +22,6 @@ Vagrant.configure("2") do |config|
    pip install -r requirements.txt
    pip install tensorflow-*-linux_x86_64.whl
    cp /usr/lib64/libcrypto.so.1.1.1[a-z] /opt/kontain/alpine-lib/lib/libcrypto.so.1.1
-   ln -sf /opt/kontain/runtime/libc.so /opt/kontain/alpine-lib/lib/ld-linux-x86-64.so.2
    mv python.kmd /usr/bin/python3.8.km
    mv /usr/bin/python3.8 /usr/bin/python3.8.orig
 

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -357,6 +357,7 @@ uint64_t km_fs_prw(km_vcpu_t* vcpu, int scall, int fd, void* buf, size_t count, 
    } else {
       ret = __syscall_4(scall, host_fd, (uintptr_t)buf, count, offset);
    }
+   km_infox(KM_TRACE_FILESYS, "%s( %d, %ld) - %d", km_hc_name_get(scall), fd, count, ret);
    return ret;
 }
 

--- a/payloads/java/runenv.dockerfile
+++ b/payloads/java/runenv.dockerfile
@@ -19,8 +19,6 @@ ARG JAVA_DIR=/opt/kontain/java
 ENV LD_LIBRARY_PATH ${JAVA_DIR}/lib/server:${JAVA_DIR}/lib/jli:${JAVA_DIR}/lib:/opt/kontain/runtime:/lib64
 
 COPY ${FROM}/ ${JAVA_DIR}/
-# Java is looking for /lib64/ld-linux-x86-64.so.2 so below is the hack to shortcut investigation
-RUN mkdir /lib64; ln -s /opt/kontain/runtime/libc.so /lib64/ld-linux-x86-64.so.2
 RUN ln -s /opt/kontain/bin/km  ${JAVA_DIR}/bin/java; \
    cd ${JAVA_DIR}/bin/; ln -s  java.kmd java.km
 RUN ln -s ${JAVA_DIR}/bin/java /usr/bin/java

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -91,7 +91,8 @@ all: ${BLDDIR}/.finalize
 # After the build, set neccessary symlinks and install to KM_OPT_RT
 # symlnks:
 # libc.a -> libruntime.a           # needed for '-lc'; we may want to rename going forward
-# libc.musl-x86_64.so.1 -> libc.so # needed for libstdc++
+# libc.musl-x86_64.so.1 -> libc.so # needed for Alpine libstdc++
+# ld-linux-x86-64.so.2 -> libc.so  # needed for all non-Alpine (eg Fedora) .so
 .PHONY: ${BLDDIR}/.finalize
 ${BLDDIR}/.finalize: $(addprefix ${BLDDIR}/,libm.a libpthread.a libpthread.so libc.so) ${CRT_OBJS} ${KM_OPT_RT}
 	@#
@@ -101,6 +102,8 @@ ${BLDDIR}/.finalize: $(addprefix ${BLDDIR}/,libm.a libpthread.a libpthread.so li
 		echo symlink libc.a ; ln -s ./libruntime.a libc.a ; fi
 	@cd ${BLDDIR} ; if [ ! -L libc.musl-x86_64.so.1 ] ; then \
 		echo symlink lib.musl.so; ln -s ./libc.so libc.musl-x86_64.so.1 ; fi
+	@cd ${BLDDIR} ; if [ ! -L ld-linux-x86-64.so.2 ] ; then \
+		echo symlink lib.musl.so; ln -s ./libc.so ld-linux-x86-64.so.2 ; fi
 	@#
 	@# mkdir and fill /opt/kontain/runtime
 	@#
@@ -108,7 +111,7 @@ ${BLDDIR}/.finalize: $(addprefix ${BLDDIR}/,libm.a libpthread.a libpthread.so li
 		echo -e "${RED}${KM_OPT_RT} is not writeable - run 'make -C tests buildenv-local-fedora'$(NOCOLOR)" ; \
 		false; \
 	fi
-	@echo Copy libs to ${KM_OPT_RT}...; cp --no-dereference --preserve=all --update ${BLDDIR}/lib{*.a,*.so*} ${KM_OPT_RT}
+	@echo Copy libs to ${KM_OPT_RT}...; cp --no-dereference --preserve=all --update ${BLDDIR}/lib{*.a,*.so*} ${BLDDIR}/ld-linux* ${KM_OPT_RT}
 	@touch $@
 
 $(addprefix ${BLDDIR}/, libm.a):


### PR DESCRIPTION
Instead of haphazardly create that link in various payloads and demos, make it part of base runtime. Fixes #496

