### PR TITLE
Use a truly invalid pid in another place in the sid_pgid_test.

### DIFF
--- a/tests/sid_pgid_test.c
+++ b/tests/sid_pgid_test.c
@@ -100,8 +100,12 @@ TEST pgid_test(void)
    ASSERT_NEQ(-1, pgid);
    fprintf(stdout, "getpid()'s pgid is %d\n", pgid);
 
+   // Get an invalid pid.
+   pid_t invalid_pid = get_pid_max();
+   ASSERT_NEQ(-1, invalid_pid);
+
    // get pgid using an invalid process id
-   pgid = getpgid(7777);
+   pgid = getpgid(invalid_pid);
    ASSERT_EQ(-1, pgid);
    ASSERT_EQ(ESRCH, errno);
 


### PR DESCRIPTION
There are 2 places in the sid_pgid_test where an invalid pid is needed.
The other place was fixed a few days ago.  Fix it it the other location
today.
There don't seem to be any other places where the tests need an invalid pid.