### PR TITLE
Add getgroups() hypercall to km

### DIFF
--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1739,6 +1739,32 @@ static km_hc_ret_t waitid_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 }
 
 /*
+ * uid_t geteuid(void);
+ * uid_t getuid(void);
+ * gid_t getgid(void);
+ * gid_t getegid(void);
+ */
+static km_hc_ret_t getXXid_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   arg->hc_ret = __syscall_0(hc);
+   return HC_CONTINUE;
+}
+
+/*
+ * int getgroups(int size, gid_t list[]);
+ */
+static km_hc_ret_t getgroups_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   gid_t* list = km_gva_to_kma(arg->arg2);
+   if (list == NULL) {
+      arg->hc_ret = -EFAULT;
+      return HC_CONTINUE;
+   }
+   arg->hc_ret = __syscall_2(hc, arg->arg1, (uint64_t)list);
+   return HC_CONTINUE;
+}
+
+/*
  * pid_t getsid(pid_t pid);
  */
 static km_hc_ret_t getsid_hcall(void* vcpu, int hc, km_hc_args_t* arg)
@@ -2041,10 +2067,12 @@ const km_hcall_fn_t km_hcalls_table[KM_MAX_HCALL] = {
     [SYS_gettid] = gettid_hcall,
 
     [SYS_getrusage] = getrusage_hcall,
-    [SYS_geteuid] = dummy_hcall,
-    [SYS_getuid] = dummy_hcall,
-    [SYS_getegid] = dummy_hcall,
-    [SYS_getgid] = dummy_hcall,
+    [SYS_geteuid] = getXXid_hcall,
+    [SYS_getuid] = getXXid_hcall,
+    [SYS_getegid] = getXXid_hcall,
+    [SYS_getgid] = getXXid_hcall,
+
+    [SYS_getgroups] = getgroups_hcall,
 
     [SYS_setsid] = setsid_hcall,
     [SYS_getsid] = getsid_hcall,

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1475,3 +1475,14 @@ fi
    assert_success
    rm -f $KMTRACE
 }
+
+@test "uidgid($test_type): smoke test for uid/gid related hypercalls (uidgid_test$ext)" {
+   UIDGIDOUT=/tmp/uidgid$$.out
+   km_with_timeout uidgid_test$ext | sort -n >$UIDGIDOUT
+   assert_success
+   id -G | tr " " "\n" | sort -n >$UIDGIDOUT.expected
+   assert_success
+   diff -q $UIDGIDOUT.expected $UIDGIDOUT
+   assert_success
+   rm -f $UIDGIDOUT.expected $UIDGIDOUT
+}

--- a/tests/uidgid_test.c
+++ b/tests/uidgid_test.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2021 Kontain Inc. All rights reserved.
+ *
+ * Kontain Inc CONFIDENTIAL
+ *
+ * This file includes unpublished proprietary source code of Kontain Inc. The
+ * copyright notice above does not evidence any actual or intended publication
+ * of such source code. Disclosure of this source code or any related
+ * proprietary information is strictly prohibited without the express written
+ * permission of Kontain Inc.
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+#include "greatest/greatest.h"
+
+/*
+ * A simple test to exercise the getgroups() system call.
+ * We could expand to test other id related system calls as the need arises.
+ */
+
+TEST getXXid(void)
+{
+   uid_t uid;
+   gid_t gid;
+
+   /*
+    * Try to test the getuid() family of functions.
+    * Expecting that root is not running the program may be unrealistic.
+    * Recall that km formerly returned zero for calls to these functions.
+    */
+
+   uid = geteuid();
+   ASSERT_NEQ(uid, -1);
+   ASSERT_NEQ(uid, 0);
+   uid = getuid();
+   ASSERT_NEQ(uid, -1);
+   ASSERT_NEQ(uid, 0);
+   gid = getegid();
+   ASSERT_NEQ(gid, -1);
+   ASSERT_NEQ(gid, 0);
+   gid = getgid();
+   ASSERT_NEQ(gid, -1);
+   ASSERT_NEQ(gid, 0);
+
+   PASS();
+}
+
+TEST getgroups_smoke(void)
+{
+   int ngroups;
+   gid_t grouplist[NGROUPS_MAX];
+
+   // If there are no groups the passed address is never used.
+   ngroups = getgroups(NGROUPS_MAX, NULL);
+   ASSERT(ngroups == -1 || ngroups == 0);
+   if (ngroups < 0) {
+      ASSERT_EQ(errno, EFAULT);
+   }
+
+   // Returns the number of groups, but group list is not returned
+   ngroups = getgroups(0, grouplist);
+   ASSERT_NEQ(ngroups, -1);
+
+   if (ngroups > 1) {
+      ngroups = getgroups(ngroups - 1, grouplist);
+      ASSERT_EQ(ngroups, -1);
+      ASSERT_EQ(errno, EINVAL);
+   }
+
+   PASS();
+}
+
+TEST getgroups_print(void)
+{
+   int ngroups;
+   gid_t grouplist[NGROUPS_MAX];
+
+   ngroups = getgroups(NGROUPS_MAX, grouplist);
+   ASSERT_NEQ(ngroups, -1);
+   /*
+    * Print something to compare with output from:
+    *   id -G | tr " " "\n" | sort -n
+    */
+   for (int i = 0; i < ngroups; i++) {
+      fprintf(stdout, "%d\n", grouplist[i]);
+   }
+   if (ngroups == 0) {
+      // To be like "id -G" we print the gid returned by getgid() if getgroups() returns nothing.
+      grouplist[0] = getgid();
+      fprintf(stdout, "%d\n", grouplist[0]);
+   }
+
+   PASS();
+}
+
+GREATEST_MAIN_DEFS();
+
+int main(int argc, char* argv[])
+{
+   GREATEST_MAIN_BEGIN();
+
+   RUN_TEST(getgroups_smoke);
+   RUN_TEST(getgroups_print);
+   RUN_TEST(getXXid);
+
+   GREATEST_PRINT_REPORT();
+   return greatest_info.failed;
+}


### PR DESCRIPTION
The crun test program named init calls the getgroups() hypercall from within a kontainer.
So add this hypercall to km and add a simple bats test to try it out.