### PR TITLE
vagrant box build script wasn't using the correct source code

### DIFF
--- a/cloud/azure/scripts/vagrant-box.sh
+++ b/cloud/azure/scripts/vagrant-box.sh
@@ -28,7 +28,7 @@
 #
 git clone https://$GITHUB_TOKEN@github.com:/kontainapp/km
 cd km
-git checkout -b ${SRC_BRANCH}
+git checkout ${SRC_BRANCH}
 git submodule update --init kkm
 mkdir build
 cp /tmp/kkm.run /tmp/kontain.tar.gz build


### PR DESCRIPTION
vagrant-box.sh was using "git checkout -b ${SRC_BRANCH}"  to get the source to
produce released versions of our fedora and ubuntu boxes.
-b created an new branch with the same name as the release branch.
We really wanted to switch to the branch we want to release.

This was discovered when a new target was added to a makefile and this
script tried to use the new target but the new branch from master didn't
have the target causing the make to fail.