### PR TITLE
Minor change to test command for dyn image, and kubectl log for test …[TRIVIAL]

### DIFF
--- a/cloud/k8s/tests/k8s-run-tests.sh
+++ b/cloud/k8s/tests/k8s-run-tests.sh
@@ -151,7 +151,7 @@ function main {
         cleanup_and_exit $pod_name $exit_code
     fi
 
-    echo "$self: Executing bash -c '${TEST_COMMAND}' in ${pod_name}..."
+    echo "$self: kubectl exec  ${pod_name} -- bash -c \"${TEST_COMMAND}\""
     kubectl exec ${pod_name} -- bash -c "${TEST_COMMAND}"
     local exit_code=$?
     if [[ $exit_code != 0 ]]; then

--- a/payloads/dynamic-base/Makefile
+++ b/payloads/dynamic-base/Makefile
@@ -18,7 +18,7 @@ PAYLOAD_IMAGE_SHORT_NAME := dynamic-base
 PAYLOAD_NAME := Dynamic-base
 PAYLOAD_FILES := -C /opt/kontain/ --exclude '*.a' runtime
 # Command to run tests in testenv-image container:
-CONTAINER_TEST_CMD := ./km hello_test.kmd Hello "The One"
+CONTAINER_TEST_CMD := ./km hello_test.kmd Hello 'The One'
 CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 


### PR DESCRIPTION


just a clean way of printing log, and entering multiline strings
Otherwise the logs are confusing
tested manually