### PR TITLE
relax {p}read/write check for zero buf

### DIFF
--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -147,7 +147,7 @@ static km_hc_ret_t prw_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    // ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset);
    // arg->hc_ret = __syscall_4(hc, arg->arg1, km_gva_to_kml(arg->arg2), arg->arg3, arg->arg4);
    void* buf = km_gva_to_kma(arg->arg2);
-   if (buf == NULL) {
+   if (buf == NULL && arg->arg3 != 0) {
       arg->hc_ret = -EFAULT;
       return HC_CONTINUE;
    }


### PR DESCRIPTION
I turns out `write(fd, NULL, 0)` is supposed to succeed and return 0. So out check for the args is too zealous. And yes, node v16 does make such calls.

Regular tests. Also specific test with node v16 now pass. There are more issues there so node isn't ready yet, but I thought this is important on its own.