### PR TITLE
Fix 'nixos/nix' container version to fix CI failures in nix calls

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -177,7 +177,7 @@ jobs:
           # These next two lines were taken from the crun release.yaml and build-aux/release.sh
           # to setup and execute a nix based build of stripped static
           if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
-          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix nix build --print-build-logs --file nix/ --arg enableSystemd false
+          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix nix build --print-build-logs --file nix/ --arg enableSystemd false --extra-experimental-features nix-command
           mkdir -p /tmp/krun-static
           cp ${CRUN_DIR}/result/bin/crun /tmp/krun-static/krun.static
 

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -176,8 +176,8 @@ jobs:
           CRUN_DIR=$(pwd)/container-runtime/crun
           # These next two lines were taken from the crun release.yaml and build-aux/release.sh
           # to setup and execute a nix based build of stripped static
-          if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
-          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix nix build --print-build-logs --file nix/ --arg enableSystemd false --extra-experimental-features nix-command
+          if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix:2.3.12 cp -rfT /nix /mnt/nix; fi
+          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix:2.3.12 nix build --print-build-logs --file nix/ --arg enableSystemd false
           mkdir -p /tmp/krun-static
           cp ${CRUN_DIR}/result/bin/crun /tmp/krun-static/krun.static
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,7 +131,7 @@ jobs:
           # These next two lines were taken from the crun release.yaml and build-aux/release.sh
           # to setup and execute a nix based build of stripped static
           if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
-          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix nix build --print-build-logs --file nix/ --arg enableSystemd false
+          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix nix build --print-build-logs --file nix/ --arg enableSystemd false --extra-experimental-features nix-command
           mkdir -p /tmp/krun-static
           cp ${CRUN_DIR}/result/bin/crun /tmp/krun-static/krun.static
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,8 +130,8 @@ jobs:
           CRUN_DIR=$(pwd)/container-runtime/crun
           # These next two lines were taken from the crun release.yaml and build-aux/release.sh
           # to setup and execute a nix based build of stripped static
-          if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
-          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix nix build --print-build-logs --file nix/ --arg enableSystemd false --extra-experimental-features nix-command
+          if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix:2.3.12 cp -rfT /nix /mnt/nix; fi
+          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix:2.3.12 nix build --print-build-logs --file nix/ --arg enableSystemd false
           mkdir -p /tmp/krun-static
           cp ${CRUN_DIR}/result/bin/crun /tmp/krun-static/krun.static
 


### PR DESCRIPTION
The container `nixos/nix:latest` was upgraded from 2.3.12 to 2.5.0 on 12/14/20211 and our CI step 'krun-static-build` promptly broke. So did upstream. There are two possible ways to fix this:
* add `--extra-experimental-features nix-command` to nix invocations in `km-ci-workflow.yaml` and `release.yaml`.
* fix the `nixos/nix` container version to the last working version.
Upstream CRUN choose door number 2, fix the container version to the last working verson (2.3.12) so that's what we'll do.
 
Fixes #1430 