### PR TITLE
Ensure the bats tests use known invalid pid's.

### DIFF
--- a/tests/sid_pgid_test.c
+++ b/tests/sid_pgid_test.c
@@ -26,6 +26,7 @@
 #include <sys/wait.h>
 
 #include "greatest/greatest.h"
+#include "test_common_functions.h"
 
 TEST sid_test(void)
 {
@@ -48,13 +49,13 @@ TEST sid_test(void)
    ASSERT_NEQ(-1, sid);
    fprintf(stdout, "getpid's sid is %d\n", sid);
 
-   /*
-    * getsid() for invalid km pid
-    * Since km payload pids (and hence sids) always start with 1, 9999 is only
-    * going to be valid if there is a lot of km payload forking and this test forks once.
-    */
-   sid = getsid(9999);
-   fprintf(stdout, "getsid(9999) returns %d, errno %d\n", sid, errno);
+   // Get an invalid pid.
+   pid_t invalid_pid = get_pid_max();
+   ASSERT_NEQ(-1, invalid_pid);
+
+   // getsid() for invalid pid
+   sid = getsid(invalid_pid);
+   fprintf(stdout, "getsid(%d) returns %d, errno %d\n", invalid_pid, sid, errno);
    ASSERT_EQ(-1, sid);
    ASSERT_EQ(ESRCH, errno);
 

--- a/tests/signal_test.c
+++ b/tests/signal_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Kontain Inc. All rights reserved.
+ * Copyright © 2019-2021 Kontain Inc. All rights reserved.
  *
  * Kontain Inc CONFIDENTIAL
  *
@@ -27,28 +27,10 @@
 
 #include "greatest/greatest.h"
 #include "syscall.h"
+#include "test_common_functions.h"
 
 int signal_seen = 0;
 void* stack_addr = NULL;
-
-/*
- * Return the limit on the size of the process id.
- * We should never see a pid with the returned value or larger.
- * If there is a failure -1 is returned.
- */
-pid_t get_pid_max(void)
-{
-   FILE* pidmaxfile = fopen("/proc/sys/kernel/pid_max", "r");
-   if (pidmaxfile != NULL) {
-      pid_t pidmax;
-      if (fscanf(pidmaxfile, "%d", &pidmax) != 1) {
-         pidmax = -1;
-      }
-      fclose(pidmaxfile);
-      return pidmax;
-   }
-   return -1;
-}
 
 void signal_handler(int signal)
 {

--- a/tests/test_common_functions.h
+++ b/tests/test_common_functions.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ */
+
+// Functions that may be useful for more than one test in the bats tests.
+
+/*
+ * Return the limit on the size of the process id.
+ * We should never see a pid with the returned value or larger.
+ * If there is a failure -1 is returned.
+ */
+static inline pid_t get_pid_max(void)
+{
+   FILE* pidmaxfile = fopen("/proc/sys/kernel/pid_max", "r");
+   if (pidmaxfile != NULL) {
+      pid_t pidmax;
+      if (fscanf(pidmaxfile, "%d", &pidmax) != 1) {
+         pidmax = -1;
+      }
+      fclose(pidmaxfile);
+      return pidmax;
+   }
+   return -1;
+}


### PR DESCRIPTION
A few of the bats tests want to use an invalid pid as part of testing.
They were using 9999 which is probably invalid most of the time but sometimes
it is not.
The fix is to get the contents of /proc/sys/kernel/pid_max which is one beyond
the maximum pid the kernel supports and use that value as the invalid pid.

Tested by running the bats tests on my local workstation.
When do we start writing tests to verify that the tests are correct?
Sounds like a recursive descent into test hell.
Can't think about that, brain hurts too much.