### PR TITLE
Repaired nightly build

### DIFF
--- a/cloud/k8s/kontaind/Makefile
+++ b/cloud/k8s/kontaind/Makefile
@@ -15,12 +15,11 @@ CURRENT_DIR := ${TOP}/cloud/k8s/kontaind
 
 COMPONENT = kontain-installer
 RELEASE_TAG := ${COMPONENT}
-RUNENV_PATH = ${BLDDIR}
 
 # runenv-image configs
 export define runenv_prep
-	mkdir -p ${RUNENV_PATH}/kontain/bin && cp ${KM_BIN} $$_
-	mkdir -p ${RUNENV_PATH}/kontain/runtime && cp --recursive --preserve=all ${KM_OPT_RT} $$_
+	mkdir -p ${BLDDIR}/bin && cp ${KM_BIN} $$_
+	mkdir -p ${BLDDIR}/runtime && cp --preserve=all ${KM_RT}/*.so* $$_
 	cp installer.sh ${RUNENV_PATH}/installer.sh
 endef
 
@@ -40,7 +39,7 @@ delete: ## Delete Kontaind from cluster
 	${DEPLOY_SCRIPT} delete
 
 clean: ## Clean up local build dir
-	rm -rf ${RUNENV_PATH}
+	rm -rf ${BLDDIR}
 
 TEST_SPEC ?= ${CURRENT_DIR}/tests/dweb-service.yaml
 TEST_POD ?= dweb

--- a/cloud/k8s/kontaind/installer.sh
+++ b/cloud/k8s/kontaind/installer.sh
@@ -12,11 +12,16 @@
 # Install kontain related artifacts and do verification.
 #
 # Runs in cluster and expects /opt to be mounted and /dev/kvm available
+#
+# to sanity check offline:
+# docker run --device /dev/kvm -v /tmp/x:/opt:z --rm -it  kontain/runenv-kontain-installer
 
 set -ex
 
-[ -d /opt ]
-[ -e /dev/kvm ]
+device=/dev/kvm
+
+[ -d /opt ] || (echo Missing /opt dir ; false)
+[ -e $device ] || (echo Missing access to $device  ; false)
 
 mkdir -p /opt/kontain
 rm -rf /opt/kontain/*
@@ -24,9 +29,9 @@ cp -r /kontain/* /opt/kontain/
 # non-privileged containers using kvm device plugin needs access
 chmod 666 /dev/kvm
 
-[ -d /opt/kontain ]
-[ -x /opt/kontain/bin/km ]
-[ -f /opt/kontain/runtime/libc.so ]
+echo Validating files presense...
+[ -x /opt/kontain/bin/km ] || (echo Missing KM ; false)
+[ -f /opt/kontain/runtime/libc.so ] || (echo Missing libc.so ; false)
 
-# log the version information for debugging purpose
-/opt/kontain/bin/km -v
+echo Installed KM version:
+/opt/kontain/bin/km -v 2>& 1

--- a/cloud/k8s/kontaind/runenv.dockerfile
+++ b/cloud/k8s/kontaind/runenv.dockerfile
@@ -1,5 +1,6 @@
 FROM busybox
-COPY kontain /kontain
+COPY bin /kontain/bin/
+COPY runtime/*.so /kontain/runtime/
 COPY installer.sh /installer.sh
 ENTRYPOINT [ "sh", "-c" ]
 CMD [ "/installer.sh" ]

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -40,6 +40,7 @@ BLDDIR := $(abspath ${BLDTOP}/${FROMTOP}/${BLDTYPE})
 # so we can use KM from different places
 KM_BLDDIR := $(abspath ${BLDTOP}/km/${BLDTYPE})
 KM_BIN := ${KM_BLDDIR}/km
+KM_RT := ${BLDTOP}/runtime
 KM_OPT := /opt/kontain
 KM_OPT_BIN := ${KM_OPT}/bin
 KM_OPT_INC := ${KM_OPT}/include


### PR DESCRIPTION
nightly was broken because kontaind installer was not properly placing libc.so
on nodes

This PR fixes that. 
Also makes installer log a bit more verbose

tested with manual local testing to check for files layout in installer container, and with [ manual run of a nightly build](https://dev.azure.com/kontainapp/KontainMonitor/_build/results?buildId=5580&view=logs&j=a95e37a9-8f81-5a98-db03-5318f193fa73&t=f25fa407-a8da-5ba1-57a4-366203a8363b) 