### PR TITLE
Add openssl to the list of krun dependencies.

### DIFF
--- a/container-runtime/Makefile
+++ b/container-runtime/Makefile
@@ -28,7 +28,8 @@ TOP := $(shell git rev-parse --show-toplevel)
 # To check, use the .check_packages target from dep_check.mk
 DEP_PACKAGES := python git gcc automake autoconf libcap-devel \
 		yajl-devel libseccomp-devel \
-		glibc-static python3-libmount libtool
+		glibc-static python3-libmount libtool \
+		openssl-lib openssl-devel
 # The crun workspace is in the crun directory
 CRUNDIR := crun
 


### PR DESCRIPTION
openssl should be in the crun/krun package dependencies list.
Forgot to add this when we change krun to use the hash functions from openssl.