### PR TITLE
Use currently built binaries in minikube tests

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -136,6 +136,17 @@ jobs:
           mkdir /opt/kontain/bin/shim
           cp -r build/cloud/k8s/deploy/shim/* /opt/kontain/bin/shim
 
+      - name: internal release package
+        run: |
+          sudo apt-get update
+          sudo apt-get install makeself
+          make kkm-pkg
+          make release
+          mkdir /tmp/release
+          cp -r build/kontain.tar.gz /tmp/release
+          mkdir /tmp/bin_release
+          cp -r build/kontain_bin.tar.gz /tmp/bin_release
+
       - uses: actions/upload-artifact@v2
         with:
           name: km
@@ -144,6 +155,16 @@ jobs:
             /opt/kontain/bin/krun
             /opt/kontain/bin/shim
           retention-days: 7
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: km_release
+          path: /tmp/release
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: km_bin_release
+          path: /tmp/bin_release
 
   km-test:
     name: KM, payloads, krun tests, KVM on K8S
@@ -388,7 +409,7 @@ jobs:
   minikube-testing:
     name: kubernetes tests aginst minikube
     runs-on: ubuntu-20.04
-    needs: [kkm-build]
+    needs: [km-build, kkm-build]
     strategy:
       matrix:
         # We want to test against containerd and crio. crio support is a bit brittle in
@@ -407,6 +428,18 @@ jobs:
         path: kkm
     - run: chmod a+x kkm/test_kkm/test_kkm
 
+    - uses: actions/download-artifact@v2
+      with:
+        name: km_bin_release
+        path: /tmp/bin_release
+
+    - name: print downloaded artifact
+      run: find /tmp/bin_release
+
+    - name: start local file server
+      run: |
+        (cd /tmp/bin_release; python3 -m http.server 8000) &
+
     - name: Install KKM
       run: sudo insmod kkm/kkm/kkm.ko
 
@@ -414,13 +447,15 @@ jobs:
       run: |
         minikube version
         minikube start --container-runtime=${{ matrix.runtime }} --driver=${{ matrix.driver }} --wait=all || minikube logs
+
     - name: Install Kontain on minikube k8s
       run: |
         kubectl apply -f cloud/k8s/deploy/runtime-class.yaml
         kubectl apply -f cloud/k8s/deploy/cm-install-lib.yaml
         kubectl apply -f cloud/k8s/deploy/cm-containerd-install.yaml
-        kubectl apply -f cloud/k8s/deploy/kontain-deploy.yaml
+        kubectl apply -k cloud/k8s/deploy/kontain-deploy/ci
         sleep 20
+
     - name: Run user test
       run: |
         # start the test pod, which will just sleep

--- a/cloud/k8s/deploy/README.md
+++ b/cloud/k8s/deploy/README.md
@@ -27,7 +27,7 @@ involves:
 - `kubectl apply -f runtime-class.yaml`
 - `kubectl apply -f cm-install-lib-class.yaml`
 - `kubectl apply -f cm-containerd-install.yaml` or `kubectl apply -f cm-crio-install.yaml`
-- `kubectl apply -f kontain-deploy.yaml`
+- `kubectl apply -k kontain-deploy/base`
 
 The plan is to wrap this up inside a single `kontain-install.sh` that is run from the outside (where
 security scope is hopefully not a problem).

--- a/cloud/k8s/deploy/cm-install-lib.yaml
+++ b/cloud/k8s/deploy/cm-install-lib.yaml
@@ -25,10 +25,12 @@ data:
   kontain_install_lib.sh: |
     #!/usr/bin/env bash
 
+    KONTAIN_RELEASE_URL="${KONTAIN_RELEASE_URL:-https://github.com/kontainapp/km/releases/download/v0.1-edge/kontain_bin.tar.gz}"
+
     function install_kontain_artifacts() {
       echo "Install Kontain Runtime Artifacts (KM & KRUN)"
       mkdir /kontain-artifacts
-      curl -L https://github.com/kontainapp/km/releases/download/v0.1-edge/kontain_bin.tar.gz | tar -xzf - -C /kontain-artifacts
+      curl -L "${KONTAIN_RELEASE_URL}" | tar -xzf - -C /kontain-artifacts
       mkdir -p /root/opt/kontain/bin
       cp /kontain-artifacts/km/km /root/opt/kontain/bin/km
       chmod +x /root/opt/kontain/bin/km

--- a/cloud/k8s/deploy/kontain-deploy/base/kontain-deploy.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/base/kontain-deploy.yaml
@@ -40,6 +40,8 @@ spec:
         env:
         - name: ROOT_MOUNT_DIR
           value: /root
+        - name: KONTAIN_RELEASE_URL
+          value: https://github.com/kontainapp/km/releases/download/v0.1-edge/kontain_bin.tar.gz
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/cloud/k8s/deploy/kontain-deploy/base/kustomization.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- kontain-deploy.yaml

--- a/cloud/k8s/deploy/kontain-deploy/ci/kustomization.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/ci/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../base
+patchesStrategicMerge:
+- set_ci_env.yaml

--- a/cloud/k8s/deploy/kontain-deploy/ci/set_ci_env.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/ci/set_ci_env.yaml
@@ -16,6 +16,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kontain-node-initializer
+  namespace: kube-system
 spec:
   template:
     spec:

--- a/cloud/k8s/deploy/kontain-deploy/ci/set_ci_env.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/ci/set_ci_env.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Kontain
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kontain-node-initializer
+spec:
+  template:
+    spec:
+      containers:
+      - name: node-initializer
+        env:
+        - name: KONTAIN_RELEASE_URL
+          value: http://host.minikube.internal:8000/kontain_bin.tar.gz
+


### PR DESCRIPTION
This PR enhances the `km-build` step of the CI pipeline to create the release files (`kontain.tar.gz` and `kontain_bin.tar.gz`) and to save these files as build artifacts that can be used by other steps in the pipeline

The `minikube-testing` step has been changed to download these artifacts and to start a python based HTTP server to make these artifacts available via `curl`.

Finally, a kustonization for the `kontain-deploy.yaml` modifies the release download url to use this local server.
Create release binaries in the pipeline to be consumed by other steps, in particular the minikube based kubernetes tests.

Fixes #1385