### PR TITLE
use --runtime=krun in docs, scripts and such

### DIFF
--- a/container-runtime/podman_config.sh
+++ b/container-runtime/podman_config.sh
@@ -121,7 +121,7 @@ REFRESH=REFRESH_${ID^^}_PACKAGES
 # Tell ubuntu about the ppackage repo containing podman
 if test "$ID" = "ubuntu"
 then
-   apt-get update 
+   apt-get update
    apt-get install -y wget gnupg2
    echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | apt-key add -

--- a/demo/faktory/java/README.md
+++ b/demo/faktory/java/README.md
@@ -44,9 +44,7 @@ sudo tools/faktory/bin/faktory convert --type java \
 # To run the kontainer. --init makes ^C/^Z killing handled by runtime
 docker run -it --init --rm -p 8081:8080 \
     --name demo-kontain \
-    --device /dev/kvm \
-    -v /opt/kontain/bin/km:/opt/kontain/bin/km:z \
-    -v /opt/kontain/runtime/libc.so:/opt/kontain/runtime/libc.so:z \
+    --runtime=krun \
     kontainapp/faktory-java-demo-kontain:latest
 
 # In another window

--- a/demo/spring-boot/Makefile
+++ b/demo/spring-boot/Makefile
@@ -54,7 +54,7 @@ build/demo: clean/image
 	mkdir -p empty_tmp
 	${DOCKER_BUILD} -t ${DEMO_IMAGE} --build-arg TARGET_JAR_PATH=${TARGET_JAR_PATH} -f kontain.dockerfile ${CURRENT_DIR}
 
-run_demo = ${DOCKER_RUN} -d --device=${HYPERVISOR_DEVICE} ${KM_DOCKER_VOLUME} -v $$(pwd):/mnt:z -p ${DEFAULT_DEMO_PORT}:8080 --name ${DEMO_CONTAINER} ${DEMO_IMAGE} /run.sh
+run_demo = ${DOCKER_RUN} ${DOCKER_KRUN_RUNTIME} -d -v $$(pwd):/mnt:z -p ${DEFAULT_DEMO_PORT}:8080 --name ${DEMO_CONTAINER} ${DEMO_IMAGE} /run.sh
 .PHONY: run/demo
 run/demo:
 	$(call run_demo)

--- a/demo/spring-boot/README.md
+++ b/demo/spring-boot/README.md
@@ -27,11 +27,8 @@ is available in /opt/kontain/bin.
 ### Step 2 - Start a Shell Inside Docker Container
 
 ```bash
-docker run --name=KM_SpringBoot_Demo --privileged --rm -it --device=/dev/kvm \
- -v /opt/kontain/bin:/opt/kontain/bin:z \
- -v $(pwd):/mnt:z \
- -v ${WORKSPACE}/km/payloads/java/scripts:/scripts:z \
- -p8080:8080 kontainapp/spring-boot-demo /bin/sh
+docker run --runtime=krun --name=KM_SpringBoot_Demo --rm -it \
+  -v $(pwd):/mnt:z -p8080:8080 kontainapp/spring-boot-demo /bin/sh
 ```
 
 ### Step 3 Measure Base Startup Time

--- a/demo/spring-boot/test/runperf.sh
+++ b/demo/spring-boot/test/runperf.sh
@@ -24,12 +24,7 @@ max_attempts=250
 
 START=$(date +%s%N)
 
-docker run -it --name TESTDEMO -d --device=/dev/kvm \
-  -v /opt/kontain/bin/km:/opt/kontain/bin/km:z \
-  -v /opt/kontain/runtime/libc.so:/opt/kontain/runtime/libc.so:z \
-  -v /opt/kontain/bin/km_cli:/opt/kontain/bin/km_cli:z \
-  -v ${WORKSPACE}/km/payloads/java/scripts:/scripts:z \
-  -p8080:8080 ${CONTAINER}
+docker run --runtime=krun -it --name TESTDEMO -d -p8080:8080 ${CONTAINER}
 #/opt/kontain/bin/km /opt/kontain/java/bin/java.kmd -jar /app.jar &
 #/opt/kontain/bin/km kmsnap &
 
@@ -51,4 +46,3 @@ echo $((${DFINISH} - ${START})), $((${FINISH} - ${DFINISH})), $((${FINISH} - ${S
 
 docker stop TESTDEMO
 docker rm TESTDEMO
-kill %1

--- a/demo/test-app/Makefile
+++ b/demo/test-app/Makefile
@@ -28,4 +28,4 @@ container: ${BUILD}/${TF}
 	cp ${BUILD}/${TF} .
 	docker build -t test-app .
 	@rm ${TF}
-	@echo "Run 'docker run --device=/dev/kvm -v /opt/kontain/bin/km:/opt/kontain/bin/km --name test-app --rm -it -p 5000:5000 test-app /bin/sh' to login into container"
+	@echo "Run 'docker run --runtime=krun --name test-app --rm -it -p 5000:5000 test-app /bin/sh' to login into container"

--- a/demo/test-app/README.md
+++ b/demo/test-app/README.md
@@ -24,8 +24,7 @@ make container
 ```
 
 ```bash
-docker run --device=/dev/kvm -v /opt/kontain/bin:/opt/kontain/bin:z -v $(pwd)/tmp:/mnt:Z \
-           --name test-app --rm -it -p 5000:5000 test-app /bin/sh
+docker run --runtime=krun -v $(pwd)/tmp:/mnt:Z --name test-app --rm -it -p 5000:5000 test-app /bin/sh
 ```
 
 ## To test:
@@ -89,8 +88,7 @@ Make sure km_cli is compiled and in /opt/kontain/bin.
 Run kontainer the same way as above:
 
 ```bash
-docker run --device=/dev/kvm -v /opt/kontain/bin:/opt/kontain/bin:z -v $(pwd)/tmp:/mnt:Z \
-           --name test-app --rm -it -p 5000:5000 test-app /bin/sh
+docker run --runtime=krun -v $(pwd)/tmp:/mnt:Z --name test-app --rm -it -p 5000:5000 test-app /bin/sh
 ```
 
 On the host, run

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -159,11 +159,9 @@ kubectl delete -k ~/workspace/km/payloads/k8s/azure/python
 ## (optional) Local docker with our payloads
 
 ```bash
-docker run -p 8080:8080 -t --rm --device /dev/kvm \
-  -v ~/workspace/km/build/km/km:/opt/kontain/bin/km:z  \
-  -v ~/workspace/km/payloads/python/scripts/micro_srv.py:/scripts/micro_srv.py \
-  kontainapp/runenv-python -S "/scripts/micro_srv.py" "8080"
-docker run -p 8080:8080 -t --rm --device /dev/kvm -v ~/workspace/km/build/km/km:/opt/kontain/bin/km:z kontainapp/runenv-dweb 8080
+docker run -p 8080:8080 -t --rm --runtime=krun -v ~/workspace/km/payloads/python/scripts/micro_srv.py:/scripts/micro_srv.py \
+  kontainapp/runenv-python "/scripts/micro_srv.py" "8080"
+docker run -p 8080:8080 -t --rm --runtime=krun kontainapp/runenv-dweb 8080
 ```
 
 ## Meltdown

--- a/payloads/busybox/runenv.dockerfile
+++ b/payloads/busybox/runenv.dockerfile
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 FROM scratch
+ENV HOME /root
 # turn off km symlink trick and minimal shell interpretation
 ENV KM_DO_SHELL NO
 ADD --chown=0:0 busybox/_install /

--- a/payloads/demo-dweb/dweb/Makefile
+++ b/payloads/demo-dweb/dweb/Makefile
@@ -27,7 +27,7 @@ dweb: $(OBJS)
 	$(CC) -static $(CLFAGS) -pthread  -o $@ $^
 
 dweb.km: $(OBJS)
-	${TOP}/tools/bin/kontain-gcc -static -no-pie $(CLFAGS) -pthread  -o $@ $^ && chmod a-x $@
+	${TOP}/tools/bin/kontain-gcc -static -no-pie $(CLFAGS) -pthread  -o $@ $^
 
 .PHONY: clean
 clean:

--- a/payloads/java/Makefile
+++ b/payloads/java/Makefile
@@ -46,7 +46,7 @@ DEP_PACKAGES := java-11-openjdk \
 FROMSRC=$(shell test -d $(JDK_VERSION)/.git && echo yes)
 
 # config for image validation
-RUNENV_VALIDATE_CMD := ("/opt/kontain/java/bin/java" "-cp" "/scripts" Hello)
+RUNENV_VALIDATE_CMD := ("java" "-cp" "/scripts" Hello)
 RUNENV_VALIDATE_EXPECTED := Hello, World!
 RUNENV_VALIDATE_DEPENDENCIES := scripts/Hello.class \
 	scripts/SimpleHttpServer.class \

--- a/payloads/java/runenv.dockerfile
+++ b/payloads/java/runenv.dockerfile
@@ -21,5 +21,6 @@ ARG RUNENV_IMAGE_VERSION=latest
 FROM kontainapp/runenv-dynamic-base:${RUNENV_IMAGE_VERSION}
 
 ARG JAVA_DIR=/opt/kontain/java
+ENV PATH ${JAVA_DIR}/bin:${PATH}
 ENV LD_LIBRARY_PATH ${JAVA_DIR}/lib/server:${JAVA_DIR}/lib/jli:${JAVA_DIR}/lib:/opt/kontain/runtime
 COPY . ${JAVA_DIR}/

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -158,7 +158,7 @@ clobber-modules:
 # Set info for runenv-image build
 
 RUNENV_ROOTFS_SCRIPT := runenv/rootfs.sh
-RUNENV_VALIDATE_CMD := ("/usr/local/bin/python3" "scripts/sanity_test.py")
+RUNENV_VALIDATE_CMD := ("python3" "scripts/sanity_test.py")
 
 export define runenv_prep
 	${RUNENV_ROOTFS_SCRIPT} ${PYTHONTOP} ${RUNENV_PATH} ${VERS} $(notdir ${PAYLOAD_KM})

--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -53,7 +53,7 @@ echo kontain-gcc -pthread -ggdb ${BUILD}/Programs/python.o \
 kontain-gcc -pthread -ggdb ${BUILD}/Programs/python.o \
    @linkline_km.txt ${EXTRA_FILES} ${OUT}/python.km.symbols.o \
    ${BUILD}/libpython3*.a -lz -lssl -lcrypto -lsqlite3 $LDLIBS \
-   -o ${NAME} && chmod a-x ${NAME} && echo Linked: ${OUT}/${NAME}
+   -o ${NAME} && echo Linked: ${OUT}/${NAME}
 
 kontain-gcc -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/python.o \
    -Xlinker --undefined=strtoull_l \

--- a/payloads/python/scripts/flask/Dockerfile
+++ b/payloads/python/scripts/flask/Dockerfile
@@ -26,10 +26,9 @@
 #  alpine
 #
 ARG distro
-ARG tag=latest
+ARG tag=3.13
 
 FROM $distro:$tag
-
 
 # ideally we should set add_pip3 and update_index here depending on $distro, but Dockerfile has no if/then/ese so relying on the caller
 ARG add_pip3

--- a/payloads/python/scripts/flask/Makefile
+++ b/payloads/python/scripts/flask/Makefile
@@ -63,20 +63,20 @@ build: ## build python flask example, based on alpine. alpine can we swapped for
 		--build-arg distro="$(DTYPE)" --build-arg add_pip3="$(ADD_PIP3)" --build-arg update_index="$(UPDATE_INDEX)" \
 		-t $(IMAGE) .
 
-run: ## run python flask example,based on alpine. Same DTYPE as supported as in'build'. Assumes "build" was successful.
+run: ## run python flask example based on alpine. Same DTYPE as supported as in'build'. Assumes "build" was successful.
 	$(DOCKER_RUN) $(IMAGE)
 
-faktory: ${KM_BIN} ## Convert flask example to Kontainer. Same DTYPE as supported as in'build'. Assumes "build" was successful.
+faktory: ## Convert flask example to Kontainer. Same DTYPE as supported as in'build'. Assumes "build" was successful.
 	./faktory_run_build.sh "$(IMAGE)" "$(KM_IMAGE)" "$(DTYPE)" "${KM_BIN}"
 
 test:   ## run Kontain with flask example,based. Same DTYPE as supported as in'build'. Assumes "faktory" was successful.
-	$(DOCKER_RUN) --device=/dev/kvm $(KM_IMAGE)
+	$(DOCKER_RUN) $(DOCKER_KRUN_RUNTIME) $(KM_IMAGE)
 
 clean: ## Kill test containers (if any) and remove all images build for flask-km (python flask is untouched)
 	@echo Cleaning. Ignore messages about failures and ignoring failures.
 	-docker rm -f `docker ps -aq --filter label=$(TEST_LABEL)` 2> /dev/null
 	-docker rmi $(KM_IMAGE)
-	-docker image prune  -f
+	-docker image prune -f
 
 TARGET?= build
 all-dtypes: # make TARGET for each DTYPE. E.g. `make all-dtypes TARGET=clean". Default is 'build'

--- a/payloads/python/scripts/flask/faktory_prepare.sh
+++ b/payloads/python/scripts/flask/faktory_prepare.sh
@@ -30,7 +30,6 @@ if [ -z "$DIR" ] ; then DIR=/tmp/faktory; fi
 APPDIR=$2 # where is the app
 if [ -z "$APPDIR" ] ; then APPDIR=`pwd`; fi
 
-
 msg() { echo "$@" >&2; }
 
 msg We are in $APPDIR

--- a/payloads/python/scripts/flask/faktory_run_build.sh
+++ b/payloads/python/scripts/flask/faktory_run_build.sh
@@ -36,7 +36,6 @@ KM_BIN="$4"
 
 if [ -z "${IMAGE}" -o -z "${KM_IMAGE}" -o -z "${DTYPE}" ] ; then echo Wrong usage, missing param; exit 1; fi
 
-
 RED="\033[31m"
 NOCOLOR="\033[0m"
 
@@ -47,14 +46,10 @@ entrypoint=$(docker image inspect $IMAGE -f '{{json .Config.Entrypoint }}')
 # TODO - here is a good place to check language-specific quirks with entrypoint and cmd and env, i.e usage of scripts?
 # or (better) pass this info down as build_param so in-container faktory_prepare can analyze..
 if [[ $entrypoint == *python*-*E* ]] ; then
-   echo -e "${RED}*** WARNING: -E flag in python - PYTHONHOME wont work${NOCOLOR}"  >&2
+   echo -e "${RED}*** WARNING: -E flag in python - PYTHONHOME wont work${NOCOLOR}" >&2
 fi
 
-cp ${KM_BIN} .
-cp ../../cpython/python.km python3.km # TODO - build python.km if needed; also use python versioning scheme
-
-cat faktory_stem.dockerfile  - <<EOF  | $docker_build --build-arg distro="$DTYPE"  -t $KM_IMAGE -f - .
-
+cat faktory_stem.dockerfile - <<EOF  | $docker_build --build-arg distro="$DTYPE" -t $KM_IMAGE -f - .
 #-- auto-lifted from $IMAGE. Do not edit directly:--
 
 WORKDIR    $(docker image inspect $IMAGE -f '{{json .Config.WorkingDir }}')
@@ -62,7 +57,3 @@ ENTRYPOINT $entrypoint
 CMD        $(docker image inspect $IMAGE -f '{{json .Config.Cmd }}')
 
 EOF
-
-res=$?
-rm -f python3.km $(basename ${KM_BIN})
-exit $res

--- a/payloads/python/scripts/flask/faktory_stem.dockerfile
+++ b/payloads/python/scripts/flask/faktory_stem.dockerfile
@@ -27,16 +27,13 @@ ARG distro=alpine
 # This stage will find and extract all py-related files from original container into $TMP folder
 FROM $image:$distro as original
 
-# Prep all the files needed in Kontainer , in $TMP dir
+# Prep all the files needed in Kontainer, in $TMP dir
 COPY faktory_prepare.sh /tmp
-RUN /tmp/faktory_prepare.sh /tmp/faktory
+RUN /tmp/faktory_prepare.sh /tmp/faktory 
 
 # This stage will unpack all py files from prior stage and add KM/python.km needed stuff
-FROM scratch
+FROM kontainapp/runenv-python
 
 COPY --from=original /tmp/faktory/pydirs/ /
-COPY --from=original /tmp/faktory/python3 /usr/local/bin/
-# TODO: build correct python3.km depending on payload;  package in tar as /usr/local/bin/python and use 'ADD'
-COPY python3.km km /usr/local/bin/
 
 # ENTRYPOINT and CMD will be added to to the end of this file by caller from upstairs

--- a/payloads/python/scripts/micro_srv.py
+++ b/payloads/python/scripts/micro_srv.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 #
 # Copyright 2021 Kontain Inc
 #
@@ -19,7 +20,7 @@
 Trivial HTTP server in python3.
 
 Usage::
-    km ./python.km  ../scripts/micro_srv [<port>]
+    python ../scripts/micro_srv [<port>]
 
 Send a GET request::
     curl -s http://localhost[:port]

--- a/tools/faktory/Makefile
+++ b/tools/faktory/Makefile
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-
 .PHONY: all
 all: bin/faktory
 
@@ -31,7 +30,7 @@ clean:
 .PHONY: test
 test: bin/faktory
 	@# sudo is required to run tests
-	sudo -E env "GOPATH=${GOPATH}" env "GOBIN=${GOBIN}" /usr/local/go/bin/go test -p 1 -count=1 ./tests/...
+	sudo -E env "GOPATH=${GOPATH}" env "GOBIN=${GOBIN}" go test -p 1 -count=1 ./tests/...
 
 .DEFAULT:
 	@echo $(notdir $(CURDIR)): ignoring target '$@'

--- a/tools/faktory/README.md
+++ b/tools/faktory/README.md
@@ -29,8 +29,8 @@ To work around the issue, we `docker save` the image, restore the metadata
 from the source container, compute the hash and make the right edits, and
 last `docker load` the resulting image back as the final `kontainer`. The
 image exported through `docker save` is self contained, so we have a chance
-to edit the metadata without failing all the docker hash checkings. It's
-important to note that this is reverse enginered process, and are not
+to edit the metadata without failing all the docker hash checks. It's
+important to note that this is reverse engineered process, and are not
 officially supported APIs.
 
 ### Assumptions
@@ -42,9 +42,9 @@ how the input container is constructed. Therefore, we assume the input
 container is build with the following layers.
 
 * Base OS layers: this layer contains the base operating system such as ubuntu
-and alpine. We will throw this layout.
+or alpine. We will throw this layout.
 
-* Launguage runtime layers: this will contain the python installation. We can
+* Language runtime layers: this will contain the python installation. We can
 identify this layer by searching for python installations in the known path.
 We will ignore custom installation location for now. We will try to replace
 this layer with kontain python runenv images.
@@ -74,11 +74,3 @@ The test requires:
 - km be compiled and installed onto `/opt/kontain/bin/km` on the host.
 - `kontainapp/runenv-python` is built. `make -C TOP/payloads/python
 runenv-image`.
-
-When in question, consult the km and payload/python for more info.
-
-Note: Ideally, we want to pull the official `runenv-python` image, but
-currently that's not implemented yet. This repo should be able to stand on
-it's own and have as little dependencies as possible to the km and payload
-code. Whenever possible, faktory should only consume released version of km
-and payloads.

--- a/tools/faktory/docs/HOWTO.md
+++ b/tools/faktory/docs/HOWTO.md
@@ -64,26 +64,22 @@ COPY gs-rest-service/complete /app
 WORKDIR /app
 RUN ./mvnw install
 
-FROM kontainapp/runenv-jdk-11
+FROM adoptopenjdk/openjdk11:alpine-jre
 WORKDIR /app
 ARG APPJAR=/app/target/*.jar
+# TODO: next two line are introduce a foreknowledge of kontain java. Need to do that in the converter
+ENV PATH ${PATH}:/opt/kontain/java/bin
+COPY --from=builder /tmp /tmp
+
 COPY --from=builder ${APPJAR} app.jar
-ENTRYPOINT ["java","-jar", "app.jar"]
-``` 
+ENTRYPOINT ["java", "-jar", "app.jar"]
+```
 Note: only the `FROM` from the final docker image is changed. Here we kept
 using a normal jdk docker image as the `builder` because the build
 environment is not affected by kontain.
 
 ## Run
 
-To run a kontain based container image, the container will need access to
-`/dev/kvm` and kontain monitor `km`. For Java we also requires kontain's
-version of `lic.so`.
-
 ```bash
-docker run -it --rm \
-    --device /dev/kvm \
-    -v /opt/kontain/bin/km:/opt/kontain/bin/km:z \
-    -v /opt/kontain/runtime/libc.so:/opt/kontain/runtime/libc.so:z \
-    example/kontain-java
+docker run -it --rm --runtime=krun example/kontain-java
 ```

--- a/tools/faktory/tests/flask/assets/Dockerfile
+++ b/tools/faktory/tests/flask/assets/Dockerfile
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 RUN pip install flask gunicorn
 COPY app /app
 WORKDIR /app
 EXPOSE 8080
-CMD [ "gunicorn", "--bind", "0.0.0.0:8080", "app:app" ] 
+CMD [ "gunicorn", "--bind", "0.0.0.0:8080", "app:app" ]

--- a/tools/faktory/tests/flask/flask_test.go
+++ b/tools/faktory/tests/flask/flask_test.go
@@ -62,7 +62,7 @@ func runTest() error {
 // original base as the conversion base. This will make the rootfs of the
 // converted image the same as the original.
 func testDocker(t *testing.T) error {
-	const BASE string = "python:3.7-alpine"
+	const BASE string = "python:3.8-alpine"
 	const TESTCONTAINER string = "faktory_test_docker"
 
 	// Build the from image
@@ -115,8 +115,7 @@ func testKontain(t *testing.T) error {
 		"run",
 		"-d",
 		"--rm",
-		"--device=/dev/kvm",
-		"-v", "/opt/kontain/bin/km:/opt/kontain/bin/km:z",
+		"--runtime=krun",
 		"-p", "8080:8080",
 		"--name", TESTCONTAINER,
 		TO); err != nil {

--- a/tools/faktory/tests/java/assets/Dockerfile
+++ b/tools/faktory/tests/java/assets/Dockerfile
@@ -21,5 +21,9 @@ RUN ./mvnw install
 FROM adoptopenjdk/openjdk11:alpine-jre
 WORKDIR /app
 ARG APPJAR=/app/target/*.jar
+# TODO: next two line are introduce a foreknowledge of kontain java. Need to do that in the converter
+ENV PATH ${PATH}:/opt/kontain/java/bin
+COPY --from=builder /tmp /tmp
+
 COPY --from=builder ${APPJAR} app.jar
-ENTRYPOINT ["java","-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/tools/faktory/tests/java/java_test.go
+++ b/tools/faktory/tests/java/java_test.go
@@ -151,9 +151,7 @@ func testKontain() error {
 		"run",
 		"-d",
 		"--rm",
-		"--device=/dev/kvm",
-		"-v", "/opt/kontain/bin/km:/opt/kontain/bin/km:z",
-		"-v", "/opt/kontain/runtime/libc.so:/opt/kontain/runtime/libc.so:z",
+		"--runtime=krun",
 		"-p", "8080:8080",
 		"--name", TESTCONTAINER,
 		TO); err != nil {


### PR DESCRIPTION
Looked for `--device=/dev/kvm` and such everywhere, and change to `--runtime=krun` where appropriate. 

One noted area where is is *not* appropriate is our tests directory and corresponding test targets. In these cases we assume we are testing newly build km and we call in explicitly with the specific arguments.

In demos and such we should use the runtime.