### PR TITLE
DOC ONLY-replace driver with podman

### DIFF
--- a/docs/kubernetes/quickstart.md
+++ b/docs/kubernetes/quickstart.md
@@ -6,7 +6,7 @@ how to run containers under the Kontain runtime class.
 ## Step 1 - Start Minikube
 
 ```
-$ minikube start --container-runtime=cri-o
+$ minikube start --container-runtime=cri-o --driver=podman
 ```
 
 Note: You'll need minikube version v1.22.0 (https://github.com/kubernetes/minikube/releases/tag/v1.22.0) or better.


### PR DESCRIPTION
Had to replace docker driver with podman driver for minikube(container-runtime as cri-o) for minikube to work correctly.  Now both minikube and the test app works perfectly well.