### PR TITLE
fix release URL

### DIFF
--- a/km-releases/kontain-install.sh
+++ b/km-releases/kontain-install.sh
@@ -27,8 +27,12 @@ set -e
 export DEFAULT_TAG=latest
 
 readonly TAG=${1:-$DEFAULT_TAG}
+if [[ $TAG = latest ]] ; then
+   readonly URL="https://github.com/kontainapp/km/releases/${TAG}/download/kontain.tar.gz"
+else
+   readonly URL="https://github.com/kontainapp/km/releases/download/${TAG}/kontain.tar.gz"
+fi
 readonly PREFIX="/opt/kontain"
-readonly URL="https://github.com/kontainapp/km/releases/download/${TAG}/kontain.tar.gz"
 
 function check_args {
    # "check-arg: Noop for now"


### PR DESCRIPTION
Turns out github release artifacts URLs are not what I was expecting. The _latest_ release is at

```
https://github.com/kontainapp/km/releases/latest/download/kontain.tar.gz
```

while accessed by tag (say _v0.9.0_) the URL is:

```
https://github.com/kontainapp/km/releases/download/v0.9.0/kontain.tar.gz
```
Note transposition of _`latest/download`_ vs _`download/v0.9.0`_.
Access to individual files in the repo, OTOH, is more as expected

```
https://raw.githubusercontent.com/kontainapp/km/latest/<path_in_km>
https://raw.githubusercontent.com/kontainapp/km/v0.9.0/<path_in_km>
```

I updated the release document too