### PR TITLE
Reconcile kontainapp/ and kontain/ for runenv images

### DIFF
--- a/cloud/k8s/knative/helloworld-nodejs/Dockerfile
+++ b/cloud/k8s/knative/helloworld-nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM kontain/runenv-node
+FROM kontainapp/runenv-node
 EXPOSE 8080
 COPY km /opt/kontain/bin/km
 COPY helloworld.js /opt/kontain/bin/helloworld.js

--- a/cloud/k8s/pause/Makefile
+++ b/cloud/k8s/pause/Makefile
@@ -21,7 +21,7 @@ $(BIN): $(OBJS)
 $(BIN_KM): $(OBJS)
 	${TOP}/tools/bin/kontain-gcc $(CFLAGS) -o $@ $^
 
-PAUSE_CONTAINER = kontain/pause-km
+PAUSE_CONTAINER = kontainapp/pause-km
 
 distro: $(BIN_KM)
 	docker build -t $(PAUSE_CONTAINER) .

--- a/demo/capado/kontain.dockerfile
+++ b/demo/capado/kontain.dockerfile
@@ -1,4 +1,4 @@
-FROM kontain/runenv-jdk-11.0.8:latest
+FROM kontainapp/runenv-jdk-11.0.8:latest
 COPY springboot-poc-0.0.1-SNAPSHOT.jar springboot-poc-0.0.1-SNAPSHOT.jar
 COPY cmd.sh cmd.sh
 EXPOSE 9090/tcp

--- a/demo/capado/kontain_mn.dockerfile
+++ b/demo/capado/kontain_mn.dockerfile
@@ -1,5 +1,5 @@
-FROM kontain/runenv-jdk-11.0.8:latest
-COPY micronaut-poc-0.1-all.jar micronaut-poc-0.1-all.jar 
+FROM kontainapp/runenv-jdk-11.0.8:latest
+COPY micronaut-poc-0.1-all.jar micronaut-poc-0.1-all.jar
 EXPOSE 9091/tcp
 
 ARG POSTGRES_IP=172.17.0.2

--- a/demo/faktory/java/README.md
+++ b/demo/faktory/java/README.md
@@ -39,7 +39,7 @@ curl  "http://127.0.0.1:8080/greeting"
 sudo tools/faktory/bin/faktory convert --type java \
     kontainapp/faktory-java-demo-original:latest \
     kontainapp/faktory-java-demo-kontain:latest \
-    kontain/runenv-jdk-11.0.8:latest
+    kontainapp/runenv-jdk-11.0.8:latest
 
 # To run the kontainer. --init makes ^C/^Z killing handled by runtime
 docker run -it --init --rm -p 8081:8080 \

--- a/demo/nokia/kontain-faktory/Makefile
+++ b/demo/nokia/kontain-faktory/Makefile
@@ -37,7 +37,7 @@ DOCKER_DIR := .dockerdir
 REPO := kontainstage.azurecr.io/nokia/ckaf
 CLIENT_REPO := kontainstage.azurecr.io/nokia/atg
 # prefix for target containers
-KONTAIN_REPO ?= kontain/nokia
+KONTAIN_REPO ?= kontainapp/nokia
 # source containers names in repo. Hardcoded per component, to simplify the Makefile
 Z_VERSION := zookeeper:2.0.0-3.4.14-2696
 K_VERSION := kafka:2.0.0-5.3.1-2696

--- a/demo/nokia/kontain-faktory/README.md
+++ b/demo/nokia/kontain-faktory/README.md
@@ -8,7 +8,7 @@ Typical sequence of commands:
 ```bash
 make login # login to Azure and Azure private registry
 make pull # One time, for pulling and tagging original images. Assumes login.
-make all  # same as 'make' - builds kontain/nokia-* images from the base ones
+make all  # same as 'make' - builds kontainapp/nokia-* images from the base ones
 make test # validate Kontainer with zookeeper .... just make sure it starts to listen
 ```
 

--- a/demo/spring-boot/Makefile
+++ b/demo/spring-boot/Makefile
@@ -78,7 +78,7 @@ test: clean/test
 clean/test:
 	$(call clean_container,${DEMO_CONTAINER})
 
-DEMO_IMAGE_REG := $(subst kontain/,$(REGISTRY)/,$(DEMO_IMAGE))
+DEMO_IMAGE_REG := $(subst kontainapp/,$(REGISTRY)/,$(DEMO_IMAGE))
 # note: to login, `make -C cloud/docker login' - see docs/how-twos/login-dockerhub.md
 publish-demo: ## publish to docker.io (requred login)
 	$(MAKE) MAKEFLAGS="$(MAKEFLAGS)" .push-image \

--- a/demo/spring-boot/README.md
+++ b/demo/spring-boot/README.md
@@ -133,7 +133,7 @@ for `java -jar build/libs/springboot-poc-0.0.1-SNAPSHOT.jar`
 Docker file:
 
 ```Dockerfile
-FROM kontain/runenv-jdk-11.0.8:latest
+FROM kontainapp/runenv-jdk-11.0.8:latest
 COPY springboot-poc-0.0.1-SNAPSHOT.jar springboot-poc-0.0.1-SNAPSHOT.jar
 EXPOSE 9090/tcp
 ENV POSTGRE_URL jdbc:postgresql://localhost:5432
@@ -170,7 +170,7 @@ To run `java -jar build/libs/micronaut-poc-0.1-all.jar`
 Dokerfile:
 
 ```Dockerfile
-FROM kontain/runenv-jdk-11.0.8:latest
+FROM kontainapp/runenv-jdk-11.0.8:latest
 COPY micronaut-poc-0.1-all.jar micronaut-poc-0.1-all.jar
 EXPOSE 9091/tcp
 

--- a/demo/spring-boot/kontain.dockerfile
+++ b/demo/spring-boot/kontain.dockerfile
@@ -1,4 +1,4 @@
-FROM kontain/runenv-jdk-11.0.8:latest
+FROM kontainapp/runenv-jdk-11.0.8:latest
 RUN apk add --update coreutils
 RUN echo 'rm -rf /tmp/km.sock; date +%s%N >& /tmp/start_time; /opt/kontain/bin/km --mgtpipe /tmp/km.sock /opt/kontain/java/bin/java.kmd -XX:-UseCompressedOops -jar /app.jar' > /run.sh
 RUN echo 'date +%s%N >& /tmp/start_time; /opt/kontain/bin/km kmsnap' > /run_snap.sh

--- a/demo/test-app/Dockerfile
+++ b/demo/test-app/Dockerfile
@@ -12,7 +12,7 @@
 # We have to use our own tensorflow build t avoud usage of non-POSIX APIs.
 # Copy the .whl file from ../../tools/hashicorp/build_tensorflow for Docker to pick it up.
 
-FROM kontain/test-python-fedora
+FROM kontainapp/test-python-fedora
 USER root
 RUN dnf install -y python3.8
 
@@ -28,7 +28,7 @@ RUN cp /usr/lib64/libcrypto.so.1.1.1[a-z] /opt/kontain/alpine-lib/lib/libcrypto.
 # switch to 3.8
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python3
 
-# TODO: libc.so and ld-linux-x86-64.so.2 are here only because kontain/test-python-fedora doesn't have
+# TODO: libc.so and ld-linux-x86-64.so.2 are here only because kontainapp/test-python-fedora doesn't have
 # /opt/kontain/runtime but dynamic python needs it
 RUN cp ${PHOME}/python.kmd /usr/bin/python3.8.km && \
    mkdir ${PREFIX}/bin && cp ${PHOME}/km ${PREFIX}/bin/ && \

--- a/docs/azure_pipeline.md
+++ b/docs/azure_pipeline.md
@@ -88,7 +88,7 @@ Note that push is protected (see Makefiles)
   * click on 1st `Details`
   * Click on `Create and Push KM Test container`. You will see something like `make -C tests testenv-image push-testenv-image IMAGE_VERSION=ci-695 DTYPE=fedora`.
 * pull the test image for the correct version, e.g. `make -C tests pull-testenv-image IMAGE_VERSION=ci-695`
-* Run container locally `docker run -it --rm --device=/dev/kvm kontain/test-km-fedora:ci-695`
+* Run container locally `docker run -it --rm --device=/dev/kvm kontainapp/test-km-fedora:ci-695`
 * in the Docker prompt, run tests: `./run_bats_tests.sh`
 
 ### How to debug code if it fails on Kubernetes only (and passes locally)

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -162,8 +162,8 @@ kubectl delete -k ~/workspace/km/payloads/k8s/azure/python
 docker run -p 8080:8080 -t --rm --device /dev/kvm \
   -v ~/workspace/km/build/km/km:/opt/kontain/bin/km:z  \
   -v ~/workspace/km/payloads/python/scripts/micro_srv.py:/scripts/micro_srv.py \
-  kontain/runenv-python -S "/scripts/micro_srv.py" "8080"
-docker run -p 8080:8080 -t --rm --device /dev/kvm -v ~/workspace/km/build/km/km:/opt/kontain/bin/km:z kontain/runenv-dweb 8080
+  kontainapp/runenv-python -S "/scripts/micro_srv.py" "8080"
+docker run -p 8080:8080 -t --rm --device /dev/kvm -v ~/workspace/km/build/km/km:/opt/kontain/bin/km:z kontainapp/runenv-dweb 8080
 ```
 
 ## Meltdown

--- a/make/images.mk
+++ b/make/images.mk
@@ -35,25 +35,25 @@ endif
 include ${TOP}/make/locations.mk
 
 # Image names and location for image builds
-TEST_IMG := kontain/test-${COMPONENT}-${DTYPE}
+TEST_IMG := kontainapp/test-${COMPONENT}-${DTYPE}
 TEST_IMG_TAGGED := ${TEST_IMG}:${IMAGE_VERSION}
 
-BUILDENV_IMG := kontain/buildenv-${COMPONENT}-${DTYPE}
+BUILDENV_IMG := kontainapp/buildenv-${COMPONENT}-${DTYPE}
 BUILDENV_IMG_TAGGED := ${BUILDENV_IMG}:${BUILDENV_IMAGE_VERSION}
 
 # runenv does not include anything linix distro specific, so it does not have 'DTYPE'
-RUNENV_IMG := kontain/runenv-${COMPONENT}
+RUNENV_IMG := kontainapp/runenv-${COMPONENT}
 RUNENV_IMG_TAGGED := ${RUNENV_IMG}:${IMAGE_VERSION}
 
 # runenv demo image produce a demo based on the runenv image
-RUNENV_DEMO_IMG := kontain/demo-runenv-${COMPONENT}
+RUNENV_DEMO_IMG := kontainapp/demo-runenv-${COMPONENT}
 
 # image names with proper registry
-TEST_IMG_REG := $(subst kontain/,$(REGISTRY)/,$(TEST_IMG))
-BUILDENV_IMG_REG := $(subst kontain/,$(REGISTRY)/,$(BUILDENV_IMG))
+TEST_IMG_REG := $(subst kontainapp/,$(REGISTRY)/,$(TEST_IMG))
+BUILDENV_IMG_REG := $(subst kontainapp/,$(REGISTRY)/,$(BUILDENV_IMG))
 
-RUNENV_IMG_REG := $(subst kontain/,$(REGISTRY)/,$(RUNENV_IMG))
-RUNENV_DEMO_IMG_REG := $(subst kontain/,$(REGISTRY)/,$(RUNENV_DEMO_IMG))
+RUNENV_IMG_REG := $(subst kontainapp/,$(REGISTRY)/,$(RUNENV_IMG))
+RUNENV_DEMO_IMG_REG := $(subst kontainapp/,$(REGISTRY)/,$(RUNENV_DEMO_IMG))
 
 TEST_DOCKERFILE ?= test-${DTYPE}.dockerfile
 BUILDENV_DOCKERFILE ?= buildenv-${DTYPE}.dockerfile

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -68,7 +68,7 @@ DTYPE ?= fedora
 USER  ?= appuser
 
 # needed in 'make withdocker' so duplicating it here, for now
-BUILDENV_IMG  ?= kontain/buildenv-${COMPONENT}-${DTYPE}
+BUILDENV_IMG  ?= kontainapp/buildenv-${COMPONENT}-${DTYPE}
 
 DOCKER_BUILD_LABEL := \
 	--label "Vendor=Kontain.app" \

--- a/payloads/busybox/buildenv-fedora.dockerfile
+++ b/payloads/busybox/buildenv-fedora.dockerfile
@@ -1,2 +1,2 @@
 ARG BUILDENV_IMAGE_VERSION=latest
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}

--- a/payloads/busybox/demo-runenv.dockerfile
+++ b/payloads/busybox/demo-runenv.dockerfile
@@ -1,3 +1,3 @@
 ARG runenv_image_version=latest
-FROM kontain/runenv-busybox:${runenv_image_version}
+FROM kontainapp/runenv-busybox:${runenv_image_version}
 CMD ["/bin/sh", "-c", "ls -l && echo Hello"]

--- a/payloads/busybox/test-fedora.dockerfile
+++ b/payloads/busybox/test-fedora.dockerfile
@@ -1,7 +1,7 @@
 ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
 
-FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 # turn off km symlink trick and minimal shell interpretation
 ENV KM_DO_SHELL NO

--- a/payloads/demo-dweb/buildenv-fedora.dockerfile
+++ b/payloads/demo-dweb/buildenv-fedora.dockerfile
@@ -1,2 +1,2 @@
 ARG BUILDENV_IMAGE_VERSION=latest
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} 
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}

--- a/payloads/demo-dweb/demo-runenv.dockerfile
+++ b/payloads/demo-dweb/demo-runenv.dockerfile
@@ -1,6 +1,6 @@
 ARG runenv_image_version=latest
 
-FROM kontain/runenv-dweb:${runenv_image_version}
+FROM kontainapp/runenv-dweb:${runenv_image_version}
 
 EXPOSE 8080
 CMD [ "dweb", "8080" ]

--- a/payloads/demo-dweb/runenv.dockerfile
+++ b/payloads/demo-dweb/runenv.dockerfile
@@ -1,6 +1,6 @@
 ARG runenv_image_version=latest
 
-FROM kontain/runenv-busybox:${runenv_image_version}
+FROM kontainapp/runenv-busybox:${runenv_image_version}
 
 COPY dweb /dweb
 WORKDIR /dweb

--- a/payloads/demo-dweb/test-fedora.dockerfile
+++ b/payloads/demo-dweb/test-fedora.dockerfile
@@ -13,7 +13,7 @@
 ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
 
-FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 ENV DHOME /home/$USER/demo-dweb/dweb
 

--- a/payloads/java/buildenv-fedora.dockerfile
+++ b/payloads/java/buildenv-fedora.dockerfile
@@ -16,7 +16,7 @@ ARG BUILDENV_IMAGE_VERSION=latest
 
 # Intermediate image with Java source, where Java is built.
 # Thrown away after the the build results are taken from it
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} AS build-jdk
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} AS build-jdk
 ARG JDK_VERSION
 # ENV JDK_VERSION=$JDK_VERSION
 
@@ -61,7 +61,7 @@ RUN find ${BUILD} -name '*.so' | xargs strip
 RUN rm ${BUILD}/images/jdk/lib/src.zip
 
 # Build the target image
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}
 
 ARG BUILD=/home/$USER/jdk-11.0.8+10/build/linux-x86_64-normal-server-release/
 ENV JAVATOP=/home/$USER/java

--- a/payloads/java/demo-runenv.dockerfile
+++ b/payloads/java/demo-runenv.dockerfile
@@ -1,6 +1,6 @@
 ARG runenv_image_version=latest
 
-FROM kontain/runenv-jdk-11.0.8:${runenv_image_version}
+FROM kontainapp/runenv-jdk-11.0.8:${runenv_image_version}
 COPY scripts /scripts
 EXPOSE 8080
 CMD ["-cp", "/scripts", "SimpleHttpServer"]

--- a/payloads/node/buildenv-fedora.dockerfile
+++ b/payloads/node/buildenv-fedora.dockerfile
@@ -10,21 +10,21 @@
 #
 # Dockerfile for build node.js image. There are two stages:
 #
-# buildenv-node - based on kontain/buildenv-km-fedora, git clone, compile and test node
+# buildenv-node - based on kontainapp/buildenv-km-fedora, git clone, compile and test node
 # linkenv - based on km-build-env and just copy the objetcs and test files
 
 ARG MODE=Release
 ARG VERS=v12.4.0
 ARG BUILDENV_IMAGE_VERSION=latest
 
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} AS buildenv-node
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} AS buildenv-node
 ARG MODE
 ARG VERS
 
 RUN git clone https://github.com/nodejs/node.git -b $VERS
 RUN cd node && ./configure --gdb `[[ $MODE == Debug ]] && echo -n --debug` && make -j`expr 2 \* $(nproc)` && make jstest
 
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}
 ARG MODE
 ARG VERS
 ENV MODE=$MODE VERS=$VERS NODETOP=/home/appuser/node

--- a/payloads/node/demo-runenv.dockerfile
+++ b/payloads/node/demo-runenv.dockerfile
@@ -1,6 +1,6 @@
 ARG runenv_image_version=latest
 
-FROM kontain/runenv-node:${runenv_image_version}
+FROM kontainapp/runenv-node:${runenv_image_version}
 
 COPY scripts /scripts/
 COPY docker-entrypoint.sh .

--- a/payloads/node/runenv.dockerfile
+++ b/payloads/node/runenv.dockerfile
@@ -1,4 +1,4 @@
 ARG runenv_image_version=latest
 
-FROM kontain/runenv-busybox:${runenv_image_version}
+FROM kontainapp/runenv-busybox:${runenv_image_version}
 COPY node /usr/local/bin/

--- a/payloads/node/test-fedora.dockerfile
+++ b/payloads/node/test-fedora.dockerfile
@@ -12,7 +12,7 @@
 
 ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
-FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 
 ARG MODE=Release

--- a/payloads/python/buildenv-fedora.dockerfile
+++ b/payloads/python/buildenv-fedora.dockerfile
@@ -10,7 +10,7 @@
 #
 # Dockerfile for build python image. There are two stages:
 #
-# buildenv-cpython - based on kontain/buildenv-km-fedora, git clone, compile and test node
+# buildenv-cpython - based on kontainapp/buildenv-km-fedora, git clone, compile and test node
 # linkenv - based on km-build-env and just copy the objects and test files
 
 ARG MODE=Release
@@ -20,7 +20,7 @@ ARG TAG
 ARG VERS
 ARG BUILDENV_IMAGE_VERSION=latest
 
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} AS buildenv-cpython
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION} AS buildenv-cpython
 ARG TAG
 # ARG VERS
 
@@ -49,7 +49,7 @@ RUN mv python python.orig \
    | (mkdir builtins; tar -C builtins -xf -)
 
 # Build the target image
-FROM kontain/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-fedora:${BUILDENV_IMAGE_VERSION}
 ENV PYTHONTOP=/home/$USER/cpython
 #
 # The following copies two sets of artifacts - objects needed to build (link) python.km,

--- a/payloads/python/demo-runenv.dockerfile
+++ b/payloads/python/demo-runenv.dockerfile
@@ -1,6 +1,6 @@
 ARG runenv_image_version=latest
 
-FROM kontain/runenv-python:${runenv_image_version}
+FROM kontainapp/runenv-python:${runenv_image_version}
 
 COPY scripts /scripts
 EXPOSE 8080

--- a/payloads/python/runenv.dockerfile
+++ b/payloads/python/runenv.dockerfile
@@ -1,5 +1,5 @@
 ARG runenv_image_version=latest
 
-FROM kontain/runenv-busybox:${runenv_image_version}
+FROM kontainapp/runenv-busybox:${runenv_image_version}
 COPY . /
 ENTRYPOINT [ "/opt/kontain/bin/km", "/usr/local/bin/python3" ]

--- a/payloads/python/scripts/flask/Readme.md
+++ b/payloads/python/scripts/flask/Readme.md
@@ -44,7 +44,7 @@ See `make help` for more info
 * In a container made 'FROM' the the source analyze content of the source image: python path, content of the folders, analyze imports
    * export needed files, generate shebang files, config for proper python.km build (version shared libs, etc..), cmd/env/entrypoint for target kontainer
 * build proper .km files (if needed)
-* FROM kontain/km (for docker) or scratch (for runk) create kontainer image, using exported files data created above
+* FROM kontainapp/km (for docker) or scratch (for runk) create kontainer image, using exported files data created above
 
 pieces:
 

--- a/payloads/python/test-fedora.dockerfile
+++ b/payloads/python/test-fedora.dockerfile
@@ -14,7 +14,7 @@ ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
 
 
-FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 #  Python version and ABI flag **MUST** be passed on build
 ARG VERS

--- a/tests/test-fedora.dockerfile
+++ b/tests/test-fedora.dockerfile
@@ -12,7 +12,7 @@
 
 ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
-FROM kontain/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
+FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 ARG branch
 ENV BRANCH=${branch}


### PR DESCRIPTION
This PR renames kontain/* images to kontainapp/* images. Please see below for the reason/background.
Note that there are no changes to images names in outside repos; the change is only to the local box,
so old images need to be manually deleted to avoid confusion

Tested by deleting all images on my box and tryin all pull/push/build operations

Fixes #1218

Background (from #1218):

We cannot name our images kontain/* on dockerhub since someone else owns 'kontain' org.
Thus use kontainapp/runenv-xxx on dockerhub, but kontain/runenv-xxx locally. And 'publish-runenv-image' does the retaggin

This creates a messy case where we need to use 'kontainapp' in any external/customer-faces doc or script. but use kontain everywhere else. We run into a few bugs of using wrong name in FROM

We need to reconcile. The suggestion is use kontainapp/* everywhere (inlcuding local images. CI, etc)

The fix is to rename all kontain/runenv kontain/buildenv kontan/demo-runenv and kontain/runenv to kontainapp/*
, remove local kontain/* (docker rmi docker image ls kontain/* and re-pull buildenv