### PR TITLE
TRIVIAL: Double images cleanup timeout

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -323,6 +323,7 @@ jobs:
 
       - name: Cleanup and logout
         if: always()
+        timeout-minutes: 20
         run: |
           [ "$TRACE" ] && set -x
           make -C cloud/azure ci-image-purge CI_IMAGE_DRY_RUN=""


### PR DESCRIPTION
We've been having nightly failures that are simply timeouts in cleanup of test and run images we create for each PR. I guess we've been running a lot of tries, each creating a bunch of images, and image cleanup takes surprisingly ling time.

Simply double the timeout for now.

I'm running the cleanup now from my desktop to cleanup the backlog of images out there, should also help.