### PR TITLE
A quick fix to make KM build on Ubuntu 20.03/gcc9

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -2204,7 +2204,8 @@ static int proc_sched_read(int fd, char* buf, size_t buf_sz)
       return -errno;
    }
    char tmp[128];
-   fgets(tmp, sizeof(tmp), fp);   // skip the first line
+   char* x = fgets(tmp, sizeof(tmp), fp);   // skip the first line
+   (void)x; // avoid gcc warn
    if (feof(fp)) {                // second read, to make sure we are at end of file
       fclose(fp);
       return 0;

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -324,7 +324,7 @@ void km_dump_vcpu(km_vcpu_t* vcpu)
       return;
    }
 
-   km_warnx(buf);
+   km_warnx("%s", buf);
 }
 
 /*


### PR DESCRIPTION
the compiler there is more sensitive to unused return values and missing format strings in printf. so the build was failing.
I needed this when doing misc. experiments with packer-based test

tested by by build only , I did not force these messages to trigger