### PR TITLE
Fix to the release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,6 @@ on:
 env:
   BUILDENV_IMAGE_VERSION: latest # use this for all buildenv containers
   IMAGE_VERSION: ci-${{ github.run_number }} # use this for all other containers
-  SRC_BRANCH: ${{ github.event.head }}
   SP_SUBSCRIPTION_ID: ${{ secrets.SP_SUBSCRIPTION_ID }}
   SP_APPID: ${{ secrets.SP_APPID }}
   SP_PASSWORD: ${{ secrets.SP_PASSWORD }}

--- a/cloud/azure/scripts/vagrant-box.sh
+++ b/cloud/azure/scripts/vagrant-box.sh
@@ -26,8 +26,9 @@
 # clone
 # preload proper boxes in base image
 #
-git clone https://$GITHUB_TOKEN@github.com:/kontainapp/km -b ${SRC_BRANCH}
+git clone https://$GITHUB_TOKEN@github.com:/kontainapp/km
 cd km
+git checkout -b ${SRC_BRANCH}
 git submodule update --init kkm
 mkdir build
 cp /tmp/kkm.run /tmp/kontain.tar.gz build

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -28,12 +28,15 @@ FROMTOP := $(shell git rev-parse --show-prefix)
 
 # Current branch. Note that on Github merges the branch name is in
 # GITHUB_HEAD_REF, and current branch is refs/merge/pr-id.
-# IN all other cases we extract branch namee from git rev-parse
-# on GTHUB PullRequests (and push )
+# In all other cases we extract branch name from git rev-parse
+# on GITHUB PullRequests (and push)
 ifneq (${GITHUB_HEAD_REF},)
 SRC_BRANCH ?= ${GITHUB_HEAD_REF}
 else
-SRC_BRANCH ?= $(shell git rev-parse --abbrev-ref  HEAD)
+SRC_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+ifeq (${SRC_BRANCH},HEAD)
+SRC_BRANCH = ${GITHUB_SHA}
+endif
 endif
 # current SHA, to be saved for 'km -v' uniquiness
 SRC_SHA ?= $(shell git rev-parse HEAD)


### PR DESCRIPTION
Turns out SRC_BRANCH isn't set correctly when a github action is triggered with tag push. 

Tested by applying v0.1-edge tag. Will apply v0.9.0 tag when merged