### PR TITLE
Add a shell function that retries apt-get until the lock file is available

### DIFF
--- a/container-runtime/podman_config.sh
+++ b/container-runtime/podman_config.sh
@@ -108,22 +108,20 @@ function selinux_is_enabled()
    return 1
 }
 
-# A small function to keep trying apt-get until othe apt-get'ers finish.
+# A small function to keep trying apt-get until other apt-get'ers finish.
 function persistent-apt-get
 {
-   MESSAGE="E: Could not get lock /var/lib/dpkg/lock-frontend."
    eflag=0
    if echo $- | grep -q "e"; then eflag=1; fi
-   echo eflag $eflag
 
-   rv=0
+   MESSAGE="E: Could not get lock /var/lib/dpkg/lock-frontend."
    APT_GET_OUTPUT=/tmp/apt-get-out-$$
    while true; do
       cp /dev/null $APT_GET_OUTPUT
-      if [ $eflag -ne 0 ]; then set +e; fi
+      [ $eflag -ne 0 ] && set +e
       apt-get $* >$APT_GET_OUTPUT 2>&1
       rv=$?
-      if [ $eflag -ne 0 ]; then set -e; fi
+      [ $eflag -ne 0 ] && set -e
       if test $rv -ne 0; then
          if grep -q "$MESSAGE" $APT_GET_OUTPUT; then
             # Another apt-get is running, try again.

--- a/container-runtime/podman_config.sh
+++ b/container-runtime/podman_config.sh
@@ -56,12 +56,12 @@ readonly FEDORA_KRUN_PACKAGES="libcap yajl libseccomp openssl-libs"
 readonly FEDORA_PACKAGES="podman selinux-policy-devel"
 readonly UBUNTU_KRUN_PACKAGES="libcap2 libyajl2 libseccomp2 openssl"
 readonly UBUNTU_PACKAGES="podman"
-readonly REFRESH_UBUNTU_PACKAGES="sudo apt-get update"
+readonly REFRESH_UBUNTU_PACKAGES="persistent-apt-get update"
 readonly REFRESH_FEDORA_PACKAGES=true
-readonly INSTALL_UBUNTU_PACKAGES="sudo apt-get install -y "
-readonly INSTALL_FEDORA_PACKAGES="sudo dnf install -y "
-readonly UNINSTALL_UBUNTU_PACKAGES="sudo apt-get remove -y "
-readonly UNINSTALL_FEDORA_PACKAGES="sudo dnf remove -y "
+readonly INSTALL_UBUNTU_PACKAGES="persistent-apt-get install -y "
+readonly INSTALL_FEDORA_PACKAGES="dnf install -y "
+readonly UNINSTALL_UBUNTU_PACKAGES="persistent-apt-get remove -y "
+readonly UNINSTALL_FEDORA_PACKAGES="dnf remove -y "
 
 # UNINSTALL
 if [ $# -eq 1 -a "$1" = "-u" ]; then


### PR DESCRIPTION
apt-get doesn't retry if another instance is currently running so we have an apt-get wrapper function that retries.