### PR TITLE
fixes for snapshot demos

### DIFF
--- a/demo/spring-boot/README.md
+++ b/demo/spring-boot/README.md
@@ -18,7 +18,6 @@ make -j
 make -C payloads/java
 make -C payloads/java runenv-image
 make -C demo/spring-boot
-make -C km_cli install
 ```
 
 This will create docker image called `kontainapp/spring-boot-demo` and make sure km_cli (needed for initiating a snapshot)
@@ -28,7 +27,8 @@ is available in /opt/kontain/bin.
 
 ```bash
 docker run --runtime=krun --name=KM_SpringBoot_Demo --rm -it \
-  -v $(pwd):/mnt:z -p8080:8080 kontainapp/spring-boot-demo /bin/sh
+  -v /opt/kontain/bin/km_cli:/opt/kontain/bin/km_cli \
+  -v $(pwd):/mnt:rw -p8080:8080 kontainapp/spring-boot-demo /bin/sh
 ```
 
 ### Step 3 Measure Base Startup Time

--- a/demo/test-app/.gitignore
+++ b/demo/test-app/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 start_time
+*.whl

--- a/demo/test-app/Dockerfile
+++ b/demo/test-app/Dockerfile
@@ -19,6 +19,7 @@
 # Copy the .whl file from ../../tools/hashicorp/build_tensorflow for Docker to pick it up.
 
 FROM fedora:32 as app
+ARG TF=tensorflow-2.4.1-cp38-cp38-linux_x86_64.whl
 ARG UID=1001
 ARG GID=117
 ARG USERNAME=appuser
@@ -26,9 +27,9 @@ RUN groupadd -f -g $GID $USERNAME && useradd -u $UID -g $GID -d /home/$USERNAME 
 RUN dnf install -y pip
 USER $USERNAME
 WORKDIR /home/$USERNAME
-COPY app.py requirements.txt tensorflow-2.4.1-cp38-cp38-linux_x86_64.whl /home/$USERNAME/
-RUN pip install --user -r requirements.txt tensorflow-2.4.1-cp38-cp38-linux_x86_64.whl
-RUN rm requirements.txt tensorflow-2.4.1-cp38-cp38-linux_x86_64.whl
+COPY app.py requirements.txt ${TF} /home/$USERNAME/
+RUN pip install --user -r requirements.txt ${TF}
+RUN rm requirements.txt ${TF}
 
 FROM kontainapp/runenv-dynamic-python
 ARG UID=1001

--- a/demo/test-app/Makefile
+++ b/demo/test-app/Makefile
@@ -26,6 +26,6 @@ vm: ${BUILD}/${TF}
 container: ${BUILD}/${TF}
 	@-docker rmi -f test-app
 	cp ${BUILD}/${TF} .
-	docker build -t test-app .
+	docker build -t test-app --build-arg TF=${TF} .
 	@rm ${TF}
 	@echo "Run 'docker run --runtime=krun --name test-app --rm -it -p 5000:5000 test-app /bin/sh' to login into container"

--- a/demo/test-app/README.md
+++ b/demo/test-app/README.md
@@ -88,12 +88,13 @@ Make sure km_cli is compiled and in /opt/kontain/bin.
 Run kontainer the same way as above:
 
 ```bash
-docker run --runtime=krun -v $(pwd)/tmp:/mnt:Z --name test-app --rm -it -p 5000:5000 test-app /bin/sh
+docker run --runtime=krun -v /opt/kontain/bin/km_cli:/opt/kontain/bin/km_cli \
+  -v $(pwd)/tmp:/mnt:rw --name test-app --rm -it -p 5000:5000 test-app /bin/sh
 ```
 
 On the host, run
 
-```
+```bash
 ./test.sh
 ```
 
@@ -101,7 +102,7 @@ The script will take care of carefully measuring start time and response time, a
 
 Inside the kontainer, run:
 
-```
+```bash
 /run.sh
 ```
 
@@ -109,18 +110,18 @@ The app will start, and eventually respond to the request.
 
 To take the snapshot:
 
-```
+```bash
 docker exec -it test-app /opt/kontain/bin/km_cli -s /tmp/km.sock
 ```
 
 To show snapshot, run the
 
-```
+```bash
 ./test.sh
 ```
 
 again, and then run:
 
-```
+```bash
 /run_snap.sh
 ```

--- a/tools/hashicorp/build_tensorflow/Makefile
+++ b/tools/hashicorp/build_tensorflow/Makefile
@@ -25,7 +25,7 @@
 TF := tensorflow-2.4.1-cp38-cp38-linux_x86_64.whl
 
 all:
-	vagrant up
+	MEM=$(shell awk -e '/MemTotal:/{printf("%d\n", $$2/1024)}' /proc/meminfo) CPU=$(shell nproc) vagrant up
 	@vagrant ssh-config > ssh-config
 	scp -F ssh-config default:${TF} .
 	@vagrant halt

--- a/tools/hashicorp/build_tensorflow/Vagrantfile
+++ b/tools/hashicorp/build_tensorflow/Vagrantfile
@@ -4,17 +4,20 @@
 # Vagrantfile to build our custon tensorflow. All we need from this is the wheel.
 # After vagrant up --provision the resulting wheel is in /tmp/tensorflow-<version>-<tags>.whl
 
+mem = ENV['MEM'] ? ENV['MEM'] : "31744"
+cpu = ENV['CPU'] ? ENV['CPU'] : "16"
+
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu2004"
+  config.vm.box = "generic/ubuntu2104"
 
   config.vm.provider "libvirt" do |lv|
-    lv.memory = "31744"
-    lv.cpus = "16"
+    lv.memory = mem
+    lv.cpus = cpu
   end
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = "31744"
-    vb.cpus = "16"
+    vb.memory = mem
+    vb.cpus = cpu
   end
 
   config.vm.provision "shell", inline: <<-SHELL
@@ -30,7 +33,7 @@ Vagrant.configure("2") do |config|
     git clone https://github.com/tensorflow/tensorflow.git -b v2.4.1
     cd tensorflow
     ./configure < /dev/null
-    bazel build --jobs=16 --copt=-D_GTHREAD_USE_RECURSIVE_MUTEX_INIT_FUNC=1 //tensorflow/tools/pip_package:build_pip_package
+    bazel build --jobs=#{cpu} --copt=-D_GTHREAD_USE_RECURSIVE_MUTEX_INIT_FUNC=1 //tensorflow/tools/pip_package:build_pip_package
     ./bazel-bin/tensorflow/tools/pip_package/build_pip_package ..
   SHELL
 end


### PR DESCRIPTION
Turns out some steps in snapshot demos were incorrect, fixing that. Springboot should be good now.

However tensorflow is still broken after switch to new version of python (3.9).