### PR TITLE
Fixed runenv in Java

### DIFF
--- a/make/locations.mk
+++ b/make/locations.mk
@@ -113,7 +113,7 @@ else
 endif
 
 KM_OPT_KM := ${KM_OPT_BIN_PATH}/km
-KM_DOCKER_VOLUME := -v ${KM_OPT_KM}:${KM_OPT_KM}:z -v ${KM_OPT_RT}:${KM_OPT_RT}:z
+KM_DOCKER_VOLUME := -v ${KM_OPT_KM}:${KM_OPT_KM}:z
 
 # Utility functions for common docker operations.
 clean_container = @-docker rm --force ${1} 2>/dev/null

--- a/payloads/java/Makefile
+++ b/payloads/java/Makefile
@@ -40,8 +40,6 @@ DEP_PACKAGES := java-11-openjdk \
 # 'yes' if java was build from src (based on existable of .git repo)
 FROMSRC=$(shell test -d $(JDK_VERSION)/.git && echo yes)
 
-# docker build dir for runenv-image
-RUNENV_PATH := .
 # config for image validation
 RUNENV_VALIDATE_DIR := scripts
 RUNENV_VALIDATE_CMD := -cp /scripts Hello
@@ -50,6 +48,13 @@ RUNENV_VALIDATE_DEPENDENCIES := scripts/Hello.class \
 	app/kontain/snapshots/Snapshot.class \
 	app/kontain/snapshots/libkm_java_native.so
 RUNENV_DEMO_DEPENDENCIES := scripts/SimpleHttpServer.class
+
+# runenv-image configs
+export define runenv_prep
+	mkdir -p ${BLDDIR}/java && cp --recursive --preserve=all ${JDK_BUILD_DIR}/images/jdk/* ${BLDDIR}/java
+	mkdir -p ${BLDDIR}/runtime && cp --preserve=all ${KM_RT}/*.so $$_
+endef
+
 
 include ${TOP}/make/images.mk
 

--- a/payloads/java/runenv.dockerfile
+++ b/payloads/java/runenv.dockerfile
@@ -14,13 +14,16 @@
 # TODO: switch to 'from scratch'. See https://github.com/kontainapp/km/issues/496
 FROM alpine
 
-ARG FROM=jdk-11.0.8+10/build/linux-x86_64-normal-server-release/images/jdk
 ARG JAVA_DIR=/opt/kontain/java
 ENV LD_LIBRARY_PATH ${JAVA_DIR}/lib/server:${JAVA_DIR}/lib/jli:${JAVA_DIR}/lib:/opt/kontain/runtime:/lib64
 
-COPY ${FROM}/ ${JAVA_DIR}/
-RUN ln -s /opt/kontain/bin/km  ${JAVA_DIR}/bin/java; \
-   cd ${JAVA_DIR}/bin/; ln -s  java.kmd java.km
-RUN ln -s ${JAVA_DIR}/bin/java /usr/bin/java
+COPY java ${JAVA_DIR}/
+COPY runtime /opt/kontain/runtime/
+
+RUN \
+   ln -s /opt/kontain/runtime/libc.so /opt/kontain/runtime/ld-linux-x86-64.so.2 && \
+   ln -s /opt/kontain/bin/km  ${JAVA_DIR}/bin/java && \
+   cd ${JAVA_DIR}/bin/; ln -s  java.kmd java.km && \
+   ln -s ${JAVA_DIR}/bin/java /bin/java
 
 ENTRYPOINT [ "java" ]


### PR DESCRIPTION
For now ld-linux is still symlinked, so this is just a simple fix
to add proper files

Tested with make runenv-image validate-runenv image in ./payloads