### PR TITLE
Update kontain-deploy.yaml to use v0.9.2 release bits

### DIFF
--- a/cloud/k8s/deploy/kontain-deploy/base/kontain-deploy.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/base/kontain-deploy.yaml
@@ -41,7 +41,7 @@ spec:
         - name: ROOT_MOUNT_DIR
           value: /root
         - name: KONTAIN_RELEASE_URL
-          value: https://github.com/kontainapp/km/releases/download/v0.1-edge/kontain_bin.tar.gz
+          value: https://github.com/kontainapp/km/releases/download/v0.9.2/kontain_bin.tar.gz
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
v0.1-edge didn't get built, and I'm not sure how much sense that makes. Make KM use the v0.9.2 release bits by default. This picks up the static KRUN bits we need for k8s installs.