### PR TITLE
Assign selinux file contexts at install time

### DIFF
--- a/container-runtime/podman_config.sh
+++ b/container-runtime/podman_config.sh
@@ -259,12 +259,13 @@ EOF
 
    cat <<EOF >$KONTAIN_SELINUX_POLICY.fc
 $KKM_DEVICE		-c	gen_context(system_u:object_r:kvm_device_t,s0)
+$KM_PATH		--	gen_context(system_u:object_r:bin_t,s0)
 EOF
 
    ln -sf /usr/share/selinux/devel/Makefile
    make
    make reload
-   restorecon -i -F $KKM_DEVICE
+   restorecon -i -F $KKM_DEVICE $KM_PATH
    popd || exit
 else
    echo "selinux not enabled on this system"

--- a/km-releases/kontain-install.sh
+++ b/km-releases/kontain-install.sh
@@ -133,7 +133,7 @@ function check_prereqs {
 function get_bundle {
    mkdir -p $PREFIX
    echo "Pulling $URL..."
-   wget $URL --output-document - -q | tar -C ${PREFIX} -xzf - --selinux
+   wget $URL --output-document - -q | tar -C ${PREFIX} -xzf -
    echo Done.
    if [ $validate == 1 ]; then
       $PREFIX/bin/km $PREFIX/tests/hello_test.km Hello World

--- a/tools/bin/create_release.sh
+++ b/tools/bin/create_release.sh
@@ -30,7 +30,7 @@ readonly OPT_KONTAIN_TMP=${BLDTOP}/opt_kontain
 
 rm -fr $TARBALL $TARBALL.gz $OPT_KONTAIN_TMP
 # we may need to modify all obj file so make sure we work on a copy
-cp -rf --preserve=links,context /opt/kontain $OPT_KONTAIN_TMP
+cp -rf --preserve=links /opt/kontain $OPT_KONTAIN_TMP
 
 [ -d  ${OPT_KONTAIN_TMP}/include ] || mkdir ${OPT_KONTAIN_TMP}/include
 cp ${TOP}/include/km_hcalls.h ${OPT_KONTAIN_TMP}/include/km_hcalls.h
@@ -65,7 +65,7 @@ for i in $(seq 0 $(("${#locations[@]}" - 1))); do
    done
 
    echo "Packaging ${source}"
-   tar -C ${locations[$i]} -rf $TARBALL --selinux ${files[$i]}
+   tar -C ${locations[$i]} -rf $TARBALL ${files[$i]}
 done
 
 echo "Zipping $TARBALL.gz ..."


### PR DESCRIPTION
Built files (like km) may be built on machine with or without selinux.
And, these same files may be installed on machines with or with selinux.
So, it is not important to propagate file contexts as part of building a release.
But we always install the contexts if the install target has selinux enabled.

We also need to set a file's selinux context as part of a build so that we
can test on the build machine.