### PR TITLE
publish busybox runenvs

### DIFF
--- a/payloads/busybox/Makefile
+++ b/payloads/busybox/Makefile
@@ -66,6 +66,8 @@ clean clobber:
 RUNENV_VALIDATE_CMD := ("/bin/sh" "-c" "echo Hello world!")
 RUNENV_VALIDATE_EXPECTED := Hello world
 
+RUNENV_TAG := ${COMPONENT}
+
 export define runenv_prep
 	tar -cf - ${PAYLOAD_FILES} | tar -C $(RUNENV_PATH) -xf -
 endef

--- a/payloads/dynamic-base-large/Makefile
+++ b/payloads/dynamic-base-large/Makefile
@@ -35,6 +35,8 @@ clean clobber:
 RUNENV_VALIDATE_CMD := ("./hello_test" "Hello, World!")
 RUNENV_VALIDATE_EXPECTED := Hello, World
 
+RUNENV_TAG := ${COMPONENT}
+
 export define runenv_prep
 	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}

--- a/payloads/dynamic-base/Makefile
+++ b/payloads/dynamic-base/Makefile
@@ -35,6 +35,8 @@ clean clobber:
 RUNENV_VALIDATE_CMD := ("./hello_test" "Hello, World!")
 RUNENV_VALIDATE_EXPECTED := Hello, World
 
+RUNENV_TAG := ${COMPONENT}
+
 export define runenv_prep
 	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}


### PR DESCRIPTION
Turns out (thanks Sanjay!) busybox runenvs were not published, because we haven't defined `RUNENV_TAG` in Makefiles. This fixes it. As for v0.9.1 - I simply published the images manually. 