### PR TITLE
TRIVIAL: fix typo introduced by fixing gcc9 messages

### DIFF
--- a/km/km_exec_fd_save_recover.c
+++ b/km/km_exec_fd_save_recover.c
@@ -250,7 +250,7 @@ char* km_exec_save_fd(char* varname)
                      i,
                      file->how,
                      file->flags,
-                     km_filename_table_line(ops))) {
+                     km_filename_table_line(ops)) == -1) {
                         km_warn("failed save info for non-socket %s", file->name);
                      }
          }


### PR DESCRIPTION
Noticed bogus messages running demo payloads. Looks like one of the checks comparing with the wrong value.

Tested manually. Went through the commit to make sure other places are OK.