### PR TITLE
Better nightly control for manual CI runs [trivial]

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -31,10 +31,10 @@ on:
   # See https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
   workflow_dispatch:
     inputs:
-      logLevel: # just an example fo how we can tune the manual run with more logging
-        description: 'Log level'
+      run_type:
+        description: 'Run type: regular or nightly'
+        default: 'regular'
         required: true
-        default: 'warning'
 
 env:
   BUILDENV_IMAGE_VERSION: latest # use this for all buildenv containers
@@ -56,6 +56,7 @@ jobs:
 
       - name: Print build environment info
         run: |
+          echo "Event: ${{ github.event_name }} inputs.run_type: ${{ github.event.inputs.run_type }}"
           echo ====Environment info===
           echo "SHA: $(git rev-parse HEAD)"
           echo "=== Last 10 commits:"
@@ -223,7 +224,8 @@ jobs:
     runs-on: ubuntu-20.04
     # The extra tests run if the workflow is triggered on schedule or manually.
     # comment out (in your branch) if you want to force it on your run
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_type == 'nightly') }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -237,7 +239,8 @@ jobs:
     name: Run all tests on a new K8s cluster
     runs-on: ubuntu-20.04
     needs: [km-build, km-k8s-cluster]
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_type == 'nightly') }}
     env:
       K8S_TEST_ERR_NO_CLEANUP: true # true means "on error, keep pods around". (assumes cluster is not cleaned up)
     steps:


### PR DESCRIPTION
With the new CI you can run it manually from Github UI. 
There is a button "Run Workflow" under a specific workflow. It also allows you to choose options.

This PR makes it to present "run  type" option, with default "regular", You can type "nightly" and it will run nightly worklow from your manual request. 

Note1: you can also choose a branch in the same UI
Note2: there is a command line for this too: https://cli.github.com/

Not really tested much, it needs to be on master to be functional, but I read multiple docs :-) and the fix is trivial
