### PR TITLE
DOC-ONLY-kubectl apply uses URL direct without curl

### DIFF
--- a/docs/kubernetes/quickstart.md
+++ b/docs/kubernetes/quickstart.md
@@ -29,7 +29,7 @@ kube-system   storage-provisioner                1/1     Running   0          67
 ## Step 2 - Deploy Kontain Runtime
 
 ```
-kubectl apply -f curl https://raw.githubusercontent.com/kontainapp/km/latest/cloud/k8s/deploy/k8s-deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/kontainapp/km/latest/cloud/k8s/deploy/k8s-deploy.yaml
 ```
 
 To verify the installation, type:


### PR DESCRIPTION
The additional curl in the example above caused an error.  Kubectl can use a URL directly to apply the manifest.