### PR TITLE
Assign Kontain runtime install daemonset to 'kube-system' namespace

### DIFF
--- a/cloud/k8s/deploy/cm-containerd-install.yaml
+++ b/cloud/k8s/deploy/cm-containerd-install.yaml
@@ -17,7 +17,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: install-entrypoint
+  name: kontain-install-entrypoint
+  namespace: kube-system
   labels:
     app: kontain-init
 data:

--- a/cloud/k8s/deploy/cm-crio-install.yaml
+++ b/cloud/k8s/deploy/cm-crio-install.yaml
@@ -17,7 +17,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: install-entrypoint
+  name: kontain-install-entrypoint
+  namespace: kube-system
   labels:
     app: kontain-init
 data:

--- a/cloud/k8s/deploy/cm-install-lib.yaml
+++ b/cloud/k8s/deploy/cm-install-lib.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kontain-install-lib
+  namespace: kube-system
   labels:
     app: kontain-init
 data:

--- a/cloud/k8s/deploy/kontain-deploy.yaml
+++ b/cloud/k8s/deploy/kontain-deploy.yaml
@@ -18,6 +18,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kontain-node-initializer
+  namespace: kube-system
   labels:
     app: kontain-init
 spec:
@@ -66,7 +67,7 @@ spec:
           path: /
       - name: entrypoint
         configMap:
-          name: install-entrypoint
+          name: kontain-install-entrypoint
           defaultMode: 0744
       - name: lib-entrypoint
         configMap:


### PR DESCRIPTION
Fixes: #1384