### PR TITLE
Fix for the node test-fs-realpath-pipe.js test

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -535,26 +535,10 @@ static int proc_self_fd_name(const char* pathname, char* buf, size_t bufsz)
    if (sscanf(pathname, PROC_SELF_FD, &fd) != 1 && sscanf(pathname, proc_pid_fd, &fd) != 1) {
       return -ENOENT;
    }
-   char* mpath;
-   if ((mpath = km_guestfd_name(NULL, fd)) == NULL) {
+   if (fd >= km_fs()->nfdmap) {
       return -ENOENT;
    }
-   /*
-    * /proc/self/fd symlinks contain full path name of file, so try to get that.
-    */
-   char* rpath = realpath(mpath, NULL);
-   if (rpath != NULL) {
-      mpath = rpath;
-   }
-   strncpy(buf, mpath, bufsz);
-   int ret = strlen(mpath);
-   if (ret > bufsz) {
-      ret = bufsz;
-   }
-   if (rpath != NULL) {
-      free(rpath);
-   }
-   return ret;
+   return 0;
 }
 
 /*


### PR DESCRIPTION
The problem was a statx() call on /proc/NNNNNNNN/fd/0 was failing when it should have worked.
The reason for the failure is proc_self_fd_name() was returning the contents of the symlink
which km_fs_statx() would pass to syscall(SYS_statx, ....).
fd 0 in this test was a socket.  And the contents of the /proc/pid/fd/0 symlink was something
like "socket:[456789]" which is not a value filename causing statx to fail.

The fix is to remove code from proc_self_fd_name() which was there to xlate the filename from
/proc/1/fd/0 to the path with the real process id in the path which would then be passed to
statx().
We also added some code to disallow attempts to access the km internal fd's above approximately
fd 727.

This was tested with the bats tests and the node "make test-all" test on my workstation.