### PR TITLE
Remove last traces of --dynlinker

### DIFF
--- a/km/km_elf.h
+++ b/km/km_elf.h
@@ -22,7 +22,6 @@
 
 #define KM_DLOPEN_SYM_NAME "dlopen"
 
-#define KM_DYNLINKER_STR "__km_dynlink__"
 /*
  * Description of the guest payload. Note these structures come from guest ELF and represent values
  * in guest address space. We'll need to convert them to monitor (KM) addresses to acces.
@@ -42,7 +41,6 @@ typedef struct km_payload {
 
 extern km_payload_t km_guest;
 extern km_payload_t km_dynlinker;
-extern const char* km_dynlinker_file;
 
 // Open elf file descriptor
 typedef struct km_elf {

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -1429,25 +1429,6 @@ static int km_gdb_linkmap_visit(link_map_t* kmap, link_map_t* gvap, void* argp)
    int worked;
    char temp[GDB_LIBRARY_DESC_LEN + PATH_MAX];
    char* libname = (char*)km_gva_to_kma((km_gva_t)kmap->l_name);
-   char dynlinker_absolute[PATH_MAX];
-   uint8_t is_dynlinker;
-
-   is_dynlinker = (strcmp(libname, KM_DYNLINKER_STR) == 0);
-   if (is_dynlinker != 0) {
-      if (km_dynlinker_file[0] != '/') {
-         if (getcwd(dynlinker_absolute, sizeof(dynlinker_absolute)) == NULL) {
-            km_info(KM_TRACE_GDB, "getcwd() failied");
-            return 1;
-         }
-         snprintf(&dynlinker_absolute[strlen(dynlinker_absolute)],
-                  sizeof(dynlinker_absolute) - strlen(dynlinker_absolute),
-                  "/%s",
-                  km_dynlinker_file);
-      } else {
-         snprintf(dynlinker_absolute, sizeof(dynlinker_absolute), "%s", km_dynlinker_file);
-      }
-   }
-
    if (lmargp->count == 0) {
       snprintf(temp,
                sizeof(temp),
@@ -1457,7 +1438,7 @@ static int km_gdb_linkmap_visit(link_map_t* kmap, link_map_t* gvap, void* argp)
       snprintf(temp,
                sizeof(temp),
                "  <library name=\"%s\" lm=\"%p\" l_addr=\"0x%lx\" l_ld=\"0x%lx\"/>\n",
-               is_dynlinker != 0 ? dynlinker_absolute : libname,
+               libname,
                gvap,
                kmap->l_addr,
                kmap->l_ld);

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -665,8 +665,8 @@ int main(int argc, char* argv[])
    // snapshot file is type ET_CORE. We check for additional notes in restore
    if (elf->ehdr.e_type == ET_CORE) {
       // check for incompatible options
-      if (envp != NULL || km_dynlinker_file != NULL) {
-         km_errx(1, "cannot set new environment or dynlinker when resuming a snapshot");
+      if (envp != NULL) {
+         km_errx(1, "cannot set new environment when resuming a snapshot");
       }
       if (argc_p > 1) {
          km_errx(1, "cannot set payload arguments when resuming a snapshot");

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -27,8 +27,6 @@
 
 km_payload_t km_guest;
 km_payload_t km_dynlinker;
-static const const_string_t km_dynlinker_default = "/opt/kontain/lib64/libc.so";
-const char* km_dynlinker_file;   // could be set on command line, .interp ELF section, or default above
 
 static void my_mmap(int fd, void* buf, size_t count, off_t offset)
 {
@@ -158,14 +156,7 @@ static void load_dynlink(km_gva_t interp_vaddr, uint64_t interp_len, km_gva_t in
               interp_len,
               interp_adjust);
    }
-   if (strncmp(interp_kma, KM_DYNLINKER_STR, interp_len) != 0) {
-      // Use the dynamic linker in the .interp section
-      km_dynlinker_file = interp_kma;
-   } else if (km_dynlinker_file == NULL) {
-      // Use the dynamic linker mentioned on the command line
-      km_dynlinker_file = km_dynlinker_default;
-   }
-   km_dynlinker.km_filename = km_dynlinker_file;
+   km_dynlinker.km_filename = interp_kma;
 
    km_elf_t* e = km_open_elf_file(km_dynlinker.km_filename);
    km_gva_t base = km_mem_brk(0);


### PR DESCRIPTION
Simplfy dynamic linker processing in load_elf.c and km_gdb_stub.c.

Fixes #1235