### PR TITLE
clone3() and changes in sigaltstack to work with glibc 2.34

### DIFF
--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -72,13 +72,13 @@ make
 file dweb dweb.km
 
 # Run dweb.km as Kontain VM payload, and demo it (test->CPUID)
-~/workspace/km/build/km/km ./dweb.km 8080
+~/workspace/km/build/km/km --vendorid ./dweb.km 8080
 
 # Build Docker container with dweb
 (cd ..; docker build -t dweb . -f dweb-demo.dockerfile)
 
 # Show start time ('-x' to exit from server right away)
-time docker run --rm  dweb  /dweb/dweb -x
+time docker run --rm dweb /dweb/dweb -x
 time ~/workspace/km/build/km/km dweb.km -x
 
 ```

--- a/km/km.h
+++ b/km/km.h
@@ -31,6 +31,7 @@
 #include <sys/param.h>
 #include <sys/types.h>
 #include <linux/kvm.h>
+#include <linux/sched.h>
 
 #include "bsd_queue.h"
 #include "km_elf.h"
@@ -385,6 +386,7 @@ int km_clone(km_vcpu_t* vcpu,
              km_gva_t ptid,
              km_gva_t ctid,
              unsigned long newtls);
+long km_clone3(km_vcpu_t* vcpu, struct clone_args* cl_args);
 uint64_t km_set_tid_address(km_vcpu_t* vcpu, km_gva_t tidptr);
 void km_exit(km_vcpu_t* vcpu);
 

--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -505,6 +505,9 @@ int km_vcpu_clone_to_run(km_vcpu_t* vcpu, km_vcpu_t* new_vcpu)
    new_vcpu->regs = vcpu->regs;
    new_vcpu->regs.rsp = sp;
    *((uint64_t*)km_gva_to_kma_nocheck(sp)) = 0;   // hc return value
+   // syscall trap uses this to restore RDX 
+   *((uint64_t*)km_gva_to_kma_nocheck(sp + 0x18)) =
+       *((uint64_t*)km_gva_to_kma_nocheck(vcpu->regs.rsp + 0x18));
    km_vmdriver_clone(vcpu, new_vcpu);
    new_vcpu->regs_valid = 1;
 

--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -329,6 +329,22 @@ int km_clone(km_vcpu_t* vcpu,
    return km_vcpu_get_tid(new_vcpu);
 }
 
+long km_clone3(km_vcpu_t* vcpu, struct clone_args* cl_args)
+{
+   if (cl_args->set_tid_size != 0 || cl_args->cgroup != 0) {
+      km_warnx("Not supported clone3 args: tid_size, cgroup %llu, %llu",
+               cl_args->set_tid_size,
+               cl_args->cgroup);
+      return -ENOSYS;
+   }
+   return km_clone(vcpu,
+                   cl_args->flags | cl_args->exit_signal,
+                   cl_args->stack + cl_args->stack_size,
+                   cl_args->parent_tid,
+                   cl_args->child_tid,
+                   cl_args->tls);
+}
+
 uint64_t km_set_tid_address(km_vcpu_t* vcpu, km_gva_t tidptr)
 {
    vcpu->clear_child_tid = tidptr;

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -148,6 +148,7 @@ static int wait_for_signal = 0;
 int debug_dump_on_err = 0;   // if 1, will abort() instead of err()
 static char* mgtpipe = NULL;
 static int log_to_fd = -1;
+extern int set_cpu_vendor_id;
 
 struct option km_cmd_long_options[] = {
     {"wait-for-signal", no_argument, &wait_for_signal, 1},
@@ -157,6 +158,7 @@ struct option km_cmd_long_options[] = {
     {"overcommit-memory", no_argument, &(km_machine_init_params.overcommit_memory), KM_FLAG_FORCE_ENABLE},
     {"coredump", required_argument, 0, 'C'},
     {"membus-width", required_argument, 0, 'P'},
+    {"vendorid", no_argument, &set_cpu_vendor_id, KM_FLAG_FORCE_ENABLE},
     {"log-to", required_argument, 0, 'l'},
     {"km-log-to", required_argument, 0, 'k'},
     {"putenv", required_argument, 0, 'e'},
@@ -511,7 +513,7 @@ static char* km_parse_args(
          mgtpipe = strdup(mgt_e);
       }
    }
-   
+
    // Configure payload's env and args
    *envp_p = envp;
    *envc_p = envc;

--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -834,9 +834,6 @@ uint64_t km_sigaltstack(km_vcpu_t* vcpu, km_stack_t* new, km_stack_t* old)
          vcpu->sigaltstack.ss_size = 0;
          vcpu->sigaltstack.ss_sp = NULL;
       } else {
-         if (new->ss_size < MINSIGSTKSZ) {
-            return -ENOMEM;
-         }
          if (km_gva_to_kma((km_gva_t) new->ss_sp) == NULL) {
             return -EFAULT;
          }

--- a/payloads/node/platform:f35_skip
+++ b/payloads/node/platform:f35_skip
@@ -1,0 +1,1 @@
+test/parallel/test-crypto.js

--- a/payloads/node/scripts/test-run.sh
+++ b/payloads/node/scripts/test-run.sh
@@ -29,6 +29,14 @@ EOF
    exit 1
 }
 
+check_crypto() {
+   msg="Unsupported crypto setting for this version of node. Use 'sudo update-crypto-policies --set LEGACY'"
+   source /etc/os-release
+   [[ $PLATFORM_ID == platform:f35 ]] && [[ $(update-crypto-policies --show) == DEFAULT ]] && echo $msg && exit 1
+   return 0
+}
+check_crypto
+
 case "$1" in
   test)
    KM_BIN=$2
@@ -47,7 +55,8 @@ case "$1" in
    NODETOP=$2
    BUILD=$3
 	cd ${NODETOP}
-   /bin/python2.7 tools/test.py -J --mode=`echo -n ${BUILD} | tr '[A-Z]' '[a-z]'` --skip-tests=`cat ../skip_* | tr '\n' ','` default addons js-native-api node-api
+   echo /bin/python2.7 tools/test.py -J --mode=`echo -n ${BUILD} | tr '[A-Z]' '[a-z]'` --skip-tests=`cat ../skip_* ../${PLATFORM_ID}_skip | tr '\n' ','` default addons js-native-api node-api
+   /bin/python2.7 tools/test.py -J --mode=`echo -n ${BUILD} | tr '[A-Z]' '[a-z]'` --skip-tests=`cat ../skip_* ../${PLATFORM_ID}_skip | tr '\n' ','` default addons js-native-api node-api
    echo "Tests are Successful"
   ;;
 

--- a/runtime/clone_km.s
+++ b/runtime/clone_km.s
@@ -35,6 +35,7 @@ __clone:
    mov %rsp, %gs:0
    outl %eax, (%dx)
    mov 0(%rsp), %eax # Get return code into %rax
+   # mov 8(%rsp), %rdx # Restore RDX, although nobody seems to care
    add $56, %rsp
    test %eax,%eax
    jnz 1f         # parent jumps

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,8 +28,8 @@ BUILDENV_PATH = ${BLDDIR}
 include ${TOP}/make/images.mk
 
 # We use coverage version of km to test.
+ifdef TEST_COVERAGE
 TESTENV_EXTRA_FILES := ${COVERAGE_KM_BIN} ${KM_LDSO}
-
 # We need to put both KM_BIN and COVERAGE_KM_BIN into the testenv. Since km
 # binaries have the same name, special care is required. As part of the copy,
 # we rename the coverage km into km.coverage, so we won't have issue with
@@ -43,10 +43,9 @@ override define testenv_prep =
 endef
 
 override define testenv_cleanup =
-	rm ./km
-	rm ./libc.so
-	rm km.coverage
+	rm -f ./km ./libc.so km.coverage
 endef
+endif
 
 # To serialiaze, pass TEST_JOBS=1
 ifneq ($(TEST_JOBS),.)

--- a/tests/hello_2_loops_test.c
+++ b/tests/hello_2_loops_test.c
@@ -116,7 +116,7 @@ TEST nested_threads(void)
    pthread_t pt1, pt2;
    int ret;
    void* status;
-   void* ptr = (void*)0x17;
+   static const void* const ptr = (void*)0x17;
 
    pthread_key_create(&mystr_key_2, free_key);
    pthread_setspecific(mystr_key_2, ptr);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -41,7 +41,7 @@ not_needed_alpine_static='km_main_argv0 km_main_shebang km_main_symlink linux_ex
 todo_alpine_static='dl_iterate_phdr gdb_forkexec'
 
 # glibc native
-not_needed_glibc_static='setup_link setup_load gdb_sharedlib readlink_argv km_identity dlopen exec_sh'
+not_needed_glibc_static='cpuid setup_link setup_load gdb_sharedlib readlink_argv km_identity dlopen exec_sh'
 
 # exception - extra segment in kmcore
 # dl_iterate_phdr - load starts at 4MB instead of 2MB
@@ -50,7 +50,7 @@ not_needed_glibc_static='setup_link setup_load gdb_sharedlib readlink_argv km_id
 # raw_clone - glibc clone() wrapper needs pthread structure
 # gdb_forkexec - gdb stack trace needs symbols when in a hypercall
 
-todo_glibc_static='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test  threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
+todo_glibc_static='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
 
 not_needed_alpine_dynamic=$not_needed_alpine_static
 todo_alpine_dynamic=$todo_alpine_static
@@ -193,7 +193,6 @@ fi
    assert_success
    assert [ -e $log ]
    assert grep -q 'Hello, world' $log       # guest stdout redirected by --log-to
-   assert_output --partial 'Setting VendorId ' $log  # km stderr
    rm $log
    run km_with_timeout -V --log-to=/very/bad/place -- hello_test$ext
    assert_failure
@@ -539,7 +538,7 @@ fi
    assert_line --partial "Thread 6 \"vcpu-5\""
    # TODO: remove the check with glibc_static when stack trace is implemented
    [[ $test_type =~ (alpine|glibc)* ]] || assert_line --partial "in do_nothing_thread (instance"
-   assert_line --partial "Inferior 1 (Remote target) detached"
+   assert_output --partial "Inferior 1 (Remote target) detached"
 
    # 2nd try to test async gdb client attach to the target
    run gdb_with_timeout -q -nx \
@@ -549,7 +548,7 @@ fi
    assert_line --partial "Thread 8 \"vcpu-7\""
    # TODO: remove the check with glibc_static when stack trace is implemented
    [[ $test_type =~ (alpine|glibc)* ]] || assert_line --partial "in do_nothing_thread (instance"
-   assert_line --partial "Inferior 1 (Remote target) detached"
+   assert_output --partial "Inferior 1 (Remote target) detached"
 
    # ok, gdb client attach seems to be working, shut the test program down.
    run gdb_with_timeout -q -nx \
@@ -557,7 +556,7 @@ fi
       --ex="set stop_running=1" \
       --ex="source cmd_for_attach_test.gdb" --ex=q
    assert_success
-   assert_line --partial "Inferior 1 (Remote target) detached"
+   assert_output --partial "Inferior 1 (Remote target) detached"
 
    wait_and_check $pid 0
 
@@ -679,7 +678,7 @@ fi
    if [ "${USE_VIRT}" = 'kkm' ]; then
       cpuidexpected='GenuineIntel'
    fi
-   run km_with_timeout cpuid_test$ext
+   run km_with_timeout --vendorid cpuid_test$ext
    assert_success
    assert_line --partial $cpuidexpected
 }

--- a/tests/sigaltstack_test.c
+++ b/tests/sigaltstack_test.c
@@ -84,7 +84,7 @@ TEST sas_lj()
       perror("sigaction");
       exit(EXIT_FAILURE);
    }
-   sigsetjmp(jbuf, 0);
+   sigsetjmp(jbuf, 1);
    if (greatest_get_verbosity() == 1) {
       printf("about to assign to %p\n", bad);
    }
@@ -167,6 +167,9 @@ TEST sas()
    if (greatest_get_verbosity() == 1) {
       printf("ss_flags = 0x%x\n", lss.ss_flags);
    }
+   free(ss.ss_sp);
+   free(ptr);
+   bad = 0;
    PASS();
 }
 
@@ -175,6 +178,8 @@ GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv)
 {
+   printf("=== %d %d\n", SIGSTKSZ, MINSIGSTKSZ);
+
    GREATEST_MAIN_BEGIN();   // init & parse command-line args
    // greatest_set_verbosity(1);
 

--- a/tests/test-fedora.dockerfile
+++ b/tests/test-fedora.dockerfile
@@ -25,7 +25,7 @@ ENV BRANCH=${branch}
 
 COPY libc.so /opt/kontain/runtime/libc.so
 COPY km /opt/kontain/bin/km
-COPY km.coverage /opt/kontain/coverage/bin/km
+RUN test -f km.coverage && cp km.coverage /opt/kontain/coverage/bin/km || true
 
 ENV KM_TOP=/home/appuser/km
 ENV KM_TEST_TOP=${KM_TOP}/tests

--- a/tests/var_storage_test.cpp
+++ b/tests/var_storage_test.cpp
@@ -34,6 +34,9 @@ using namespace std;
 #include <string.h>
 std::once_flag flag;
 
+// std::thread::join() has pthread_join as weak. Force the linking
+const void* _ = (void*)pthread_join;
+
 void may_throw_function(bool do_throw)
 {
    std::stringstream msg;


### PR DESCRIPTION
Fedora 35 brings in glibc-2.34, which uses clone3() and dynamic stack size. This makes changes to support theses.

Tested manually running tests on Fedora 35. Separate clone3() test isn't implemented s musl has no wrapper for it.

There are still some other failures on Fedora 35 static glibc tests so this is not fully done yet.