### PR TITLE
more parallel CI jobs

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -139,7 +139,7 @@ jobs:
           retention-days: 7
 
   km-test:
-    name: Test KM/KVM on K8S and Azure VM
+    name: Test KM/KVM on K8S and KKM on Azure VM
     runs-on: ubuntu-20.04
     needs: km-build
     steps:
@@ -172,11 +172,9 @@ jobs:
         timeout-minutes: 10
 
   km-test-withpacker:
-    name: Basic payload tests with Packer
+    name: Basic payload tests on Azure VM
     runs-on: ubuntu-latest
-    needs: [km-build, km-test]
-    # km-test and km-test-withpacker use the same resource group which causes the km-ci-workflow to fail.
-    # So, we serialize them even thought there is no real dependency.
+    needs: km-build
     steps:
       - uses: actions/checkout@v2
         with:
@@ -192,7 +190,7 @@ jobs:
       - name: Payload tests with packer
         # to avoid calling packer in a loop, we call it on one dir (does not matter which one)
         # and pass the parent to it, so that the scan of payloads will happen inside a single docker
-        run: make -C payloads/busybox test-withpacker PACKER_DIR=payloads TIMEOUT=15m
+        run: make -C payloads/busybox test-withpacker PACKER_DIR=payloads TIMEOUT=15m STEP=test
         # note: not using CI's 'timeout-minutes' to avoid a kill without cleaning resources
 
   kkm-build:
@@ -266,13 +264,13 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: make -C tests test-withpacker HYPERVISOR_DEVICE=/dev/kkm TIMEOUT=20m
+        run: make -C tests test-withpacker HYPERVISOR_DEVICE=/dev/kkm TIMEOUT=20m STEP=test-vms
         # note: not using CI's 'timeout-minutes' to avoid a kill without cleaning resources
 
   km-krun-validate-runenv:
     name: Validate runenv on AWS and Azure VMs
     runs-on: ubuntu-20.04
-    needs: [km-build]
+    needs: km-build
     steps:
       - uses: actions/checkout@v2
 
@@ -281,11 +279,29 @@ jobs:
           name: km
           path: /tmp/
 
-      - name: KM with KKM Test - AWS and Azure with packer
+      - name: Validate runenv images on Azure
+        run: make -C tests validate-runenv-image-withpacker TIMEOUT=20m PACKER_DIR=payloads STEP=validate-runenv
+        # note: not using CI's 'timeout-minutes' to avoid a kill without cleaning resources
+
+  km-krun-kkm-validate-runenv:
+    name: Validate runenv on AWS and Azure VMs
+    # TODO: Enable when KKM on fedora with selinux is complete
+    if: ${{ false }}
+    runs-on: ubuntu-20.04
+    needs: km-build
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: km
+          path: /tmp/
+
+      - name: Validate runenv images with kkm on AWS and Azure
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: make -C tests validate-runenv-image-withpacker HYPERVISOR_DEVICE=/dev/kvm TIMEOUT=20m PACKER_DIR=payloads
+        run: make -C tests validate-runenv-image-withpacker HYPERVISOR_DEVICE=/dev/kkm TIMEOUT=20m PACKER_DIR=payloads STEP=kkm-validate-runenv
         # note: not using CI's 'timeout-minutes' to avoid a kill without cleaning resources
 
   km-k8s-cluster:
@@ -372,7 +388,7 @@ jobs:
     if: (failure() && github.ref == 'refs/heads/master') ||
       contains(github.workflow, 'noisy')
     # Dependencies. (A skipped dependency is considered satisfied)
-    needs: [km-build, kkm-build, km-test, km-test-withpacker, kkm-test, kkm-test-vms, km-krun-validate-runenv, km-test-all]
+    needs: [km-build, kkm-build, km-test, km-test-withpacker, kkm-test, kkm-test-vms, km-krun-validate-runenv, km-krun-kkm-validate-runenv, km-test-all]
     steps:
       - name: Send notification to slack
         uses: Gamesight/slack-workflow-status@master

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -285,8 +285,6 @@ jobs:
 
   km-krun-kkm-validate-runenv:
     name: Validate runenv on AWS and Azure VMs
-    # TODO: Enable when KKM on fedora with selinux is complete
-    if: ${{ false }}
     runs-on: ubuntu-20.04
     needs: km-build
     steps:

--- a/docs/build.md
+++ b/docs/build.md
@@ -341,11 +341,11 @@ file=~/.ssh/$t_name
 az ad sp create-for-rbac -n "$t_name" --role contributor --years 3 | tee $file
 chmod 400 $file
 echo -e "\n# Azure secret for non-interactive login $t_name. Created $(date)" >> ~/.bash_profile
-cat $file  | jq -r  '"export SP_APPID=\(.appId)",
-                     "export SP_DISPLAYNAME=\(.displayName)",
-                     "export SP_NAME=\(.name)",
-                     "export SP_PASSWORD=\(.password)",
-                     "export SP_TENANT=\(.tenant)"' \
+cat $file  | jq -r '"export SP_APPID=\(.appId)",
+                    "export SP_DISPLAYNAME=\(.displayName)",
+                    "export SP_NAME=\(.name)",
+                    "export SP_PASSWORD=\(.password)",
+                    "export SP_TENANT=\(.tenant)"' \
                >> ~/.bash_profile
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,7 +55,7 @@ On AWS, only “metal” instances (e.g. i3.metal) enable nested virtualization.
 
 ### Do I Need KVM or KKM?
 
-On Linux development machines, Kontain can run on the machine directly, with either KVM (native Linux virtualization) or KKM (Kontain kernel module) installed.
+On Linux development machines, Kontain can run on the machine directly, with KVM.
 
 On OSX and Windows development machines, Kontain can be run in a Linux VM with either KVM module (nested virtualization) enabled or the KKM module installed. Support for nested virtualization depends on the hypervisor. KKM can be installed in the Linux VM if the hypervisor does not support nested virtualization.
 
@@ -937,34 +937,6 @@ Your output should look like this:
 ```
 posix.uname_result(sysname='kontain-runtime', nodename='ddef05d46147', release='4.1', version='preview', machine='kontain_KVM')
 ```
-
-### Using the Docker Runtime
-
-Running a workload in Docker using Kontain runtime (`krun`) requires Docker configuration. (See ["Runtime Config for Docker"](#runtime-config-for-docker).)
-
-When you use Kontain runtime, `docker exec` and all subprocesses are automatically wrapped in dedicated Kontain VMs (one VM per process).
-
-You can also run a Kontain workload using the Docker default runtime, but `docker exec` and any subprocesses will circumvent Kontain VM encapsulation.
-
-```
-docker run --rm -v /opt/kontain/bin/km:/opt/kontain/bin/km:z --device /dev/kvm kontain-hello
-```
-
-NOTE: Use `--device /dev/kkm` on platforms with Kontain KKM module (e.g. AWS)
-
-You will need to pass the necessary information to Docker.
-
-EXAMPLE:
-
-```
-docker run -it --rm \
-    --device /dev/kvm \
-    -v /opt/kontain/bin/km:/opt/kontain/bin/km:z \
-    -v /opt/kontain/runtime/libc.so:/opt/kontain/runtime/libc.so:z \
-    example/kontain-java
-```
-
-NOTE: On platforms with KKM installed, use `--device /dev/kkm`
 
 ### Using Kontain runtime with Podman
 

--- a/make/images.mk
+++ b/make/images.mk
@@ -289,7 +289,7 @@ endif
 	cd ${TOP}/tests ; \
 	packer build -force \
 		-var src_branch=${SRC_BRANCH} -var image_version=${IMAGE_VERSION} -var target=$(subst -withpacker,,$@) \
-		-var dir=${PACKER_DIR} -var hv_device=${HYPERVISOR_DEVICE} -var timeout=${TIMEOUT} \
+		-var dir=${PACKER_DIR} -var hv_device=${HYPERVISOR_DEVICE} -var timeout=${TIMEOUT} -var step=${STEP} \
 	packer/km-az-test.pkr.hcl
 
 # === BUILDENV LOCAL

--- a/tests/packer/km-aws-test.pkr.hcl
+++ b/tests/packer/km-aws-test.pkr.hcl
@@ -16,47 +16,41 @@
 #  Test KM using packer build process on AWS
 
 variable "src_branch" {
-   type = string
-   description="Branch being tested"
+  type        = string
+  description = "Branch being tested"
 }
 
 variable "image_version" {
-   type = string
-   description="Branch-specific tag (aka IMAGE_VERSION) for docker images"
+  type        = string
+  description = "Branch-specific tag (aka IMAGE_VERSION) for docker images"
 }
 
 variable "target" {
-   type = string
-   description="which target to run See km-test.sh for details"
-   default="test"
+  type        = string
+  description = "which target to run See km-test.sh for details"
+  default     = "test"
 }
 
 variable "dir" {
-   type = string
-   description="where to do 'make $target', e.g. tests or payloads"
+  type        = string
+  description = "where to do 'make $target', e.g. tests or payloads"
 }
 
 variable "timeout" {
-   type = string
-   description = "Timeout for tests. Should be less that outer timeout, so packer cleans up resources"
+  type        = string
+  description = "Timeout for tests. Should be less that outer timeout, so packer cleans up resources"
 }
 
 variables {
-   aws_instance_type = "m5.xlarge"  // 4 CPU 16GB
-   aws_region = "us-east-2"
-   hv_device = "/dev/kkm"
-   ssh_user = "fedora"
-   // Azure access (for docker images)
-   sp_tenant = env("SP_TENANT")
-   sp_appid = env("SP_APPID")
-   sp_password = env("SP_PASSWORD")
-   github_token = env("GITHUB_TOKEN")
-   // azure images
-   src_image_name = "L0BaseImage" // would be good to pass from upstairs so others can use it
-   // can conflict with other runs. TODO - make unique
-   // see https://www.packer.io/docs/templates/hcl_templates/functions
-   image_name = "KKMTestTmpImage"
-   image_rg = "PackerBuildRG"
+  aws_instance_type = "m5.xlarge" // 4 CPU 16GB
+  aws_region        = "us-east-2"
+  hv_device         = "/dev/kkm"
+  ssh_user          = "fedora"
+  // Azure access (for docker images)
+  sp_tenant    = env("SP_TENANT")
+  sp_appid     = env("SP_APPID")
+  sp_password  = env("SP_PASSWORD")
+  github_token = env("GITHUB_TOKEN")
 }
 
 data "amazon-ami" "build" {
@@ -71,7 +65,7 @@ data "amazon-ami" "build" {
 }
 
 locals {
-   source_ami      = data.amazon-ami.build.id
+  source_ami = data.amazon-ami.build.id
 }
 
 source "amazon-ebs" "km-test" {
@@ -82,7 +76,7 @@ source "amazon-ebs" "km-test" {
   region          = var.aws_region
   ssh_username    = var.ssh_user
   # this allows to handle tty output in tests
-  ssh_pty         = true
+  ssh_pty = true
 }
 
 build {
@@ -97,12 +91,14 @@ build {
     # packer provisioners run as tmp 'packer' user.
     # For docker to run with no sudo, let's add it to 'docker' group and
     # later use 'sg' to run all as this group without re-login
-    inline = ["sudo usermod -aG docker $USER" ]
+    inline = ["sudo usermod -aG docker ${var.ssh_user}"]
   }
 
   provisioner "shell" {
     script = "packer/scripts/km-test.sh"
-    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sg docker -c '{{ .Path }}'"
+    // double sg invocation to get docker into the process's grouplist but not the primary group.
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sg docker -c 'sg ${var.ssh_user} {{ .Path }}'"
+
     // vars to pass to the remote script
     environment_vars = [
       "TRACE=1",
@@ -117,5 +113,9 @@ build {
       "SP_TENANT=${var.sp_tenant}"
     ]
     timeout = var.timeout
+  }
+  
+  error-cleanup-provisioner "shell" {
+    script = "packer/scripts/gather-logs.sh"
   }
 }

--- a/tests/packer/scripts/gather-logs.sh
+++ b/tests/packer/scripts/gather-logs.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright 2021 Kontain Inc
 #
@@ -13,23 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Script to run if something failed.
+# Intented to run on a remote VM to gather logs and such.
 
+[ "$TRACE" ] && set -x
 
-# A basic Makefile to make KKM AWS test slightly more uniform
-# (this is currently used only for KKM testing on AWS)
-#
-# to run locally, pass IMAGE_VERSION for an existing test pass, e.g.
-# make IMAGE_VERSION=ci-146
+# Log environment
+env
 
-TOP := $(shell git rev-parse --show-toplevel)
-
-LOG ?= 0
-PACKER_BUILD = PACKER_LOG=${LOG} packer build
-
-test: .check_packer .check_image_version ## Test KKM build on AWS using Hashicorp Packer
-	${PACKER_BUILD} \
-		--var src_branch=${SRC_BRANCH} \
-		--var image_version=${IMAGE_VERSION} \
-		km-aws-test.pkr.hcl
-
-include ${TOP}/make/locations.mk
+echo Checking for kkm or kvm modules
+lsmod | grep -i k.m
+ls -lZ /dev/k*
+echo '============ Kernel messages'
+sudo dmesg
+echo '============ Journal'
+sudo journalctl -b
+echo '============ End of logs'


### PR DESCRIPTION
Make packer driven CI steps run in parallel.
Add log gathering if something fails - not really tested as nothing failed after adding these.
Disable KKM packer driven run for now, until KKM setup on Fedora (selinux related) is complete - see `km-krun-kkm-validate-runenv` step in `km-ci-workflow.yaml`