### PR TITLE
squelch gcc diagnostics for getgroups in test

### DIFF
--- a/tests/uidgid_test.c
+++ b/tests/uidgid_test.c
@@ -56,9 +56,10 @@ TEST getgroups_smoke(void)
    int ngroups;
    gid_t grouplist[NGROUPS_MAX];
 
-   // If there are no groups the passed address is never used.
+   // we want the compiler to let us pass an invalid address to force an EFAULT
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnonnull"
+   // If there are no groups the passed address is never used.
    ngroups = getgroups(NGROUPS_MAX, NULL);
 #pragma GCC diagnostic pop
    ASSERT(ngroups == -1 || ngroups == 0);


### PR DESCRIPTION
Turns out on Fedora 33 the `/usr/include/unistd.h` uses `__attr_access ((__write_only__, 2, 1))` attributes to make certain bugs into compile time bugs. In this case:

```
extern int getgroups (int __size, __gid_t __list[]) __THROW __wur
    __attr_access ((__write_only__, 2, 1));
```
makes specifying non-zero size with NULL for list into a compile warning, rather than runtime error. And we compile with -Werror so it breaks the build.

I used #pragma to force gcc into accepting this.
