### PR TITLE
Changes to support make validate-runenv-image targets using podman

### DIFF
--- a/container-runtime/docker_config.sh
+++ b/container-runtime/docker_config.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright 2021 Kontain Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DEBUG=echo
+#DEBUG=
+
+# docker config file locations
+ETC_DAEMON_JSON=/etc/docker/daemon.json
+
+id=`grep ^ID= /etc/os-release`
+
+function restart_docker()
+{
+   echo "Restarting docker"
+   if test $id = "ID=fedora"
+   then
+      $DEBUG sudo systemctl restart docker.service   # fedora
+   elif test $id = "ID=ubuntu"
+   then
+      $DEBUG sudo service docker restart   # ubuntu
+   else
+      echo "unknown linux distribution $id"
+      false
+   fi
+}
+
+# Can we assume docker is installed?
+#sudo apt-get install -y -q docker.io
+#sudo dnf install -y -q moby-engine
+
+if ! sudo test -e $ETC_DAEMON_JSON
+then
+   # doesn't exist, create what we need
+   cat <<EOF >/tmp/daemon.json$$
+{
+  "runtimes": {
+    "krun": {
+      "path": "/opt/kontain/bin/krun"
+    }
+  }
+}
+EOF
+   # get docker to ingest the new daemon.json file
+   sudo cp /tmp/daemon.json$$ $ETC_DAEMON_JSON
+   rm -fr /tmp/daemon.json$$
+   restart_docker
+else
+   # update existing file.  I've found if the file is not really json (it is an empty file),
+   # jq fails without returning an error.
+   krun=`sudo jq '.runtimes["krun"]' $ETC_DAEMON_JSON`
+   if test "$krun" = "null"
+   then
+      sudo jq '.runtimes["krun"].path = "/opt/kontain/bin/krun"' $ETC_DAEMON_JSON >/tmp/daemon.json$$
+      sudo cp /tmp/daemon.json$$ $ETC_DAEMON_JSON
+      # get docker to ingest the new daemon.json file
+      if test $? -eq 0
+      then
+         restart_docker
+      fi
+      rm -f /tmp/daemon.json$$
+   else
+      echo "krun already configured in $ETC_DAEMON_JSON"
+      echo "\"krun\": $krun"
+   fi
+fi

--- a/container-runtime/oci-runtime.md
+++ b/container-runtime/oci-runtime.md
@@ -135,19 +135,10 @@ systemctl reload-or-restrt docker.service
 
 # Configure podman to use krun as a runtime
 
-Edit the file /usr/share/containers/containers.conf using sudo.
+The script podman_config.sh in this directory is provided to configure podman and your system to run kontain containers using podman and krun.
+The script currently changes ~/.config/containers/containers.conf, and adds some minor selinux policy changes to allow krun and km to work.
+You can also place the podman configuration changes in /usr/share/containers/containers.conf, or /etc/containers/containers.conf
 
-Add the following (with the appropriate path to krun) under the section [engine.runtimes]:
-
-```txt
-krun = [
-   "/opt/kontain/bin/krun",
-]
-```
-
-The default runtime can be specified with the following directive:
-
-runtime = "krun"
 
 # Running a kontainer using the krun runtime
 
@@ -181,12 +172,15 @@ Make your changes to the source code and then test them.  Once you are satisfied
 git push origin krun/yourname/what-you-are-fixing
 ```
 
-When you push your krun changes to the kontainapp/crun repository, the crun github workflows will run.  You need to check that the "Test" workflow succeeds.
+After you push your krun changes to the kontainapp/crun repository, you will need to go to github and chose a target branch for the PR.
+Be sure you select our repository (not the containers/crun repository) for the merge target.  And, ensure that the changes go into the krun branch, not main or master.
+
+Once the PR is created the crun github workflows will run.  You need to check that the "Test" workflow succeeds.
 If it fails, you need to find and fix the problem.  It should be noted that this workflow does check coding style.  We need to follow the containers/crun
 coding style.
 There is also an "Artifact" workflow which fails in the kontainapp/crun repository.  This needs to be fixed.
 
-Once the crun Test workflow is successful the changes need to be reviewed and approved using github.
+Once the crun Test workflow is successful the changes need to be approved using github.
 Complete the code review on github and get approval to merge the changes.  Once approved, merge the changes on github.
 
 Once your changes are in the kontain crun repository, km needs be updated so those changes are being used in what is built in the kontainapp/km

--- a/container-runtime/podman_config.sh
+++ b/container-runtime/podman_config.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+#
+# Copyright 2021 Kontain Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+#
+# A little script to get needed linux packages, change podman config files, and add a small
+# kontain selinux policy to allow podman to run containers using krun and km.
+#
+
+# podman config file locations
+CONTAINERS_CONF=/usr/share/containers/containers.conf
+HOME_CONTAINERS_CONF=~/.config/containers/containers.conf
+ETC_CONTAINERS_CONF=/etc/containers/containers.conf
+DOCKER_INIT=/usr/libexec/docker/docker-init
+KRUN_PATH=/opt/kontain/bin/krun
+KM_PATH=/opt/kontain/bin/km
+KM_SELINUX_CONTEXT="system_u:object_r:bin_t:s0"
+
+# Either do it or just print the commands we think should be run.
+#DEBUG=echo
+DEBUG=""
+
+linuxdist=`grep "^ID=" /etc/os-release`
+
+# Install podman and policy build tools
+echo "Installing podman and selinux packages"
+if test "$linuxdist" =  "ID=fedora"
+then
+   $DEBUG sudo dnf install -y -q --refresh podman selinux-policy-devel
+elif test "$linuxdist" = "ID=ubuntu"
+then
+   $DEBUG sudo apt-get update
+   $DEBUG sudo apt-get install -y -q podman selinux-policy-dev
+else
+   echo "Unsupported linux distributionn $linuxdist"
+   exit 1
+fi
+
+
+# set init_path in the [containers] section of ~/.config/containers/containers.conf
+# We don't ensure we add this in the [containers] section.
+# We hope the init_path command line comment exists and is in the proper section.
+echo
+if ! grep -q "^ *init_path" $HOME_CONTAINERS_CONF
+then
+   # no init_path, use the docker init
+   $DEBUG sed --in-place -e "/^# *init_path/ainit_path = \"$DOCKER_INIT\"" $HOME_CONTAINERS_CONF
+else
+   if ! grep -q "^ *init_path *= *\"$DOCKER_INIT\"" $HOME_CONTAINERS_CONF
+   then
+      echo "Leaving init_path statement in $HOME_CONTAINERS_CONF unchanged, you may need to change it to $DOCKER_INIT"
+      echo "Existing init_path:"
+      grep "^ *init_path" $HOME_CONTAINERS_CONF
+   else
+      echo "init_path = \"$DOCKER_INIT\"" is already in $HOME_CONTAINERS_CONF
+   fi
+fi
+
+
+# add krun to ~/.config/containers/containers.conf at the beginning of the [engine.runtimes] section
+echo
+if ! grep -q "^ *krun =" $HOME_CONTAINERS_CONF
+then
+   $DEBUG sed --in-place -e "/^\[engine.runtimes\]/akrun = [\n   \"$KRUN_PATH\",\n]\n" $HOME_CONTAINERS_CONF
+else
+   echo "runtime krun already configured in $HOME_CONTAINERS_CONF"
+   grep -A 3 "^ *krun =" $HOME_CONTAINERS_CONF
+fi
+
+
+# set selinux context on /opt/kontain/bin/km
+echo
+$DEBUG chcon $KM_SELINUX_CONTEXT $KM_PATH
+
+
+# Add kontain selinux policy adjustments
+POLDIR=/tmp/kontain_selinux_policy
+mkdir -p $POLDIR
+pushd $POLDIR || exit
+cat <<EOF >kontain_selinux_policy.te
+module kontain_selinux_policy 1.0.0;
+
+require {
+  type container_t;
+  type kvm_device_t;
+  class chr_file { append getattr ioctl lock open read write };
+}
+
+allow container_t kvm_device_t:chr_file { append getattr ioctl lock open read write };
+
+# You may get errors when this is "compiled".
+# This is a known issue, see:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1861968
+EOF
+
+$DEBUG ln -sf /usr/share/selinux/devel/Makefile
+$DEBUG make
+$DEBUG sudo make reload
+popd || exit
+

--- a/container-runtime/podman_config.sh
+++ b/container-runtime/podman_config.sh
@@ -18,8 +18,6 @@
 # A little script to get needed linux packages, change podman config files, and add a small
 # kontain selinux policy to allow podman to run containers using krun and km.
 
-TRACE=x
-
 # exit if any command fails, don't execute commands if TRACE has a value.
 set -e ; [ "$TRACE" ] && set -x
 

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1562,6 +1562,9 @@ static int do_exec(char* filename, char** argv, char** envp)
    int ret;
 
    if ((ret = stat(filename, &statbuf)) != 0) {
+      char cwd[PATH_MAX];
+      getcwd(cwd, sizeof(cwd));
+      km_info(KM_TRACE_HC, "can't stat %s, cwd %s", filename, cwd);
       return -errno;
    }
 

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1563,7 +1563,9 @@ static int do_exec(char* filename, char** argv, char** envp)
 
    if ((ret = stat(filename, &statbuf)) != 0) {
       char cwd[PATH_MAX];
-      getcwd(cwd, sizeof(cwd));
+      if (getcwd(cwd, sizeof(cwd)) == NULL) {
+         snprintf(cwd, sizeof(cwd), "<Couldn't get cwd, error %d>", errno);
+      }
       km_info(KM_TRACE_HC, "can't stat %s, cwd %s", filename, cwd);
       return -errno;
    }

--- a/make/dep_check.mk
+++ b/make/dep_check.mk
@@ -35,3 +35,61 @@ endef
 
 .check_packages:
 	eval $(check_packages)
+
+PODMAN_PATH := /usr/bin/podman
+CONTAINER_CONF := /usr/share/containers/containers.conf 
+HOME_CONTAINER_CONF := ~/.config/containers/containers.conf
+KM_OPT_KRUN := /opt/kontain/bin/krun
+CONTAINER_INIT_PATH := /usr/libexec/docker/docker-init
+SESEARCH_PATH := /usr/bin/sesearch
+
+# To use podman certain things must exist on the system running kontainers with podman.
+# Check for these prerequisites with this target.
+# /opt/kontain/bin/km and /opt/kontain/bin/krun must exist
+# /opt/kontain/bin/km must have the proper selinux context
+# Changes to the selinux policy are needed to allow krun to access /dev/kvm and probably /dev/kkm
+# podman must be installed
+# podman must be configured to allow it to use krun.
+.check_podman_prereqs:
+	@if [ ! -e ${KM_OPT_KM} ]; then \
+		echo "${KM_OPT_KM} is missing, run 'make -C km' to build it"; \
+		false; \
+	fi
+	@if [ ! -e ${KM_OPT_KRUN} ] ; then \
+		echo "${KM_OPT_KM} is missing, run 'make -C container-runtime' to build it"; \
+		false; \
+	fi
+	@if [ ! -e ${PODMAN_PATH} ]; then \
+		echo "${PODMAN_PATH} is missing, run 'sudo dnf install podman' to have it installed"; \
+		false; \
+	fi
+	@if ! grep -q 'krun = \[' ${CONTAINER_CONF} ${HOME_CONTAINER_CONF}; then \
+		echo "podman is not configured to allow krun use"; \
+		echo "Add the following to ${CONTAINER_CONF} or ${HOME_CONTAINER_CONF} in the [engine.runtimes] table"; \
+		echo "krun = ["; \
+		echo "        \"/opt/kontain/bin/krun\","; \
+		echo "]"; \
+		false; \
+	fi
+	@if ! grep -q "init_path = \"${CONTAINER_INIT_PATH}\"" ${CONTAINER_CONF} ${HOME_CONTAINER_CONF}; then \
+		echo "podman is not configured to use docker's init program"; \
+		echo "This may cause problems when running 'podman run --init ....'"; \
+	fi
+	@if ! getenforce | grep -q Enforcing; then \
+		echo "selinux not configured or not enforcing"; \
+	fi
+	@if ! ls -Z ${KM_OPT_KM} | grep -q -e system_u:object_r:bin_t -e system_u:object_r:container_file_t; then \
+		echo "${KM_OPT_KM} has the wrong selinux context"; \
+		echo "run 'chcon system_u:object_r:bin_t:s0 ${KM_OPT_KM}' to repair"; \
+		false; \
+	fi
+	@if [ ! -e ${SESEARCH_PATH} ]; then \
+		echo "sesearch not installed, run 'dnf install setools-console'"; \
+		false; \
+	fi
+	@echo "Running sesearch, this takes a few seconds"; \
+	if ! ${SESEARCH_PATH} --allow | grep -q "allow container_t kvm_device_t:chr_file"; then \
+		echo "selinux policy will not allow podman et.al. to run krun"; \
+		false; \
+	fi
+	@echo "podman should be able to run kontain kontainers"

--- a/make/images.mk
+++ b/make/images.mk
@@ -175,7 +175,7 @@ validate-runenv-image: ## Validate runtime image
 	${DOCKER_RUN} ${DOCKER_INTERACTIVE} --init ${DOCKER_KRUN_RUNTIME} \
 	${RUNENV_DEMO_IMG_TAGGED} \
 	"$${tmp_bash_array[@]}" | grep "${RUNENV_VALIDATE_EXPECTED}"
-	-podman image rm ${RUNENV_DEMO_IMG_TAGGED}
+	@-podman image rm ${RUNENV_DEMO_IMG_TAGGED} >/dev/null 2>&1
 	tmp_bash_array=${RUNENV_VALIDATE_CMD} && \
 	${PODMAN_RUN_TEST} ${PODMAN_KRUN_RUNTIME} \
 	docker-daemon:${RUNENV_DEMO_IMG_TAGGED} \

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -102,6 +102,7 @@ DOCKER_RUN_CLEANUP ?= --rm
 # When running tests in containers on CI, we can't use tty and interactive
 DOCKER_INTERACTIVE ?= -it
 
+DOCKER_KRUN_RUNTIME ?= --runtime krun
 DOCKER_RUN := docker run ${DOCKER_RUN_CLEANUP}
 # DOCKER_RUN_BUILD are used for building and other operations that requires
 # output of files to volumes. When we need to write files to the volumes mapped
@@ -109,6 +110,12 @@ DOCKER_RUN := docker run ${DOCKER_RUN_CLEANUP}
 # using `appuser`, which is different from user on the host.
 DOCKER_RUN_BUILD := ${DOCKER_RUN} -u ${CURRENT_UID}:${CURRENT_GID}
 DOCKER_RUN_TEST := ${DOCKER_RUN} ${DOCKER_INTERACTIVE} --device=${HYPERVISOR_DEVICE} --init
+
+# These PODMAN_* variables mirror the docker related ones.
+# Initially we use these to verify that runenv-images work with podman
+PODMAN_KRUN_RUNTIME ?= --runtime krun
+PODMAN_RUN := podman run ${DOCKER_RUN_CLEANUP}
+PODMAN_RUN_TEST := ${PODMAN_RUN} ${DOCKER_INTERACTIVE} --init
 
 # Inside docker image (buildenv + testenv), appuser will be the user created
 # inside the container.

--- a/payloads/Makefile
+++ b/payloads/Makefile
@@ -31,12 +31,10 @@ java: dynamic-base
 
 dynamic-python: dynamic-base-large python
 
-# Filter out 'make test' requests' to assure that 'make test' only builds/tests KM.
-# If payload needs to be tested, use 'make test-all'
 # Also, just 'make' will not cause building payloads , so it is reserved for building KM only.
 # Use 'make all' or 'make build' to request payloads build
 
-default test coverage:
+default coverage:
 	@echo "Info: ignoring target '$@' in payloads"
 
 # use this target to force payloads build

--- a/payloads/busybox/runenv.dockerfile
+++ b/payloads/busybox/runenv.dockerfile
@@ -17,5 +17,3 @@ FROM scratch
 # turn off km symlink trick and minimal shell interpretation
 ENV KM_DO_SHELL NO
 ADD --chown=0:0 busybox/_install /
-# stopgap - krun will insert this at the beginning, put it here for now
-ENTRYPOINT [ "/opt/kontain/bin/km" ]

--- a/payloads/demo-dweb/Makefile
+++ b/payloads/demo-dweb/Makefile
@@ -89,7 +89,7 @@ export define runenv_prep
 	tar -cf - ${PAYLOAD_FILES} | tar -C $(RUNENV_PATH) -xf -
 	mv $(RUNENV_PATH)/$(PAYLOAD_KM) $(basename $(RUNENV_PATH)/$(PAYLOAD_KM))
 endef
-RUNENV_VALIDATE_CMD := ("dweb" "-x")
+RUNENV_VALIDATE_CMD := ("./dweb" "-x")
 RUNENV_VALIDATE_EXPECTED := I am DWEB
 
 include ${TOP}/make/images.mk

--- a/payloads/dynamic-base-large/Makefile
+++ b/payloads/dynamic-base-large/Makefile
@@ -32,7 +32,7 @@ test test-krun test-all:
 clean clobber:
 	@true
 
-RUNENV_VALIDATE_CMD := ("hello_test" "Hello, World!")
+RUNENV_VALIDATE_CMD := ("./hello_test" "Hello, World!")
 RUNENV_VALIDATE_EXPECTED := Hello, World
 
 export define runenv_prep

--- a/payloads/dynamic-base/Makefile
+++ b/payloads/dynamic-base/Makefile
@@ -32,7 +32,7 @@ test test-krun test-all:
 clean clobber:
 	@true
 
-RUNENV_VALIDATE_CMD := ("hello_test" "Hello, World!")
+RUNENV_VALIDATE_CMD := ("./hello_test" "Hello, World!")
 RUNENV_VALIDATE_EXPECTED := Hello, World
 
 export define runenv_prep


### PR DESCRIPTION
Change the validate-runenv-image make target to also run the container image using podman.
Pick up a small krun fix to allow the java payload's runenv-image to work with podman.
Added a .check_podman_prereqs make target that verifies prerequisites needed for podman are done.

With these changes the following payloads validate-runenv-image targets work:
busybox, node, python, java