### PR TITLE
Install KKM from a Kubernetes DaemonSet.

### DIFF
--- a/cloud/k8s/deploy/README.md
+++ b/cloud/k8s/deploy/README.md
@@ -3,8 +3,23 @@
 This directory tools to install the Kontain runtime on Kubernets clusters. The of installation are
 per-node DeamonSet objects. There are two DaemonSets defined here:
 
-- `k8s-deploy.yaml` - Install the Kontain runtime
 - `kkm-install.yaml` - Install the KKM driver
+- `k8s-deploy.yaml` - Install the Kontain runtime
+
+## Installing KKM
+
+KKM is a software-only virutalization driver that the Kontain runtime can use when hardware virtualization (KVM)
+is not availale or is undesirable. KKM is not a full, general purpose virtualization driver. KKM only supports
+the facilities needed by the Kontain runtime. 
+
+To install KKM on all nodes in kubernetes cluster, run:
+
+```
+$ kubectl apply -f cm-kkm-install.yaml
+$ kubektl apply -f km-install.yaml
+```
+
+## Installing Kontain Runtime
 
 * THIS IS A WORK IN PROGRESS *
 
@@ -37,3 +52,18 @@ The Runtime Class spacification uses a `scheuduling: nodeSelector` label to spei
 the kontain runtime installed.
 
 Currently the DeamonSet tries to install on all Nodes in a cluster.
+
+TODO:
+
+The current runtime installation script requires privileges to query the k8s cluster configuration to decide whether to
+add itself to the `containerd` or `crio` configuration. This is actually counter to what GKE seems to encourge, pods
+having little or no premission to use k8s control plane services. Ideally, it appears that a model where these decisions
+are made outside the cluster, say in a script that can run kubectl, fits better.
+
+The KKM installation procedure was inspired by a Google Cloud 'solutions' example of using a DaemonSet. The interesting
+ideas introducted here are two:
+
+-  Do the work in an 'init' container that goes away when the work is complete. The long term DaemonSet pod is a simple
+`pause` conatainer with no real worker. Seems pretty good from a security POV.
+
+- Use a standard container and do the customization (entrypoint script) as a `config` record.

--- a/cloud/k8s/deploy/README.md
+++ b/cloud/k8s/deploy/README.md
@@ -1,4 +1,12 @@
-# Kontain Deployment for Kubernetes
+# Kontain Runtime for Kubernetes
+
+This directory tools to install the Kontain runtime on Kubernets clusters. The of installation are
+per-node DeamonSet objects. There are two DaemonSets defined here:
+
+- `k8s-deploy.yaml` - Install the Kontain runtime
+- `kkm-install.yaml` - Install the KKM driver
+
+* THIS IS A WORK IN PROGRESS *
 
 Deployment for Kontain Runtime for Kubernetes. This is modeled on the kata containers deployment, but it is simplified.
 Both containerd and CRIO are supported by this script.

--- a/cloud/k8s/deploy/cm-kkm-install.yaml
+++ b/cloud/k8s/deploy/cm-kkm-install.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 Kontain
+# Derived from:
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kkm-install-entrypoint
+  labels:
+    app: kontain-init
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+
+    set -x
+    set -euo pipefail
+
+    ROOT_MOUNT_DIR="${ROOT_MOUNT_DIR:-/root}"
+
+    echo "Installing dependencies"
+    apt-get update
+    apt-get install -y make gcc git
+
+    # Link to kernel headers on real root disk.
+    KERNEL_VERSION=$(uname -r)
+    mkdir -p /usr/src
+    ln --symbolic "${ROOT_MOUNT_DIR}"/usr/src/linux-headers-"${KERNEL_VERSION}" /usr/src/linux-headers-"${KERNEL_VERSION}"
+    mkdir -p /lib/modules/"${KERNEL_VERSION}"
+    ln --symbolic /usr/src/linux-headers-"${KERNEL_VERSION}" /lib/modules/"${KERNEL_VERSION}"/build
+
+    git clone https://github.com/kontainapp/kkm.git
+    make -C kkm/kkm
+    mv kkm/kkm/kkm.ko "${ROOT_MOUNT_DIR}/kkm.ko"
+
+    # We use chroot to run the following commands in the host root (mounted as the /root volume in the container)
+    chroot "${ROOT_MOUNT_DIR}" insmod kkm.ko

--- a/cloud/k8s/deploy/kkm-install.yaml
+++ b/cloud/k8s/deploy/kkm-install.yaml
@@ -1,0 +1,59 @@
+# Copyright 2021 Kontain
+# Derived from: 
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kkm-node-initializer
+  labels:
+    app: kontain-init
+spec:
+  selector:
+    matchLabels:
+      app: kontain-init
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: kkm-node-initializer
+        app: kontain-init
+    spec:
+      volumes:
+      - name: root-mount
+        hostPath:
+          path: /
+      - name: entrypoint
+        configMap:
+          name: kkm-install-entrypoint
+          defaultMode: 0744
+      initContainers:
+      - image: ubuntu:18.04
+        name: node-initializer
+        command: ["/scripts/entrypoint.sh"]
+        env:
+        - name: ROOT_MOUNT_DIR
+          value: /root
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: root-mount
+          mountPath: /root
+        - name: entrypoint
+          mountPath: /scripts
+      containers:
+      - image: "gcr.io/google-containers/pause:2.0"
+        name: pause


### PR DESCRIPTION
Install KKM as a k8s DaemonSet. This does a build from source and load from an init container in a DaemonSet. The pattern was taken from a Google cloud example (https://github.com/GoogleCloudPlatform/solutions-gke-init-daemonsets-tutorial).

This builds and installs on GKE `ubuntu_containerd` type node.