### PR TITLE
Fix bugs found with 'make release'

### DIFF
--- a/include/Makefile
+++ b/include/Makefile
@@ -14,5 +14,6 @@ TOP := $(shell git rev-parse --show-toplevel)
 include ${TOP}/make/actions.mk
 
 all: km_hcalls.h
+	[ -d ${KM_OPT_INC} ] || mkdir ${KM_OPT_INC}
 	cp km_hcalls.h ${KM_OPT_INC}
 

--- a/lib/libkontain/Makefile
+++ b/lib/libkontain/Makefile
@@ -19,7 +19,9 @@ SOURCES := libkontain.c
 INCLUDES := ${TOP}/include
 
 all: libkontain.h
+	[ -d ${KM_OPT_INC} ] || mkdir ${KM_OPT_INC}
 	cp libkontain.h ${KM_OPT_INC}
+	[ -d ${KM_OPT_LIB} ] || mkdir ${KM_OPT_INC}
 	cp ${BLDTOP}/lib/libkontain/libkontain.a ${KM_OPT_LIB}
 	cp ${BLDTOP}/lib/libkontain/libkontain.so ${KM_OPT_LIB}
 

--- a/lib/mimalloc/Makefile
+++ b/lib/mimalloc/Makefile
@@ -21,6 +21,7 @@ ME_MI_BLDDIR := ${ME_BLDDIR}/mimalloc
 all:
 	cmake -S ${ME_MI_SRCDIR} -B ${ME_MI_BLDDIR} -D MI_BUILD_TESTS:BOOL=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_SHARED_LINKER_FLAGS="-L/opt/kontain/alpine-lib/usr/lib -L/opt/kontain/alpine-lib/lib -Wl,-rpath,/opt/kontain/alpine-lib/usr/lib:/opt/kontain/alpine-lib/lib:"
 	make -C ${ME_MI_BLDDIR}
+	[ -d ${KM_OPT_LIB} ] || mkdir ${KM_OPT_LIB}
 	cp ${ME_MI_BLDDIR}/libmimalloc.a ${KM_OPT_LIB}/libmimalloc.a
 	chmod 0644 ${KM_OPT_LIB}/libmimalloc.a
 	cp ${ME_MI_BLDDIR}/libmimalloc.so.1.7 ${KM_OPT_LIB}/libmimalloc.so.1.7

--- a/tools/bin/create_release.sh
+++ b/tools/bin/create_release.sh
@@ -31,7 +31,8 @@ for i in $(seq 0 $(("${#locations[@]}" - 1))); do
    source="${locations[$i]}/${files[$i]}"
    # newer gcc produces compressed '.debug_info'. Older linkers cannot use it. To make sure
    # we can use our (apine) libs with slightly older linkers, let's decompress .debug_info
-   decompress_list=$(find $source -type f -exec file '{}' ';' | awk -F: '/(shared|archive|relocatable)/ {print $1}')
+   decompress_list=$(find $source -type f -exec file '{}' ';' | grep -v 'archive data' | 
+                     awk -F: '/(shared|archive|relocatable)/ {print $1}')
    if [ -n "$decompress_list" ]; then
       echo Decompressing .debug_info for $(echo $decompress_list | wc -w) files in $source
       if [ ! -w $source ]; then


### PR DESCRIPTION
`make release` was failing for Dmytro and he asked for help. I identified
two issues:

- the test for an elf file in `tools/bin/create_release.sh` was too broad
  resulting in false positives. `objcopy` ended up failing.
- if `/opt/kontain/include` and `/opt/kontain/lib` did not exist, they would be
  created as regular files as part of `make`. This broke `make release`.

Fixes: #1276