### PR TITLE
Update release.yaml to include static krun in binary release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,9 +180,9 @@ jobs:
         with:
           name: kontain
           path: |
-            ./build/kontain.tar.gz
-            ./build/kontain_bin.tar.gz
-            ./build/kkm.run
+            ./kontain/kontain.tar.gz
+            ./kontain/kontain_bin.tar.gz
+            ./kontain/kkm.run
           retention-days: 7
 
   km-kkm-smoke-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
           # Create uploadable artifact 'kontain' with 
           mkdir -p /tmp/kontain
           cp /tmp/kontain_dynamic_krun/kontain.tar.gz /tmp/kontain/
-          cp /tmp/kontain_bin/kontain_bin.tar.gz /tmp/kontain/
+          cp /tmp/kontain_bin.tar.gz /tmp/kontain/
           cp /tmp/kontain_dynamic_krun/kkm.run /tmp/kontain/
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,9 +180,9 @@ jobs:
         with:
           name: kontain
           path: |
-            ./kontain/kontain.tar.gz
-            ./kontain/kontain_bin.tar.gz
-            ./kontain/kkm.run
+            /tmp/kontain/kontain.tar.gz
+            /tmp/kontain/kontain_bin.tar.gz
+            /tmp/kontain/kkm.run
           retention-days: 7
 
   km-kkm-smoke-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,27 +162,24 @@ jobs:
           set -x
           find /tmp/kontain
           mkdir -p /tmp/new-km-release-bin
-          tar -C /tmp/new-km-release-bin -xzvf /tmp/kontain/kontain_bin.tar.gz
-#          mkdir /tmp/k8s-release-bin
-#          find /tmp/km
-#          find /tmp/km_submodule_status
-#          find /tmp/krun-static
-#          mkdir -p /tmp/k8s-release-bin/km
-#          cp /tmp/km/km /tmp/k8s-release-bin/km/km
-#          chmod 755 /tmp/k8s-release-bin/km/km
-#          mkdir -p /tmp/k8s-release-bin/container-runtime
-#          cp /tmp/krun-static/krun.static /tmp/k8s-release-bin/container-runtime/krun
-#          chmod 755 /tmp/k8s-release-bin/container-runtime/krun
-#          mkdir -p /tmp/k8s-release-bin/cloud/k8s/deploy/shim
-#          cp /tmp/km/shim/containerd-shim-krun-v2 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
-#          chmod 755 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
-#          cp /tmp/km_submodule_status/km_submodule_status /tmp/k8s-release-bin/km_submodule_status
-#          chmod 444 /tmp/k8s-release-bin/km_submodule_status
-#          tar -C /tmp/k8s-release-bin -czf /tmp/km-k8s-release-artifact.tar.gz .
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          name: km-k8s-rel-artifact
-#          path: /tmp/km-k8s-release-artifact.tar.gz
+          tar -C /tmp/new-km-release-bin -xzf /tmp/kontain/kontain_bin.tar.gz
+          mkdir /tmp/k8s-release-bin
+          mkdir -p /tmp/k8s-release-bin/km
+          cp /tmp/kontain/km /tmp/k8s-release-bin/km/km
+          chmod 755 /tmp/k8s-release-bin/km/km
+          mkdir -p /tmp/k8s-release-bin/container-runtime
+          cp /tmp/krun-static/krun.static /tmp/k8s-release-bin/container-runtime/krun
+          chmod 755 /tmp/k8s-release-bin/container-runtime/krun
+          mkdir -p /tmp/k8s-release-bin/cloud/k8s/deploy/shim
+          cp /tmp/kontain/cloud/k8s/deploy/shim/containerd-shim-krun-v2 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
+          chmod 755 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
+          cp /tmp/km_submodule_status/km_submodule_status /tmp/k8s-release-bin/km_submodule_status
+          chmod 444 /tmp/k8s-release-bin/km_submodule_status
+          tar -C /tmp/k8s-release-bin -czf /tmp/km-k8s-release-artifact.tar.gz .
+      - uses: actions/upload-artifact@v2
+        with:
+          name: km-k8s-rel-artifact
+          path: /tmp/km-k8s-release-artifact.tar.gz
 
   km-kkm-smoke-test:
     name: Smoke test KM/KKM on CI VM

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,19 +163,12 @@ jobs:
           find /tmp/kontain
           mkdir -p /tmp/new-km-release-bin
           tar -C /tmp/new-km-release-bin -xzf /tmp/kontain/kontain_bin.tar.gz
-          mkdir /tmp/k8s-release-bin
-          mkdir -p /tmp/k8s-release-bin/km
-          cp /tmp/kontain/km /tmp/k8s-release-bin/km/km
-          chmod 755 /tmp/k8s-release-bin/km/km
-          mkdir -p /tmp/k8s-release-bin/container-runtime
-          cp /tmp/krun-static/krun.static /tmp/k8s-release-bin/container-runtime/krun
-          chmod 755 /tmp/k8s-release-bin/container-runtime/krun
-          mkdir -p /tmp/k8s-release-bin/cloud/k8s/deploy/shim
-          cp /tmp/kontain/cloud/k8s/deploy/shim/containerd-shim-krun-v2 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
-          chmod 755 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
-          cp /tmp/km_submodule_status/km_submodule_status /tmp/k8s-release-bin/km_submodule_status
-          chmod 444 /tmp/k8s-release-bin/km_submodule_status
-          tar -C /tmp/k8s-release-bin -czf /tmp/km-k8s-release-artifact.tar.gz .
+          cp /tmp/krun-static/krun.static /tmp/new-km-release-bin/container-runtime/krun
+          chmod 755 /tmp/new-km-release-bin/container-runtime/krun
+          cp /tmp/km_submodule_status/km_submodule_status /tmp/new-km-release-bin/km_submodule_status
+          chmod 444 /tmp/new-km-release-bin/km_submodule_status
+          rm -f /tmp/new-km-release-bin/kkm.run
+          tar -C /tmp/new-km-release-bin -czvf /tmp/km-k8s-release-artifact.tar.gz .
       - uses: actions/upload-artifact@v2
         with:
           name: km-k8s-rel-artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,6 +98,92 @@ jobs:
             ./build/kkm.run
           retention-days: 7
 
+      - name: capture submodules
+        run: git submodule status > /tmp/km_submodule_status
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: km_submodule_status
+          path: /tmp/km_submodule_status
+          retention-days: 7
+
+
+  # Builds a static linked, stripped binary for krun/crun
+  # This uses the NIX virtual machine, just like the crun CI.
+  # NIX takes a long time, so we build the static krun binary in
+  # parallel with the rest of KM build and test. We just the
+  krun-static-build:
+    name: Build static KRUN binary
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - uses: actions/cache@v2
+        with:
+          path: .cache
+          key: nix-v1-${{ hashFiles('container-runtime/crun/nix/nixpkgs.json') }}
+
+      - run: |
+          set -x
+          CRUN_DIR=$(pwd)/container-runtime/crun
+          # These next two lines were taken from the crun release.yaml and build-aux/release.sh
+          # to setup and execute a nix based build of stripped static
+          if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
+          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix nix build --print-build-logs --file nix/ --arg enableSystemd false
+          mkdir -p /tmp/krun-static
+          cp ${CRUN_DIR}/result/bin/crun /tmp/krun-static/krun.static
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: krun-static
+          path: /tmp/krun-static
+          retention-days: 7
+
+  k8s-release-bin:
+    name: make k8s release bundle
+    runs-on: ubuntu-20.04
+    needs: [km-kkm-build, krun-static-build]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: kontain
+          path: /tmp/kontain
+      - uses: actions/download-artifact@v2
+        with:
+          name: km_submodule_status
+          path: /tmp/km_submodule_status
+      - uses: actions/download-artifact@v2
+        with:
+          name: krun-static
+          path: /tmp/krun-static
+      - run: |
+          set -x
+          find /tmp/kontain
+          mkdir -p /tmp/new-km-release-bin
+          tar -C /tmp/new-km-release-bin -xzvf /tmp/kontain/kontain_bin.tar.gz
+#          mkdir /tmp/k8s-release-bin
+#          find /tmp/km
+#          find /tmp/km_submodule_status
+#          find /tmp/krun-static
+#          mkdir -p /tmp/k8s-release-bin/km
+#          cp /tmp/km/km /tmp/k8s-release-bin/km/km
+#          chmod 755 /tmp/k8s-release-bin/km/km
+#          mkdir -p /tmp/k8s-release-bin/container-runtime
+#          cp /tmp/krun-static/krun.static /tmp/k8s-release-bin/container-runtime/krun
+#          chmod 755 /tmp/k8s-release-bin/container-runtime/krun
+#          mkdir -p /tmp/k8s-release-bin/cloud/k8s/deploy/shim
+#          cp /tmp/km/shim/containerd-shim-krun-v2 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
+#          chmod 755 /tmp/k8s-release-bin/cloud/k8s/deploy/shim/containerd-shim-krun-v2
+#          cp /tmp/km_submodule_status/km_submodule_status /tmp/k8s-release-bin/km_submodule_status
+#          chmod 444 /tmp/k8s-release-bin/km_submodule_status
+#          tar -C /tmp/k8s-release-bin -czf /tmp/km-k8s-release-artifact.tar.gz .
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          name: km-k8s-rel-artifact
+#          path: /tmp/km-k8s-release-artifact.tar.gz
+
   km-kkm-smoke-test:
     name: Smoke test KM/KKM on CI VM
     runs-on: ubuntu-20.04
@@ -225,7 +311,7 @@ jobs:
     if: (failure() && github.ref == 'refs/heads/master') ||
       contains(github.workflow, 'noisy')
     # Dependencies. (A skipped dependency is considered satisfied)
-    needs: [ km-kkm-build, km-kkm-smoke-test, km-boxes, km-ami, km-runenv, km-release ]
+    needs: [ km-kkm-build, krun-static-build, km-kkm-smoke-test, km-boxes, km-ami, km-runenv, km-release ]
     steps:
       - name: Send notification to slack
         uses: Gamesight/slack-workflow-status@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,7 +188,7 @@ jobs:
   km-kkm-smoke-test:
     name: Smoke test KM/KKM on CI VM
     runs-on: ubuntu-20.04
-    needs: [ km-kkm-build ]
+    needs: [ km-kkm-build, k8s-release-bin ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: kontain
+          name: kontain_dynamic_krun
           path: |
             ./build/kontain.tar.gz
             ./build/kontain_bin.tar.gz
@@ -148,8 +148,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: kontain
-          path: /tmp/kontain
+          name: kontain_dynamic_krun
+          path: /tmp/kontain_dynamic_krun
       - uses: actions/download-artifact@v2
         with:
           name: km_submodule_status
@@ -160,19 +160,30 @@ jobs:
           path: /tmp/krun-static
       - run: |
           set -x
-          find /tmp/kontain
-          mkdir -p /tmp/new-km-release-bin
-          tar -C /tmp/new-km-release-bin -xzf /tmp/kontain/kontain_bin.tar.gz
-          cp /tmp/krun-static/krun.static /tmp/new-km-release-bin/container-runtime/krun
-          chmod 755 /tmp/new-km-release-bin/container-runtime/krun
-          cp /tmp/km_submodule_status/km_submodule_status /tmp/new-km-release-bin/km_submodule_status
-          chmod 444 /tmp/new-km-release-bin/km_submodule_status
-          rm -f /tmp/new-km-release-bin/kkm.run
-          tar -C /tmp/new-km-release-bin -czvf /tmp/km-k8s-release-artifact.tar.gz .
+          #
+          # create kontain_bin with static krun by patching up old format
+          mkdir -p /tmp/kontain_bin
+          tar -C /tmp/kontain_bin -xzf /tmp/kontain_dynamic_krun/kontain_bin.tar.gz
+          cp /tmp/krun-static/krun.static /tmp/kontain_bin/container-runtime/krun
+          chmod 755 /tmp/kontain_bin/container-runtime/krun
+          cp /tmp/km_submodule_status/km_submodule_status /tmp/kontain_bin/km_submodule_status
+          chmod 444 /tmp/kontain_bin/km_submodule_status
+          rm -f /tmp/kontain_bin/kkm.run
+          tar -C /tmp/kontain_bin -czvf /tmp/kontain_bin.tar.gz .
+          #
+          # Create uploadable artifact 'kontain' with 
+          mkdir -p /tmp/kontain
+          cp /tmp/kontain_dynamic_krun/kontain.tar.gz /tmp/kontain/
+          cp /tmp/kontain_bin/kontain_bin.tar.gz /tmp/kontain/
+          cp /tmp/kontain_dynamic_krun/kkm.run /tmp/kontain/
       - uses: actions/upload-artifact@v2
         with:
-          name: km-k8s-rel-artifact
-          path: /tmp/km-k8s-release-artifact.tar.gz
+          name: kontain
+          path: |
+            ./build/kontain.tar.gz
+            ./build/kontain_bin.tar.gz
+            ./build/kkm.run
+          retention-days: 7
 
   km-kkm-smoke-test:
     name: Smoke test KM/KKM on CI VM


### PR DESCRIPTION
Static krun in binary release (only). Messy. Different logic than workflow yaml. Will open an issue to align this and workflow yaml later, but this is needed to move k8s effort forward.