### PR TITLE
disable validate-runenv-withk8s

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -335,9 +335,12 @@ jobs:
         run: make -C payloads test-all-withk8s
         timeout-minutes: 60
 
-      - name: Payloads runenv validation, on K8s
-        run: make -C payloads validate-runenv-withk8s
-        timeout-minutes: 5
+      # TODO: https://github.com/kontainapp/km/issues/1326
+      # The runenv images assume runtime=krun now.
+      # Disable until we figure out how to enable that on AKS.
+      # - name: Payloads runenv validation, on K8s
+      #   run: make -C payloads validate-runenv-withk8s
+      #   timeout-minutes: 5
 
       - name: KM tests with coverage, on K8s
         # pull buildenv before testing, coverage analysis will need it

--- a/payloads/Makefile
+++ b/payloads/Makefile
@@ -38,4 +38,4 @@ default coverage:
 	@echo "Info: ignoring target '$@' in payloads"
 
 # use this target to force payloads build
-link build: $(SUBDIRS)
+link build clobber: $(SUBDIRS)


### PR DESCRIPTION
Nightly tests run `make validate-runenv-withk8s`. The nightly cluster is configured with with the kontaind, allowing the /dev/kvm access to the pods, and mount /opt/kontain/bin/km into the pods, not --runtime=krun. Our new demo-runenv-image do not support that as nothing inserts KM into the execution path.

Disable this step for now, until we figure out how to enable krun runtime on AKS

https://github.com/kontainapp/km/issues/1326
