### PR TITLE
TRIVIAL: Cleanup CI images for all test and demo-runenv

### DIFF
--- a/cloud/azure/Makefile
+++ b/cloud/azure/Makefile
@@ -105,8 +105,8 @@ CI_IMAGE_NAMES := busybox dweb dynamic-base dynamic-base-large dynamic-python jd
 CI_IMAGE_REPOS_TO_PURGE := test-km-fedora $(patsubst %,test-%-fedora,$(CI_IMAGE_NAMES)) $(patsubst %,demo-runenv-%,$(CI_IMAGE_NAMES)) runenv-kontain-installer
 CI_IMAGE_DRY_RUN ?= --dry-run
 # "image purge" command to execute on each registry. We *ONLY* clean up images tagged as ci-*
-CI_IMAGE_PURGE_CMD="mcr.microsoft.com/acr/acr-cli:0.1 purge --registry {{.Run.Registry}} \
-	--filter '${repo}:ci-.*' --untagged ${CI_IMAGE_DRY_RUN} --ago ${CI_IMAGE_PURGE_AGE}"
+CI_IMAGE_PURGE_CMD=mcr.microsoft.com/acr/acr-cli:0.1 purge --registry {{.Run.Registry}} \
+	--untagged ${CI_IMAGE_DRY_RUN} --ago ${CI_IMAGE_PURGE_AGE}
 
 CI_BUILDENV_IMAGE_VERSION ?= latest
 ci-image-purge: ## purge CI test images older that CI_IMAGE_PURGE_AGE
@@ -114,7 +114,7 @@ ifneq ($(CI_IMAGE_DRY_RUN),)
 	@echo -e "${GREEN}Doing dry run. To do actual purge, run with CI_IMAGE_DRY_RUN=\"\" ${NOCOLOR}"
 endif
 	@echo "Purging images for $(CI_IMAGE_REPOS_TO_PURGE) older than $(CI_IMAGE_PURGE_AGE)"
-	@set -x; $(foreach repo,${CI_IMAGE_REPOS_TO_PURGE}, az acr run --cmd '${CI_IMAGE_PURGE_CMD}' --registry ${REGISTRY_NAME} /dev/null; )
+	az acr run --cmd '"${CI_IMAGE_PURGE_CMD} $(patsubst %,--filter %:ci-.*,${CI_IMAGE_REPOS_TO_PURGE})"' --registry ${REGISTRY_NAME} /dev/null;
 
 # Helpers to avoid cut-n-paste in pipeline definition.
 ci-prepare-testenv: ## helper for Azure CI. Obsolete for GitHub workflows


### PR DESCRIPTION
Correct the list of CI images needing cleanup, include the images introduced lately.