### PR TITLE
run 'clang-format -i' on km and tests directories

### DIFF
--- a/km/gdb_kvm_x86_64.c
+++ b/km/gdb_kvm_x86_64.c
@@ -77,7 +77,7 @@ static struct breakpoints_head hw_breakpoints;
  */
 #define MAX_HW_BREAKPOINTS 4   // DR7 has space for 4 breakpoints
 #define DR dbg.arch.debugreg   // generic debug register
-#define DR7 DR[7]              // debug control register
+#define DR7 DR[7]   // debug control register
 
 static uint32_t nr_hw_breakpoints = 0;
 
@@ -657,7 +657,7 @@ int km_gdb_remove_breakpoint(gdb_breakpoint_type_t type, km_gva_t addr, size_t l
       return -1;
    }
    if (skip_hw_update != 0) {
-     return 0;
+      return 0;
    }
    return km_gdb_update_guest_debug();
 }

--- a/km/km.h
+++ b/km/km.h
@@ -491,7 +491,7 @@ void km_trace_setup(int argc, char* argv[], char* payload_name);
 
 extern int km_collect_hc_stats;
 
-#define km_trace_enabled() (km_info_trace.level != KM_TRACE_NONE)      // 1 for yes, 0 for no
+#define km_trace_enabled() (km_info_trace.level != KM_TRACE_NONE)   // 1 for yes, 0 for no
 #define km_trace_enabled_tag() (km_info_trace.level == KM_TRACE_TAG)   // 1 for yes, 0 for no
 
 #define km_trace_tag_enabled(tag)                                                                  \

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -88,8 +88,8 @@ typedef struct km_nt_vcpu {
 /*
  * fp_format values for km_nt_vcpu
  */
-#define NT_KM_VCPU_FPDATA_NONE 0      /* No fp data follows */
-#define NT_KM_VCPU_FPDATA_KVM_FPU 1   /* KVM_GET_FPU follows*/
+#define NT_KM_VCPU_FPDATA_NONE 0 /* No fp data follows */
+#define NT_KM_VCPU_FPDATA_KVM_FPU 1 /* KVM_GET_FPU follows*/
 #define NT_KM_VCPU_FPDATA_KVM_XSAVE 2 /* KVM_GET_XSAVE follows*/
 #define NT_KM_VCPU_FPDATA_KKM_XSAVE 3 /* KKM_GET_XSAVE follows*/
 
@@ -103,7 +103,7 @@ typedef struct km_nt_guest {
    Elf64_Ehdr ehdr;
    // Followed by PHDR list and filename
 } km_nt_guest_t;
-#define NT_KM_GUEST 0x4b4d4754       // "KMGT" no null term
+#define NT_KM_GUEST 0x4b4d4754   // "KMGT" no null term
 #define NT_KM_DYNLINKER 0x4b4d444c   // "KMDL" no null term
 
 /*

--- a/km/km_exec_fd_save_recover.c
+++ b/km/km_exec_fd_save_recover.c
@@ -224,14 +224,14 @@ char* km_exec_save_fd(char* varname)
          TAILQ_FOREACH (event, &file->events, link) {
             char* tmp;
             if (asprintf(&tmp,
-                     "%s,{%d,%x,%lx}%s",
-                     more_env_value,
-                     event->fd,
-                     event->event.events,
-                     event->event.data.u64,
-                     event == TAILQ_LAST(&file->events, km_fs_event_head) ? "}" : "") == -1 ) {
-                        km_warn("failed save info for %s eventfd %d", file->name, event->fd);
-                     }
+                         "%s,{%d,%x,%lx}%s",
+                         more_env_value,
+                         event->fd,
+                         event->event.events,
+                         event->event.data.u64,
+                         event == TAILQ_LAST(&file->events, km_fs_event_head) ? "}" : "") == -1) {
+               km_warn("failed save info for %s eventfd %d", file->name, event->fd);
+            }
             free(more_env_value);
             more_env_value = tmp;
          }
@@ -242,41 +242,48 @@ char* km_exec_save_fd(char* varname)
             return NULL;
          }
          if (S_ISFIFO(st.st_mode)) {
-            if (asprintf(&more_env_value, "{%x,%d,%d,%x,%d}", KM_FDTYPE_PIPE, i, file->how, file->flags, file->ofd) == -1) {
+            if (asprintf(&more_env_value,
+                         "{%x,%d,%d,%x,%d}",
+                         KM_FDTYPE_PIPE,
+                         i,
+                         file->how,
+                         file->flags,
+                         file->ofd) == -1) {
                km_warn("failed save info for %s FIFO", file->name);
             }
          } else {
             km_file_ops_t* ops;
             km_fs_g2h_fd(i, &ops);
             if (asprintf(&more_env_value,
-                     "{%x,%d,%d,%x,%d}",
-                     KM_FDTYPE_FILE,
-                     i,
-                     file->how,
-                     file->flags,
-                     km_filename_table_line(ops)) == -1) {
-                        km_warn("failed save info for non-socket %s", file->name);
-                     }
+                         "{%x,%d,%d,%x,%d}",
+                         KM_FDTYPE_FILE,
+                         i,
+                         file->how,
+                         file->flags,
+                         km_filename_table_line(ops)) == -1) {
+               km_warn("failed save info for non-socket %s", file->name);
+            }
          }
       } else if (file->how == KM_FILE_HOW_SOCKETPAIR0 ||
                  file->how == KM_FILE_HOW_SOCKETPAIR1) {   // socketpair
-         if(asprintf(&more_env_value, "{%d,%d,%d,%d}", KM_FDTYPE_SOCKETPAIR, i, file->how, file->ofd) == -1) {
+         if (asprintf(&more_env_value, "{%d,%d,%d,%d}", KM_FDTYPE_SOCKETPAIR, i, file->how, file->ofd) ==
+             -1) {
             km_warn("failed save info for socket pair %d %d", file->how, file->ofd);
          }
       } else {   // socket fd
          char asciihex[257];
          km_bin2hex((unsigned char*)file->sockinfo->addr, file->sockinfo->addrlen, asciihex);
          if (asprintf(&more_env_value,
-                  "{%x,%d,%d,%d,%d,%d,%s}",
-                  KM_FDTYPE_SOCKET,
-                  i,
-                  file->how,
-                  file->sockinfo->state,
-                  file->sockinfo->backlog,
-                  file->ofd,
-                  asciihex) == -1) {
-                     km_warn("failed save info for socket %s", file->name);
-                  }
+                      "{%x,%d,%d,%d,%d,%d,%s}",
+                      KM_FDTYPE_SOCKET,
+                      i,
+                      file->how,
+                      file->sockinfo->state,
+                      file->sockinfo->backlog,
+                      file->ofd,
+                      asciihex) == -1) {
+            km_warn("failed save info for socket %s", file->name);
+         }
       }
 
       // Paste info for this fd onto the end of what we have already accumulated.

--- a/km/km_exec_fd_save_recover.h
+++ b/km/km_exec_fd_save_recover.h
@@ -21,4 +21,4 @@ char* km_exec_save_fd(char* varname);
 int km_exec_restore_fd(char* env_value);
 void km_exec_fdtrace(char* tag, int fd);
 
-#endif // !defined(__KM_EXEC_FD_SAVE_RECOVER_H__)
+#endif   // !defined(__KM_EXEC_FD_SAVE_RECOVER_H__)

--- a/km/km_filesys_private.h
+++ b/km/km_filesys_private.h
@@ -17,8 +17,8 @@
 #define __KM_FILESYS_PRIVATE_H__
 
 /*
- * Definitions of km_filesys.c private structures that have been exposed because km_filesys.c is getting
- * big and we need to split out functionality to another file.
+ * Definitions of km_filesys.c private structures that have been exposed because km_filesys.c is
+ * getting big and we need to split out functionality to another file.
  */
 
 // Each km_file_t has an optional point to socket state described by this structure.
@@ -30,7 +30,7 @@ typedef struct km_fd_socket {
    int protocol;
    // currently all linux sockaddr variations fit in 128 bytes
    int addrlen;
-   char addr[128];          // the local address passed to bind()
+   char addr[128];   // the local address passed to bind()
 } km_fd_socket_t;
 
 // Valid values for the state field in km_fd_socket_t
@@ -56,14 +56,14 @@ typedef struct km_file {
    km_file_ops_t* ops;   // Overwritten file ops for file matched at open
    int ofd;              // 'other' fd (pipe and socketpair)
    char* name;           // the name opened to yield the guest fd
-   km_fd_socket_t* sockinfo;           // For sockets
+   km_fd_socket_t* sockinfo;                           // For sockets
    TAILQ_HEAD(km_fs_event_head, km_fs_event) events;   // for epoll_create fd's
 } km_file_t;
 
 // Valid values for the how field in km_file_t
-#define KM_FILE_HOW_OPEN 0    /* Regular open */
-#define KM_FILE_HOW_PIPE_0 1  /* read half of pipe */
-#define KM_FILE_HOW_PIPE_1 2  /* write half of pipe */
+#define KM_FILE_HOW_OPEN 0 /* Regular open */
+#define KM_FILE_HOW_PIPE_0 1 /* read half of pipe */
+#define KM_FILE_HOW_PIPE_1 2 /* write half of pipe */
 #define KM_FILE_HOW_EPOLLFD 3 /* epoll_create() */
 #define KM_FILE_HOW_SOCKET 4
 #define KM_FILE_HOW_ACCEPT 5
@@ -87,4 +87,4 @@ static inline km_filesys_t* km_fs()
    return machine.filesys;
 }
 
-#endif    // !defined(__KM_FILESYS_PRIVATE_H__)
+#endif   // !defined(__KM_FILESYS_PRIVATE_H__)

--- a/km/km_fork.c
+++ b/km/km_fork.c
@@ -376,7 +376,7 @@ int km_dofork(int* in_child)
       km_infox(KM_TRACE_FORK,
                "parent: after fork/clone linux_child_pid %d, errno %d",
                linux_child_pid,
-               linux_child_pid < 0 ? errno: 0);
+               linux_child_pid < 0 ? errno : 0);
       km_fork_state.fork_in_progress = 0;
       km_cond_signal(&km_fork_state.cond);
       km_mutex_unlock(&km_fork_state.mutex);

--- a/km/km_gdb.h
+++ b/km/km_gdb.h
@@ -54,40 +54,40 @@ typedef enum {
  * You know what happens when gdb changes these values!
  */
 typedef enum {
-   GDB_SIGNAL_HUP = 1,       // SIGHUP
-   GDB_SIGNAL_INT = 2,       // SIGINT
-   GDB_SIGNAL_QUIT = 3,      // SIGQUIT
-   GDB_SIGNAL_ILL = 4,       // SIGILL
-   GDB_SIGNAL_TRAP = 5,      // SIGTRAP
-   GDB_SIGNAL_ABRT = 6,      // SIGABRT
-   GDB_SIGNAL_EMT = 7,       // SIGEMT
-   GDB_SIGNAL_FPE = 8,       // SIGFPE
-   GDB_SIGNAL_KILL = 9,      // SIGKILL
-   GDB_SIGNAL_BUS = 10,      // SIGBUS
-   GDB_SIGNAL_SEGV = 11,     // SIGSEGV
-   GDB_SIGNAL_SYS = 12,      // SIGSYS
-   GDB_SIGNAL_PIPE = 13,     // SIGPIPE
-   GDB_SIGNAL_ALRM = 14,     // SIGALRM
-   GDB_SIGNAL_TERM = 15,     // SIGTERM
-   GDB_SIGNAL_URG = 16,      // SIGURG
-   GDB_SIGNAL_STOP = 17,     // SIGSTOP
-   GDB_SIGNAL_TSTP = 18,     // SIGTSTP
-   GDB_SIGNAL_CONT = 19,     // SIGCONT
-   GDB_SIGNAL_CHLD = 20,     // SIGCHLD
-   GDB_SIGNAL_TTIN = 21,     // SIGTTIN
-   GDB_SIGNAL_TTOU = 22,     // SIGTTOU
-   GDB_SIGNAL_IO = 23,       // SIGIO
-   GDB_SIGNAL_XCPU = 24,     // SIGXCPU
-   GDB_SIGNAL_XFSZ = 25,     // SIGXFSZ
-   GDB_SIGNAL_VTALRM = 26,   // SIGVTALRM
-   GDB_SIGNAL_PROF = 27,     // SIGPROF
-   GDB_SIGNAL_WINCH = 28,    // SIGWINCH
-   GDB_SIGNAL_LOST = 29,     // SIGLOST
-   GDB_SIGNAL_USR1 = 30,     // SIGUSR1
-   GDB_SIGNAL_USR2 = 31,     // SIGUSR2
-   GDB_SIGNAL_PWR = 32,      // SIGPWR
-   GDB_SIGNAL_POLL = 33,     // SIGPOLL
-   GDB_SIGNAL_WIND = 34,         // SIGWIND not available on linux
+   GDB_SIGNAL_HUP = 1,            // SIGHUP
+   GDB_SIGNAL_INT = 2,            // SIGINT
+   GDB_SIGNAL_QUIT = 3,           // SIGQUIT
+   GDB_SIGNAL_ILL = 4,            // SIGILL
+   GDB_SIGNAL_TRAP = 5,           // SIGTRAP
+   GDB_SIGNAL_ABRT = 6,           // SIGABRT
+   GDB_SIGNAL_EMT = 7,            // SIGEMT
+   GDB_SIGNAL_FPE = 8,            // SIGFPE
+   GDB_SIGNAL_KILL = 9,           // SIGKILL
+   GDB_SIGNAL_BUS = 10,           // SIGBUS
+   GDB_SIGNAL_SEGV = 11,          // SIGSEGV
+   GDB_SIGNAL_SYS = 12,           // SIGSYS
+   GDB_SIGNAL_PIPE = 13,          // SIGPIPE
+   GDB_SIGNAL_ALRM = 14,          // SIGALRM
+   GDB_SIGNAL_TERM = 15,          // SIGTERM
+   GDB_SIGNAL_URG = 16,           // SIGURG
+   GDB_SIGNAL_STOP = 17,          // SIGSTOP
+   GDB_SIGNAL_TSTP = 18,          // SIGTSTP
+   GDB_SIGNAL_CONT = 19,          // SIGCONT
+   GDB_SIGNAL_CHLD = 20,          // SIGCHLD
+   GDB_SIGNAL_TTIN = 21,          // SIGTTIN
+   GDB_SIGNAL_TTOU = 22,          // SIGTTOU
+   GDB_SIGNAL_IO = 23,            // SIGIO
+   GDB_SIGNAL_XCPU = 24,          // SIGXCPU
+   GDB_SIGNAL_XFSZ = 25,          // SIGXFSZ
+   GDB_SIGNAL_VTALRM = 26,        // SIGVTALRM
+   GDB_SIGNAL_PROF = 27,          // SIGPROF
+   GDB_SIGNAL_WINCH = 28,         // SIGWINCH
+   GDB_SIGNAL_LOST = 29,          // SIGLOST
+   GDB_SIGNAL_USR1 = 30,          // SIGUSR1
+   GDB_SIGNAL_USR2 = 31,          // SIGUSR2
+   GDB_SIGNAL_PWR = 32,           // SIGPWR
+   GDB_SIGNAL_POLL = 33,          // SIGPOLL
+   GDB_SIGNAL_WIND = 34,          // SIGWIND not available on linux
    GDB_SIGNAL_PHONE = 35,         // SIGPHONE not available on linux
    GDB_SIGNAL_WAITING = 36,       // SIGWAITING not available on linux
    GDB_SIGNAL_LWP = 37,           // SIGLWP not available on linux
@@ -130,90 +130,90 @@ typedef enum {
    GDB_SIGNAL_REALTIME_62 = 74,   // "SIG62", "Real-time event 62"
    GDB_SIGNAL_REALTIME_63 = 75,   // "SIG63", "Real-time event 63"
 
-   GDB_SIGNAL_CANCEL = 76,        // SIGCANCEL musl signal
+   GDB_SIGNAL_CANCEL = 76,   // SIGCANCEL musl signal
 
-   GDB_SIGNAL_REALTIME_32 = 77,   // SIG32, "Real-time event 32"
-   GDB_SIGNAL_REALTIME_64 = 78,   // "SIG64", "Real-time event 64"
-   GDB_SIGNAL_REALTIME_65 = 79,   // "SIG65", "Real-time event 65"
-   GDB_SIGNAL_REALTIME_66 = 80,   // "SIG66", "Real-time event 66"
-   GDB_SIGNAL_REALTIME_67 = 81,   // "SIG67", "Real-time event 67"
-   GDB_SIGNAL_REALTIME_68 = 82,   // "SIG68", "Real-time event 68"
-   GDB_SIGNAL_REALTIME_69 = 83,   // "SIG69", "Real-time event 69"
-   GDB_SIGNAL_REALTIME_70 = 84,   // "SIG70", "Real-time event 70"
-   GDB_SIGNAL_REALTIME_71 = 85,   // "SIG71", "Real-time event 71"
-   GDB_SIGNAL_REALTIME_72 = 86,   // "SIG72", "Real-time event 72"
-   GDB_SIGNAL_REALTIME_73 = 87,   // "SIG73", "Real-time event 73"
-   GDB_SIGNAL_REALTIME_74 = 88,   // "SIG74", "Real-time event 74"
-   GDB_SIGNAL_REALTIME_75 = 89,   // "SIG75", "Real-time event 75"
-   GDB_SIGNAL_REALTIME_76 = 90,   // "SIG76", "Real-time event 76"
-   GDB_SIGNAL_REALTIME_77 = 91,   // "SIG77", "Real-time event 77"
-   GDB_SIGNAL_REALTIME_78 = 92,   // "SIG78", "Real-time event 78"
-   GDB_SIGNAL_REALTIME_79 = 93,   // "SIG79", "Real-time event 79"
-   GDB_SIGNAL_REALTIME_80 = 94,   // "SIG80", "Real-time event 80"
-   GDB_SIGNAL_REALTIME_81 = 95,   // "SIG81", "Real-time event 81"
-   GDB_SIGNAL_REALTIME_82 = 96,   // "SIG82", "Real-time event 82"
-   GDB_SIGNAL_REALTIME_83 = 97,   // "SIG83", "Real-time event 83"
-   GDB_SIGNAL_REALTIME_84 = 98,   // "SIG84", "Real-time event 84"
-   GDB_SIGNAL_REALTIME_85 = 99,   // "SIG85", "Real-time event 85"
-   GDB_SIGNAL_REALTIME_86 = 100,  // "SIG86", "Real-time event 86"
-   GDB_SIGNAL_REALTIME_87 = 101,  // "SIG87", "Real-time event 87"
-   GDB_SIGNAL_REALTIME_88 = 102,  // "SIG88", "Real-time event 88"
-   GDB_SIGNAL_REALTIME_89 = 103,  // "SIG89", "Real-time event 89"
-   GDB_SIGNAL_REALTIME_90 = 104,  // "SIG90", "Real-time event 90"
-   GDB_SIGNAL_REALTIME_91 = 105,  // "SIG91", "Real-time event 91"
-   GDB_SIGNAL_REALTIME_92 = 106,  // "SIG92", "Real-time event 92"
-   GDB_SIGNAL_REALTIME_93 = 107,  // "SIG93", "Real-time event 93"
-   GDB_SIGNAL_REALTIME_94 = 108,  // "SIG94", "Real-time event 94"
-   GDB_SIGNAL_REALTIME_95 = 109,  // "SIG95", "Real-time event 95"
-   GDB_SIGNAL_REALTIME_96 = 110,  // "SIG96", "Real-time event 96"
-   GDB_SIGNAL_REALTIME_97 = 111,  // "SIG97", "Real-time event 97"
-   GDB_SIGNAL_REALTIME_98 = 112,  // "SIG98", "Real-time event 98"
-   GDB_SIGNAL_REALTIME_99 = 113,  // "SIG99", "Real-time event 99"
-   GDB_SIGNAL_REALTIME_100 = 114, // "SIG100", "Real-time event 100"
-   GDB_SIGNAL_REALTIME_101 = 115, // "SIG101", "Real-time event 101"
-   GDB_SIGNAL_REALTIME_102 = 116, // "SIG102", "Real-time event 102"
-   GDB_SIGNAL_REALTIME_103 = 117, // "SIG103", "Real-time event 103"
-   GDB_SIGNAL_REALTIME_104 = 118, // "SIG104", "Real-time event 104"
-   GDB_SIGNAL_REALTIME_105 = 119, // "SIG105", "Real-time event 105"
-   GDB_SIGNAL_REALTIME_106 = 120, // "SIG106", "Real-time event 106"
-   GDB_SIGNAL_REALTIME_107 = 121, // "SIG107", "Real-time event 107"
-   GDB_SIGNAL_REALTIME_108 = 122, // "SIG108", "Real-time event 108"
-   GDB_SIGNAL_REALTIME_109 = 123, // "SIG109", "Real-time event 109"
-   GDB_SIGNAL_REALTIME_110 = 124, // "SIG110", "Real-time event 110"
-   GDB_SIGNAL_REALTIME_111 = 125, // "SIG111", "Real-time event 111"
-   GDB_SIGNAL_REALTIME_112 = 126, // "SIG112", "Real-time event 112"
-   GDB_SIGNAL_REALTIME_113 = 127, // "SIG113", "Real-time event 113"
-   GDB_SIGNAL_REALTIME_114 = 128, // "SIG114", "Real-time event 114"
-   GDB_SIGNAL_REALTIME_115 = 129, // "SIG115", "Real-time event 115"
-   GDB_SIGNAL_REALTIME_116 = 130, // "SIG116", "Real-time event 116"
-   GDB_SIGNAL_REALTIME_117 = 131, // "SIG117", "Real-time event 117"
-   GDB_SIGNAL_REALTIME_118 = 132, // "SIG118", "Real-time event 118"
-   GDB_SIGNAL_REALTIME_119 = 133, // "SIG119", "Real-time event 119"
-   GDB_SIGNAL_REALTIME_120 = 134, // "SIG120", "Real-time event 120"
-   GDB_SIGNAL_REALTIME_121 = 135, // "SIG121", "Real-time event 121"
-   GDB_SIGNAL_REALTIME_122 = 136, // "SIG122", "Real-time event 122"
-   GDB_SIGNAL_REALTIME_123 = 137, // "SIG123", "Real-time event 123"
-   GDB_SIGNAL_REALTIME_124 = 138, // "SIG124", "Real-time event 124"
-   GDB_SIGNAL_REALTIME_125 = 139, // "SIG125", "Real-time event 125"
-   GDB_SIGNAL_REALTIME_126 = 140, // "SIG126", "Real-time event 126"
-   GDB_SIGNAL_REALTIME_127 = 141, // "SIG127", "Real-time event 127"
+   GDB_SIGNAL_REALTIME_32 = 77,     // SIG32, "Real-time event 32"
+   GDB_SIGNAL_REALTIME_64 = 78,     // "SIG64", "Real-time event 64"
+   GDB_SIGNAL_REALTIME_65 = 79,     // "SIG65", "Real-time event 65"
+   GDB_SIGNAL_REALTIME_66 = 80,     // "SIG66", "Real-time event 66"
+   GDB_SIGNAL_REALTIME_67 = 81,     // "SIG67", "Real-time event 67"
+   GDB_SIGNAL_REALTIME_68 = 82,     // "SIG68", "Real-time event 68"
+   GDB_SIGNAL_REALTIME_69 = 83,     // "SIG69", "Real-time event 69"
+   GDB_SIGNAL_REALTIME_70 = 84,     // "SIG70", "Real-time event 70"
+   GDB_SIGNAL_REALTIME_71 = 85,     // "SIG71", "Real-time event 71"
+   GDB_SIGNAL_REALTIME_72 = 86,     // "SIG72", "Real-time event 72"
+   GDB_SIGNAL_REALTIME_73 = 87,     // "SIG73", "Real-time event 73"
+   GDB_SIGNAL_REALTIME_74 = 88,     // "SIG74", "Real-time event 74"
+   GDB_SIGNAL_REALTIME_75 = 89,     // "SIG75", "Real-time event 75"
+   GDB_SIGNAL_REALTIME_76 = 90,     // "SIG76", "Real-time event 76"
+   GDB_SIGNAL_REALTIME_77 = 91,     // "SIG77", "Real-time event 77"
+   GDB_SIGNAL_REALTIME_78 = 92,     // "SIG78", "Real-time event 78"
+   GDB_SIGNAL_REALTIME_79 = 93,     // "SIG79", "Real-time event 79"
+   GDB_SIGNAL_REALTIME_80 = 94,     // "SIG80", "Real-time event 80"
+   GDB_SIGNAL_REALTIME_81 = 95,     // "SIG81", "Real-time event 81"
+   GDB_SIGNAL_REALTIME_82 = 96,     // "SIG82", "Real-time event 82"
+   GDB_SIGNAL_REALTIME_83 = 97,     // "SIG83", "Real-time event 83"
+   GDB_SIGNAL_REALTIME_84 = 98,     // "SIG84", "Real-time event 84"
+   GDB_SIGNAL_REALTIME_85 = 99,     // "SIG85", "Real-time event 85"
+   GDB_SIGNAL_REALTIME_86 = 100,    // "SIG86", "Real-time event 86"
+   GDB_SIGNAL_REALTIME_87 = 101,    // "SIG87", "Real-time event 87"
+   GDB_SIGNAL_REALTIME_88 = 102,    // "SIG88", "Real-time event 88"
+   GDB_SIGNAL_REALTIME_89 = 103,    // "SIG89", "Real-time event 89"
+   GDB_SIGNAL_REALTIME_90 = 104,    // "SIG90", "Real-time event 90"
+   GDB_SIGNAL_REALTIME_91 = 105,    // "SIG91", "Real-time event 91"
+   GDB_SIGNAL_REALTIME_92 = 106,    // "SIG92", "Real-time event 92"
+   GDB_SIGNAL_REALTIME_93 = 107,    // "SIG93", "Real-time event 93"
+   GDB_SIGNAL_REALTIME_94 = 108,    // "SIG94", "Real-time event 94"
+   GDB_SIGNAL_REALTIME_95 = 109,    // "SIG95", "Real-time event 95"
+   GDB_SIGNAL_REALTIME_96 = 110,    // "SIG96", "Real-time event 96"
+   GDB_SIGNAL_REALTIME_97 = 111,    // "SIG97", "Real-time event 97"
+   GDB_SIGNAL_REALTIME_98 = 112,    // "SIG98", "Real-time event 98"
+   GDB_SIGNAL_REALTIME_99 = 113,    // "SIG99", "Real-time event 99"
+   GDB_SIGNAL_REALTIME_100 = 114,   // "SIG100", "Real-time event 100"
+   GDB_SIGNAL_REALTIME_101 = 115,   // "SIG101", "Real-time event 101"
+   GDB_SIGNAL_REALTIME_102 = 116,   // "SIG102", "Real-time event 102"
+   GDB_SIGNAL_REALTIME_103 = 117,   // "SIG103", "Real-time event 103"
+   GDB_SIGNAL_REALTIME_104 = 118,   // "SIG104", "Real-time event 104"
+   GDB_SIGNAL_REALTIME_105 = 119,   // "SIG105", "Real-time event 105"
+   GDB_SIGNAL_REALTIME_106 = 120,   // "SIG106", "Real-time event 106"
+   GDB_SIGNAL_REALTIME_107 = 121,   // "SIG107", "Real-time event 107"
+   GDB_SIGNAL_REALTIME_108 = 122,   // "SIG108", "Real-time event 108"
+   GDB_SIGNAL_REALTIME_109 = 123,   // "SIG109", "Real-time event 109"
+   GDB_SIGNAL_REALTIME_110 = 124,   // "SIG110", "Real-time event 110"
+   GDB_SIGNAL_REALTIME_111 = 125,   // "SIG111", "Real-time event 111"
+   GDB_SIGNAL_REALTIME_112 = 126,   // "SIG112", "Real-time event 112"
+   GDB_SIGNAL_REALTIME_113 = 127,   // "SIG113", "Real-time event 113"
+   GDB_SIGNAL_REALTIME_114 = 128,   // "SIG114", "Real-time event 114"
+   GDB_SIGNAL_REALTIME_115 = 129,   // "SIG115", "Real-time event 115"
+   GDB_SIGNAL_REALTIME_116 = 130,   // "SIG116", "Real-time event 116"
+   GDB_SIGNAL_REALTIME_117 = 131,   // "SIG117", "Real-time event 117"
+   GDB_SIGNAL_REALTIME_118 = 132,   // "SIG118", "Real-time event 118"
+   GDB_SIGNAL_REALTIME_119 = 133,   // "SIG119", "Real-time event 119"
+   GDB_SIGNAL_REALTIME_120 = 134,   // "SIG120", "Real-time event 120"
+   GDB_SIGNAL_REALTIME_121 = 135,   // "SIG121", "Real-time event 121"
+   GDB_SIGNAL_REALTIME_122 = 136,   // "SIG122", "Real-time event 122"
+   GDB_SIGNAL_REALTIME_123 = 137,   // "SIG123", "Real-time event 123"
+   GDB_SIGNAL_REALTIME_124 = 138,   // "SIG124", "Real-time event 124"
+   GDB_SIGNAL_REALTIME_125 = 139,   // "SIG125", "Real-time event 125"
+   GDB_SIGNAL_REALTIME_126 = 140,   // "SIG126", "Real-time event 126"
+   GDB_SIGNAL_REALTIME_127 = 141,   // "SIG127", "Real-time event 127"
 
-   GDB_SIGNAL_INFO = 142,         // SIGINFO, "Information request"
+   GDB_SIGNAL_INFO = 142,   // SIGINFO, "Information request"
 
-   GDB_SIGNAL_UNKNOWN = 143,      // NULL, "Unknown signal"
+   GDB_SIGNAL_UNKNOWN = 143,   // NULL, "Unknown signal"
 
-   GDB_SIGNAL_DEFAULT = 144,      // NULL, "Internal error: printing GDB_SIGNAL_DEFAULT"
+   GDB_SIGNAL_DEFAULT = 144,   // NULL, "Internal error: printing GDB_SIGNAL_DEFAULT"
 
-   GDB_EXC_BAD_ACCESS = 145,      // "EXC_BAD_ACCESS", "Could not access memory"
-   GDB_EXC_BAD_INSTRUCTION = 146, // "EXC_BAD_INSTRUCTION", "Illegal instruction/operand"
-   GDB_EXC_ARITHMETIC = 147,      // "EXC_ARITHMETIC", "Arithmetic exception"
-   GDB_EXC_EMULATION = 148,       // "EXC_EMULATION", "Emulation instruction"
-   GDB_EXC_SOFTWARE = 149,        // "EXC_SOFTWARE", "Software generated exception"
-   GDB_EXC_BREAKPOINT = 150,      // "EXC_BREAKPOINT", "Breakpoint"
+   GDB_EXC_BAD_ACCESS = 145,        // "EXC_BAD_ACCESS", "Could not access memory"
+   GDB_EXC_BAD_INSTRUCTION = 146,   // "EXC_BAD_INSTRUCTION", "Illegal instruction/operand"
+   GDB_EXC_ARITHMETIC = 147,        // "EXC_ARITHMETIC", "Arithmetic exception"
+   GDB_EXC_EMULATION = 148,         // "EXC_EMULATION", "Emulation instruction"
+   GDB_EXC_SOFTWARE = 149,          // "EXC_SOFTWARE", "Software generated exception"
+   GDB_EXC_BREAKPOINT = 150,        // "EXC_BREAKPOINT", "Breakpoint"
 
-   GDB_SIGNAL_LIBRT = 151,        // "SIGLIBRT", "librt internal signal"
+   GDB_SIGNAL_LIBRT = 151,   // "SIGLIBRT", "librt internal signal"
 
-   GDB_SIGNAL_LAST = 152,         // none
+   GDB_SIGNAL_LAST = 152,   // none
 
 } gdb_signal_number_t;
 
@@ -234,7 +234,8 @@ extern int km_gdb_write_registers(km_vcpu_t* vcpu, uint8_t* reg, size_t len);
 extern int km_gdb_enable_ss(void);
 extern int km_gdb_disable_ss(void);
 extern int km_gdb_add_breakpoint(gdb_breakpoint_type_t type, km_gva_t addr, size_t len);
-extern int km_gdb_remove_breakpoint(gdb_breakpoint_type_t type, km_gva_t addr, size_t len, int skip_hw_update);
+extern int
+km_gdb_remove_breakpoint(gdb_breakpoint_type_t type, km_gva_t addr, size_t len, int skip_hw_update);
 extern int km_gdb_remove_all_breakpoints(int skip_hw_update);
 extern int
 km_gdb_find_breakpoint(km_gva_t trigger_addr, gdb_breakpoint_type_t* type, km_gva_t* addr, size_t* len);

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -109,7 +109,7 @@ gdbstub_info_t gdbstub = {
     .notify_mutex = PTHREAD_MUTEX_INITIALIZER,
     .event_queue = TAILQ_HEAD_INITIALIZER(gdbstub.event_queue),
 };
-#define BUFMAX (16 * 1024)       // buffer for gdb protocol
+#define BUFMAX (16 * 1024)   // buffer for gdb protocol
 static char in_buffer[BUFMAX];   // TODO: malloc/free these two
 static unsigned char registers[BUFMAX];
 

--- a/km/km_guest.h
+++ b/km/km_guest.h
@@ -24,7 +24,7 @@
 
 #include "km_mem.h"
 
-#define CACHE_LINE_LENGTH 64 // bytes
+#define CACHE_LINE_LENGTH 64   // bytes
 #define BYTES_PER_POINTER 8
 
 // Changes in this macro should be reflected in the declaration of km_hcargs in km_guest_asmcode.s

--- a/km/km_mem.h
+++ b/km/km_mem.h
@@ -241,8 +241,7 @@ static inline km_kma_t km_gva_to_kma_nocheck(km_gva_t gva)
  */
 static inline km_kma_t km_gva_to_kma(km_gva_t gva)
 {
-   if (gva < GUEST_MEM_START_VA ||
-       gva >= GUEST_MEM_TOP_VA ||
+   if (gva < GUEST_MEM_START_VA || gva >= GUEST_MEM_TOP_VA ||
        (roundup(machine.brk, KM_PAGE_SIZE) <= gva && gva < rounddown(machine.tbrk, KM_PAGE_SIZE) &&
         !(gva >= GUEST_VVAR_VDSO_BASE_VA && gva < GUEST_VVAR_VDSO_BASE_VA + km_vvar_vdso_size) &&
         !(gva >= GUEST_KMGUESTMEM_BASE_VA &&

--- a/km/km_signal.h
+++ b/km/km_signal.h
@@ -44,7 +44,8 @@ void km_wait_for_signal(int sig);
 typedef void (*sa_action_t)(int, siginfo_t*, void*);
 void km_install_sighandler(int signum, sa_action_t hander_func);
 uint64_t km_rt_sigsuspend(km_vcpu_t* vcpu, km_sigset_t* mask, size_t masksize);
-uint64_t km_rt_sigtimedwait(km_vcpu_t* vcpu, km_sigset_t* set, siginfo_t* info, struct timespec* timeout, size_t setlen);
+uint64_t km_rt_sigtimedwait(
+    km_vcpu_t* vcpu, km_sigset_t* set, siginfo_t* info, struct timespec* timeout, size_t setlen);
 
 static inline int km_sigindex(int signo)
 {
@@ -56,7 +57,7 @@ static inline void km_sigemptyset(km_sigset_t* set)
    *set = 0L;
 }
 
-static inline void km_sigfillset(km_sigset_t *set)
+static inline void km_sigfillset(km_sigset_t* set)
 {
    *set = ~0L;
 }

--- a/km/km_trace.c
+++ b/km/km_trace.c
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 #include "km.h"
 #include "km_exec.h"
@@ -192,7 +191,8 @@ void km_trace_setup(int argc, char* argv[], char* payload_name)
       int opt;
       int longopt_index;
       optind = 0;
-      while ((opt = getopt_long(argc, argv, km_cmd_short_options, km_cmd_long_options, &longopt_index)) != -1) {
+      while ((opt = getopt_long(argc, argv, km_cmd_short_options, km_cmd_long_options, &longopt_index)) !=
+             -1) {
          switch (opt) {
             case 'V':
                trace_regex = (optarg != NULL) ? optarg : "";
@@ -211,7 +211,8 @@ void km_trace_setup(int argc, char* argv[], char* payload_name)
    }
 
    if (trace_regex == NULL) {
-      // No trace settings from the command line or command line is ignored, see if the environment has anything to say.
+      // No trace settings from the command line or command line is ignored, see if the environment
+      // has anything to say.
       trace_regex = getenv(KM_VERBOSE);
    }
    if (trace_regex != NULL) {

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -640,7 +640,8 @@ void* km_vcpu_run(km_vcpu_t* vcpu)
             switch (hypercall(vcpu, &hc_ret)) {
                case HC_CONTINUE:
                   km_infox(KM_TRACE_VCPU,
-                           "return from hc = %d (%s), hc_ret 0x%x, gdb_run_state %d, pause_requested %d",
+                           "return from hc = %d (%s), hc_ret 0x%x, gdb_run_state %d, "
+                           "pause_requested %d",
                            vcpu->hypercall,
                            km_hc_name_get(vcpu->hypercall),
                            hc_ret,
@@ -804,10 +805,12 @@ void* km_vcpu_run(km_vcpu_t* vcpu)
             break;
       }   // switch(reason)
       if (vcpu->hypercall_returns_signal != 0) {
-         // rt_sigtimedwait() returns signals directly.  Let's not pile another signal on this thread this time thru.
+         // rt_sigtimedwait() returns signals directly.  Let's not pile another signal on this
+         // thread this time thru.
          if (km_gdb_client_is_attached() != 0) {
             km_gdb_notify(vcpu, vcpu->hypercall_returns_signal);
-            // When gdbstub delivers the signal from gdb client, it will need the hypercall_returns_signal flag so we don't clear it here.
+            // When gdbstub delivers the signal from gdb client, it will need the
+            // hypercall_returns_signal flag so we don't clear it here.
          } else {
             // gdb is not interfering with signal delivery
             vcpu->hypercall_returns_signal = 0;
@@ -819,10 +822,10 @@ void* km_vcpu_run(km_vcpu_t* vcpu)
                km_gdb_notify(vcpu, info.si_signo);
                /*
                 * The gdb client should send the signal back and gdb stub will call
-                * km_deliver_signal(). But, will the gdb client send the same signal back?  Or will the
-                * client eat the signal? If we got here from sigsuspend() and the gdb client ate the
-                * signal or sent a different signal back, we should really go back to wait for an
-                * unblocked signal in sigsuspend().
+                * km_deliver_signal(). But, will the gdb client send the same signal back?  Or will
+                * the client eat the signal? If we got here from sigsuspend() and the gdb client ate
+                * the signal or sent a different signal back, we should really go back to wait for
+                * an unblocked signal in sigsuspend().
                 */
             } else {
                km_deliver_signal(vcpu, &info);

--- a/km/x86_cpu.h
+++ b/km/x86_cpu.h
@@ -165,12 +165,12 @@ typedef struct x86_pte_4k {
 /*
  * CR0
  */
-#define X86_CR0_PE (1ul << 0)    // Protection Enable
-#define X86_CR0_MP (1ul << 1)    // Monitor Coprocessor
-#define X86_CR0_EM (1ul << 2)    // Emulation
-#define X86_CR0_TS (1ul << 3)    // Task Switched
-#define X86_CR0_ET (1ul << 4)    // Extension Type
-#define X86_CR0_NE (1ul << 5)    // Numeric Error
+#define X86_CR0_PE (1ul << 0)   // Protection Enable
+#define X86_CR0_MP (1ul << 1)   // Monitor Coprocessor
+#define X86_CR0_EM (1ul << 2)   // Emulation
+#define X86_CR0_TS (1ul << 3)   // Task Switched
+#define X86_CR0_ET (1ul << 4)   // Extension Type
+#define X86_CR0_NE (1ul << 5)   // Numeric Error
 #define X86_CR0_WP (1ul << 16)   // Write Protect
 #define X86_CR0_AM (1ul << 18)   // Alignment Mask
 #define X86_CR0_NW (1ul << 29)   // Not Write-through
@@ -190,58 +190,58 @@ typedef struct x86_pte_4k {
 /*
  * CR4
  */
-#define X86_CR4_VME (1ul << 0)           // enable vm86 extensions
-#define X86_CR4_PVI (1ul << 1)           // virtual interrupts flag enable
-#define X86_CR4_TSD (1ul << 2)           // disable time stamp at ipl 3
-#define X86_CR4_DE (1ul << 3)            // enable debugging extensions
-#define X86_CR4_PSE (1ul << 4)           // enable page size extensions
-#define X86_CR4_PAE (1ul << 5)           // enable physical address extensions
-#define X86_CR4_MCE (1ul << 6)           // Machine check enable
-#define X86_CR4_PGE (1ul << 7)           // enable global pages
-#define X86_CR4_PCE (1ul << 8)           // enable performance counters at ipl 3
-#define X86_CR4_OSFXSR (1ul << 9)        // enable fast FPU save and restore
+#define X86_CR4_VME (1ul << 0)   // enable vm86 extensions
+#define X86_CR4_PVI (1ul << 1)   // virtual interrupts flag enable
+#define X86_CR4_TSD (1ul << 2)   // disable time stamp at ipl 3
+#define X86_CR4_DE (1ul << 3)   // enable debugging extensions
+#define X86_CR4_PSE (1ul << 4)   // enable page size extensions
+#define X86_CR4_PAE (1ul << 5)   // enable physical address extensions
+#define X86_CR4_MCE (1ul << 6)   // Machine check enable
+#define X86_CR4_PGE (1ul << 7)   // enable global pages
+#define X86_CR4_PCE (1ul << 8)   // enable performance counters at ipl 3
+#define X86_CR4_OSFXSR (1ul << 9)   // enable fast FPU save and restore
 #define X86_CR4_OSXMMEXCPT (1ul << 10)   // enable unmasked SSE exceptions
-#define X86_CR4_UMIP (1ul << 11)         // enable UMIP support
-#define X86_CR4_VMXE (1ul << 13)         // enable VMX virtualization
-#define X86_CR4_SMXE (1ul << 14)         // enable safer mode (TXT)
-#define X86_CR4_FSGSBASE (1ul << 16)     // enable RDWRFSGS support
-#define X86_CR4_PCIDE (1ul << 17)        // enable PCID support
-#define X86_CR4_OSXSAVE (1ul << 18)      // enable xsave and xrestore
-#define X86_CR4_SMEP (1ul << 20)         // enable SMEP support
-#define X86_CR4_SMAP (1ul << 21)         // enable SMAP support
-#define X86_CR4_PKE (1ul << 22)          // enable Protection Keys support
+#define X86_CR4_UMIP (1ul << 11)   // enable UMIP support
+#define X86_CR4_VMXE (1ul << 13)   // enable VMX virtualization
+#define X86_CR4_SMXE (1ul << 14)   // enable safer mode (TXT)
+#define X86_CR4_FSGSBASE (1ul << 16)   // enable RDWRFSGS support
+#define X86_CR4_PCIDE (1ul << 17)   // enable PCID support
+#define X86_CR4_OSXSAVE (1ul << 18)   // enable xsave and xrestore
+#define X86_CR4_SMEP (1ul << 20)   // enable SMEP support
+#define X86_CR4_SMAP (1ul << 21)   // enable SMAP support
+#define X86_CR4_PKE (1ul << 22)   // enable Protection Keys support
 
 /*
  * Intel SDM, Vol3. Figure 2-5. EFLAGS bits, same RFLAGS per 2.3.1
  */
-#define X86_RFLAGS_CF (1ul << 0)      // Carry Flag
+#define X86_RFLAGS_CF (1ul << 0)   // Carry Flag
 #define X86_RFLAGS_FIXED (1ul << 1)   // Bit 1 - always on
-#define X86_RFLAGS_PF (1ul << 2)      // Parity Flag
-#define X86_RFLAGS_AF (1ul << 4)      // Auxiliary carry Flag
-#define X86_RFLAGS_ZF (1ul << 6)      // Zero Flag
-#define X86_RFLAGS_SF (1ul << 7)      // Sign Flag
-#define X86_RFLAGS_TF (1ul << 8)      // Trap Flag
-#define X86_RFLAGS_IF (1ul << 9)      // Interrupt Flag
-#define X86_RFLAGS_DF (1ul << 10)     // Direction Flag
-#define X86_RFLAGS_OF (1ul << 11)     // Overflow Flag
-#define X86_RFLAGS_IOPL (3ul << 3)    // I/O Privilege Level (2 bits)
-#define X86_RFLAGS_NT (1ul << 14)     // Nested Task
-#define X86_RFLAGS_RF (1ul << 16)     // Resume Flag
-#define X86_RFLAGS_VM (1ul << 17)     // Virtual Mode
-#define X86_RFLAGS_AC (1ul << 18)     // Alignment Check/Access Control
-#define X86_RFLAGS_VIF (1ul << 19)    // Virtual Interrupt Flag
-#define X86_RFLAGS_VIP (1ul << 20)    // Virtual Interrupt Pending
-#define X86_RFLAGS_ID (1ul << 21)     // CPUID detection
+#define X86_RFLAGS_PF (1ul << 2)   // Parity Flag
+#define X86_RFLAGS_AF (1ul << 4)   // Auxiliary carry Flag
+#define X86_RFLAGS_ZF (1ul << 6)   // Zero Flag
+#define X86_RFLAGS_SF (1ul << 7)   // Sign Flag
+#define X86_RFLAGS_TF (1ul << 8)   // Trap Flag
+#define X86_RFLAGS_IF (1ul << 9)   // Interrupt Flag
+#define X86_RFLAGS_DF (1ul << 10)   // Direction Flag
+#define X86_RFLAGS_OF (1ul << 11)   // Overflow Flag
+#define X86_RFLAGS_IOPL (3ul << 3)   // I/O Privilege Level (2 bits)
+#define X86_RFLAGS_NT (1ul << 14)   // Nested Task
+#define X86_RFLAGS_RF (1ul << 16)   // Resume Flag
+#define X86_RFLAGS_VM (1ul << 17)   // Virtual Mode
+#define X86_RFLAGS_AC (1ul << 18)   // Alignment Check/Access Control
+#define X86_RFLAGS_VIF (1ul << 19)   // Virtual Interrupt Flag
+#define X86_RFLAGS_VIP (1ul << 20)   // Virtual Interrupt Pending
+#define X86_RFLAGS_ID (1ul << 21)   // CPUID detection
 
-#define X86_XCR0_X87 (1ul << 0)         // x87 FPU/MMU state
-#define X86_XCR0_SSE (1ul << 1)         // SSE state
-#define X86_XCR0_AVX (1ul << 2)         // AVX state
-#define X86_XCR0_BNDREGS (1ul << 3)     // BNDREG state
-#define X86_XCR0_BNDCSR (1ul << 4)      // BMDCSR state
-#define X86_XCR0_OPMASK (1ul << 5)      // OPMASK state
+#define X86_XCR0_X87 (1ul << 0)   // x87 FPU/MMU state
+#define X86_XCR0_SSE (1ul << 1)   // SSE state
+#define X86_XCR0_AVX (1ul << 2)   // AVX state
+#define X86_XCR0_BNDREGS (1ul << 3)   // BNDREG state
+#define X86_XCR0_BNDCSR (1ul << 4)   // BMDCSR state
+#define X86_XCR0_OPMASK (1ul << 5)   // OPMASK state
 #define X86_XCR0_ZMM_HI256 (1ul << 6)   // ZMM HI256 FPU/MMU
-#define X86_XCR0_HI16_ZMM (1ul << 7)    // HI16 ZMM state
-#define X86_XCR0_PKRU (1ul << 9)        // PKRU state
+#define X86_XCR0_HI16_ZMM (1ul << 7)   // HI16 ZMM state
+#define X86_XCR0_PKRU (1ul << 9)   // PKRU state
 
 #define X86_XCR0_MASK                                                                              \
    (X86_XCR0_PKRU | X86_XCR0_HI16_ZMM | X86_XCR0_ZMM_HI256 | X86_XCR0_OPMASK | X86_XCR0_BNDCSR |   \
@@ -250,24 +250,24 @@ typedef struct x86_pte_4k {
 /*
  * Intel CPU features in EFER
  */
-#define X86_EFER_SCE (1ul << 0)    // SYSCALL/SYSRET
-#define X86_EFER_LME (1ul << 8)    // Long mode enable (R/W)
+#define X86_EFER_SCE (1ul << 0)   // SYSCALL/SYSRET
+#define X86_EFER_LME (1ul << 8)   // Long mode enable (R/W)
 #define X86_EFER_LMA (1ul << 10)   // Long mode active (R/O)
-#define X86_EFER_NX (1ul << 11)    // No execute enable
+#define X86_EFER_NX (1ul << 11)   // No execute enable
 
 /*
  * Protected-Mode Exceptions and Interrupts
  * Intel SDM Table 6-1
  */
-#define X86_INTR_DE (0)    // Divide Error
-#define X86_INTR_DB (1)    // Debug Exception
+#define X86_INTR_DE (0)   // Divide Error
+#define X86_INTR_DB (1)   // Debug Exception
 #define X86_INTR_NMI (2)   // NMI
-#define X86_INTR_BP (3)    // Breakpoint
-#define X86_INTR_OF (4)    // Overflow
-#define X86_INTR_BR (5)    // BOUND Range Exceeded
-#define X86_INTR_UD (6)    // Invalid Opcode (Undefined Opcode)
-#define X86_INTR_NM (7)    // Device Not Available (No Math Coprocessor)
-#define X86_INTR_DF (8)    // Double Fault (includes error, always 0)
+#define X86_INTR_BP (3)   // Breakpoint
+#define X86_INTR_OF (4)   // Overflow
+#define X86_INTR_BR (5)   // BOUND Range Exceeded
+#define X86_INTR_UD (6)   // Invalid Opcode (Undefined Opcode)
+#define X86_INTR_NM (7)   // Device Not Available (No Math Coprocessor)
+#define X86_INTR_DF (8)   // Double Fault (includes error, always 0)
 // 9 Intel Reserved. Post 386 processors do not generate.
 #define X86_INTR_TS (10)   // Invalid TSS (includes error)
 #define X86_INTR_NP (11)   // Segment Not Present (includes error)

--- a/tests/auxv_test.c
+++ b/tests/auxv_test.c
@@ -24,21 +24,21 @@ int main(int argc, char* argv[])
    auxval = (char*)getauxval(AT_PLATFORM);
    if (auxval == NULL) {
       printf("AT_PLATFORM is missing\n");
-     return 1;
+      return 1;
    } else {
       printf("AT_PLATFORM     %s\n", auxval);
    }
    auxval = (char*)getauxval(AT_EXECFN);
    if (auxval == NULL) {
       printf("AT_EXECFN is missing\n");
-     return 1;
+      return 1;
    } else {
       printf("AT_EXECFN       %s\n", auxval);
    }
    auxval = (char*)getauxval(AT_RANDOM);
    if (auxval == NULL) {
       printf("AT_RANDOM is missing\n");
-     return 1;
+      return 1;
    } else {
       printf("AT_RANDOM      ");
       for (int i = 0; i < 16; i++) {

--- a/tests/cpuid_print_details_test.c
+++ b/tests/cpuid_print_details_test.c
@@ -42,9 +42,9 @@ void cpuid(uint32_t op, uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* e
  */
 void cpuid_with_subop(uint32_t op, uint32_t subop, uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* edx)
 {
-   __asm__ __volatile__ ("cpuid\n\t"
-      : "=a" (*eax), "=b" (*ebx), "=c" (*ecx), "=d" (*edx)
-      : "a" (op), "c" (subop));
+   __asm__ __volatile__("cpuid\n\t"
+                        : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+                        : "a"(op), "c"(subop));
 }
 
 typedef union EBChar4 {

--- a/tests/crash_test.c
+++ b/tests/crash_test.c
@@ -22,7 +22,7 @@
 
 int main()
 {
-    char *bad_p = (char *) -16LL;
+   char* bad_p = (char*)-16LL;
 
-    *bad_p = 'a';
+   *bad_p = 'a';
 }

--- a/tests/exec_guest_files_test.c
+++ b/tests/exec_guest_files_test.c
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 #define _GNU_SOURCE
-#include <stdio.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <errno.h>
 #include <fcntl.h>
-#include <time.h>
-#include <sys/socket.h>
+#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <sys/epoll.h>
-#include <unistd.h>
-#include <limits.h>
-#include <errno.h>
-
 
 /*
  * This test opens all of the types of files that km snapshot does special things with
@@ -50,8 +49,8 @@ int main(int argc, char* argv[])
    int plainfilefd;
    int sockfd;
    int sockfd2;
-   int socketpairfd[2] = { 123, 456 };
-   int pipefd[2] = { 789, 012 };
+   int socketpairfd[2] = {123, 456};
+   int pipefd[2] = {789, 012};
    int epollfd;
    int rc;
 
@@ -67,7 +66,11 @@ int main(int argc, char* argv[])
       struct timespec ts;
       char plainfilename[128];
       clock_gettime(CLOCK_MONOTONIC, &ts);
-      snprintf(plainfilename, sizeof(plainfilename), "/tmp/exec_guest_files_test_%ld.%ld", ts.tv_sec, ts.tv_nsec);
+      snprintf(plainfilename,
+               sizeof(plainfilename),
+               "/tmp/exec_guest_files_test_%ld.%ld",
+               ts.tv_sec,
+               ts.tv_nsec);
       plainfilefd = open(plainfilename, O_CREAT | O_EXCL, 0666);
       if (plainfilefd < 0) {
          fprintf(stderr, "open %s failed, %s\n", plainfilename, strerror(errno));
@@ -146,14 +149,22 @@ int main(int argc, char* argv[])
       event.data.fd = socketpairfd[0];
       rc = epoll_ctl(epollfd, EPOLL_CTL_ADD, socketpairfd[0], &event);
 
-      fprintf(stderr, "plainfilefd %d, sockfd %d, sockfd2 %d, socketpairfd[0] %d, socketpairfd[1] %d, pipefd[0] %d, pipefd[1] %d, epollfd %d\n",
-              plainfilefd, sockfd, sockfd2, socketpairfd[0], socketpairfd[1], pipefd[0], pipefd[1], epollfd);
-      
+      fprintf(stderr,
+              "plainfilefd %d, sockfd %d, sockfd2 %d, socketpairfd[0] %d, socketpairfd[1] %d, "
+              "pipefd[0] %d, pipefd[1] %d, epollfd %d\n",
+              plainfilefd,
+              sockfd,
+              sockfd2,
+              socketpairfd[0],
+              socketpairfd[1],
+              pipefd[0],
+              pipefd[1],
+              epollfd);
 
       // exec to this program again with the fd's we opened as arguments
       char me[PATH_MAX];
-      char *argv[20];
-      char *env[1] = { NULL };
+      char* argv[20];
+      char* env[1] = {NULL};
       rc = readlink("/proc/self/exe", me, sizeof(me));
       if (rc < 0) {
          fprintf(stderr, "Can't readlink /proc/self/me?, %s\n", strerror(errno));
@@ -187,8 +198,17 @@ int main(int argc, char* argv[])
       pipefd[1] = atoi(argv[9]);
       epollfd = atoi(argv[10]);
 
-      fprintf(stderr, "plainfilefd %d, sockfd %d, sockfd2 %d, socketpairfd[0] %d, socketpairfd[1] %d, pipefd[0] %d, pipefd[1] %d, epollfd %d\n",
-              plainfilefd, sockfd, sockfd2, socketpairfd[0], socketpairfd[1], pipefd[0], pipefd[1], epollfd);
+      fprintf(stderr,
+              "plainfilefd %d, sockfd %d, sockfd2 %d, socketpairfd[0] %d, socketpairfd[1] %d, "
+              "pipefd[0] %d, pipefd[1] %d, epollfd %d\n",
+              plainfilefd,
+              sockfd,
+              sockfd2,
+              socketpairfd[0],
+              socketpairfd[1],
+              pipefd[0],
+              pipefd[1],
+              epollfd);
 
       rc = close(plainfilefd);
       if (rc < 0) {

--- a/tests/exec_target_test.c
+++ b/tests/exec_target_test.c
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <stdio.h>
-#include <error.h>
 #include <errno.h>
-#include <string.h>
-#include <unistd.h>
-#include <signal.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/stat.h>
+#include <error.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 #include <sys/epoll.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 /*
  * This program tests that SIGCHLD is not accidently blocked in the child process
@@ -42,7 +42,7 @@
  */
 
 int handle_sigchld_entered = 0;
-void handle_sigchld(int sig, siginfo_t *info, void *ucontext)
+void handle_sigchld(int sig, siginfo_t* info, void* ucontext)
 {
    char message[] = "handle_sigchld entered\n";
    // Just use write, fprintf() uses a mutex.
@@ -95,22 +95,28 @@ int main(int argc, char* argv[])
             return 0;
          }
          // waitpid failed
-         fprintf(stderr, "%s:%d: %s: waitpid unexpected return value, rv %d, errno %d, status 0x%x\n", __FUNCTION__, __LINE__, argv[1], rv, errno, status);
+         fprintf(stderr,
+                 "%s:%d: %s: waitpid unexpected return value, rv %d, errno %d, status 0x%x\n",
+                 __FUNCTION__,
+                 __LINE__,
+                 argv[1],
+                 rv,
+                 errno,
+                 status);
          return 1;
       }
       // We are the child
-      char* argv[] = { "exec_target", "waitforchild", NULL };
-      char* envv[] = { NULL };
+      char* argv[] = {"exec_target", "waitforchild", NULL};
+      char* envv[] = {NULL};
       rc = execve(thisprogram, argv, envv);
       fprintf(stderr, "execve() to %s failed, %s\n", thisprogram, strerror(errno));
       return 1;
    }
 
-
    if (strcmp(argv[1], "waitforchild") == 0) {
       // fork()
-      // parent: setup SIGCHLD signal handler, block in epoll_pwait(), SIGCHLD interrupts epoll_pwait(), exit
-      // child: fork() then exec("exec_target", "child")
+      // parent: setup SIGCHLD signal handler, block in epoll_pwait(), SIGCHLD interrupts
+      // epoll_pwait(), exit child: fork() then exec("exec_target", "child")
       pid = fork();
       if (pid < 0) {
          fprintf(stderr, "%s:%d: %s: fork failed, %s\n", __FUNCTION__, __LINE__, argv[1], strerror(errno));
@@ -118,7 +124,7 @@ int main(int argc, char* argv[])
       }
       if (pid != 0) {
          // we are the parent
-         struct sigaction act = { .sa_sigaction = handle_sigchld, .sa_flags = SA_SIGINFO };
+         struct sigaction act = {.sa_sigaction = handle_sigchld, .sa_flags = SA_SIGINFO};
          rc = sigaction(SIGCHLD, &act, NULL);
          if (rc < 0) {
             fprintf(stderr, "sigaction failed, %s\n", strerror(errno));
@@ -132,7 +138,7 @@ int main(int argc, char* argv[])
          }
          int epoll_target_fd[2];
          rc = pipe(epoll_target_fd);
-         struct epoll_event epoll_event = { EPOLLIN };
+         struct epoll_event epoll_event = {EPOLLIN};
          epoll_event.data.fd = epoll_target_fd[0];
          rc = epoll_ctl(epoll_thing, EPOLL_CTL_ADD, epoll_target_fd[0], &epoll_event);
          if (rc < 0) {
@@ -154,13 +160,12 @@ int main(int argc, char* argv[])
          return 1;
       }
       // We are the child
-      char* argv[] = { "exec_target", "child", NULL };
-      char* envv[] = { NULL };
+      char* argv[] = {"exec_target", "child", NULL};
+      char* envv[] = {NULL};
       rc = execve(thisprogram, argv, envv);
       fprintf(stderr, "execve() to %s failed, %s\n", thisprogram, strerror(errno));
       return 1;
    }
-
 
    if (strcmp(argv[1], "child") == 0) {
       // do nothing for a little while

--- a/tests/filesys_test.c
+++ b/tests/filesys_test.c
@@ -23,12 +23,12 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <signal.h>
 #include <sys/eventfd.h>
 #include <sys/ioctl.h>
 #include <sys/resource.h>
@@ -720,7 +720,7 @@ TEST test_pselect6()
 }
 
 int got_sigio = 0;
-void handle_sigio(int signo, siginfo_t *info, void *stuff)
+void handle_sigio(int signo, siginfo_t* info, void* stuff)
 {
    got_sigio = 1;
 }
@@ -730,7 +730,7 @@ TEST test_fcntl_fsetown()
    got_sigio = 0;
 
    // open test file
-   int pipefd[2];    // pipefd[0] is the read end
+   int pipefd[2];   // pipefd[0] is the read end
    ASSERT_NEQ(-1, pipe(pipefd));
 
    // set O_ASYNC on the read end of the pipe
@@ -756,7 +756,7 @@ TEST test_fcntl_fsetown()
       if (got_sigio != 0) {
          break;
       }
-      struct timespec snooze = {0, 50000000};  // 50ms
+      struct timespec snooze = {0, 50000000};   // 50ms
       if (nanosleep(&snooze, NULL) < 0) {
          ASSERT_EQ(EINTR, errno);
       }

--- a/tests/gdb_forker_test.c
+++ b/tests/gdb_forker_test.c
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
 #include <assert.h>
 #include <errno.h>
-#include <string.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 /*
  * A test program that forks and then th child execs to a different program.
@@ -35,7 +35,7 @@
 
 int main(int argc, char* argv[])
 {
-//   char payload[] = "tests/hello_test";
+   //   char payload[] = "tests/hello_test";
    char payload[] = "hello_test";
    pid_t pid;
 
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
       execve(payload, new_argv, new_envp);
       fprintf(stderr, "execve() to %s, pid %d, failed %s\n", payload, getpid(), strerror(errno));
       return 1;
-   } else { // parent
+   } else {   // parent
       fprintf(stderr, "Waiting for child pid %d to terminate\n", pid);
       pid_t waited_pid;
       int status;

--- a/tests/gdb_lots_of_threads_test.c
+++ b/tests/gdb_lots_of_threads_test.c
@@ -27,17 +27,17 @@
  * command shows us something less mundane.
  */
 
-#include <stdio.h>
-#include <pthread.h>
-#include <time.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
-#define MAX_THREADS	287	// KVM_MAX_VCPUS - 1 (main() is a thread too)
-#define DEFAULT_THREADS	10
-#define MAX_DEPTH	10
+#define MAX_THREADS 287   // KVM_MAX_VCPUS - 1 (main() is a thread too)
+#define DEFAULT_THREADS 10
+#define MAX_DEPTH 10
 
 int stop_running;
 time_t starttime;
@@ -45,7 +45,7 @@ int stop_after_seconds;
 
 pthread_mutex_t rand_serialize = PTHREAD_MUTEX_INITIALIZER;
 
-void do_random_sleep(uint64_t instance_number, int *depth)
+void do_random_sleep(uint64_t instance_number, int* depth)
 {
    struct timespec sleep_time;
    int rc;
@@ -59,7 +59,7 @@ void do_random_sleep(uint64_t instance_number, int *depth)
 
    (*depth)++;
    sleep_time.tv_sec = 0;
-   sleep_time.tv_nsec = rn % 10000000;  // no more than 10ms
+   sleep_time.tv_nsec = rn % 10000000;   // no more than 10ms
    rc = nanosleep(&sleep_time, NULL);
    if (rc != 0) {
       printf("thread instance %ld, nanosleep error %d\n", instance_number, rc);
@@ -99,7 +99,7 @@ void usage(void)
           DEFAULT_THREADS);
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
    long i;
    pthread_t threadid[MAX_THREADS];
@@ -112,24 +112,24 @@ int main(int argc, char *argv[])
    rc = clock_gettime(CLOCK_REALTIME, &rs);
    assert(rc == 0);
    srandom(rs.tv_nsec);
-   
+
    starttime = time(NULL);
 
    for (int j = 1; j < argc; j++) {
       if (strcmp(argv[j], "-a") == 0) {
-         if (j+1 >= argc) {
+         if (j + 1 >= argc) {
             usage();
             exit(1);
          }
-         stop_after_seconds = atoi(argv[j+1]);
+         stop_after_seconds = atoi(argv[j + 1]);
          printf("Stop running after %d seconds\n", stop_after_seconds);
          j++;
       } else if (strcmp(argv[j], "-t") == 0) {
-         if (j+1 >= argc) {
+         if (j + 1 >= argc) {
             usage();
             exit(1);
          }
-         max_threads = atoi(argv[j+1]);
+         max_threads = atoi(argv[j + 1]);
          if (max_threads > MAX_THREADS) {
             printf("Number of threads can not exceed %d\n", MAX_THREADS);
             exit(1);
@@ -154,7 +154,8 @@ int main(int argc, char *argv[])
          break;
       }
       if (stop_after_seconds != 0 && (time(NULL) - starttime) > stop_after_seconds) {
-         printf("Couldn't start requested number of threads in the time alotted, %d seconds\n", stop_after_seconds);
+         printf("Couldn't start requested number of threads in the time alotted, %d seconds\n",
+                stop_after_seconds);
          break;
       }
    }

--- a/tests/gdb_protected_mem_test.c
+++ b/tests/gdb_protected_mem_test.c
@@ -19,17 +19,17 @@
  * deny all access to those pages.
  * All we do is allocated a piece of memory with no permitted access.
  */
-#include <stdio.h>
-#include <sys/mman.h>
-#include <errno.h>
-#include <string.h>
 #include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
 
 int main(int argc, char* argv[])
 {
    void* memchunk;
-   const int chunksize = 2*4096;
-   unsigned char* imemchunk __attribute__ ((unused));
+   const int chunksize = 2 * 4096;
+   unsigned char* imemchunk __attribute__((unused));
 
    memchunk = mmap(NULL, chunksize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
    if (memchunk == MAP_FAILED) {

--- a/tests/gdb_qsupported_test.c
+++ b/tests/gdb_qsupported_test.c
@@ -23,22 +23,21 @@
  * and should be reported back to the gdb client.
  */
 #include <assert.h>
+#include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <signal.h>
-#include <pthread.h>
-#include <setjmp.h>
-#include <stdbool.h>
-
 
 /*
  * Signal handler for SIGILL
  */
 void handle_sigill(int signo)
 {
-   struct timespec delay = { 0, 50000 };  // 50 usec
+   struct timespec delay = {0, 50000};   // 50 usec
    nanosleep(&delay, NULL);
 }
 
@@ -65,7 +64,6 @@ void* breakpoint_thread(void* arg)
    return NULL;
 }
 
-
 int main()
 {
    int rc;
@@ -78,7 +76,8 @@ int main()
    rc = pthread_join(sfthread, NULL);
    assert(rc == 0);
 
-   // All done.  The test driver can look at the gdb output to see if the gdb Switching task message appeared.
+   // All done.  The test driver can look at the gdb output to see if the gdb Switching task message
+   // appeared.
 
    return 0;
 }

--- a/tests/gdb_server_entry_race_test.c
+++ b/tests/gdb_server_entry_race_test.c
@@ -23,22 +23,21 @@
  * and should be reported back to the gdb client.
  */
 #include <assert.h>
+#include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <signal.h>
-#include <pthread.h>
-#include <setjmp.h>
-#include <stdbool.h>
-
 
 /*
  * Signal handler for SIGILL
  */
 void handle_sigill(int signo)
 {
-   struct timespec delay = { 0, 50000 };  // 50 usec
+   struct timespec delay = {0, 50000};   // 50 usec
    nanosleep(&delay, NULL);
 }
 
@@ -60,12 +59,12 @@ static time_t __attribute__((noinline)) hit_breakpoint(void)
  * the test ends.
  */
 
-#define RUNTIME	1   // seconds
+#define RUNTIME 1   // seconds
 
 void* sigill_thread(void* arg)
 {
    int rc;
-   struct sigaction newsa = { .sa_handler = handle_sigill, .sa_flags = 0 }; 
+   struct sigaction newsa = {.sa_handler = handle_sigill, .sa_flags = 0};
 
    // Setup signal handler for illegal instructions
    sigemptyset(&newsa.sa_mask);
@@ -79,7 +78,6 @@ void* sigill_thread(void* arg)
    // Terminate
    return NULL;
 }
-
 
 int main()
 {

--- a/tests/gdb_sharedlib2_test.c
+++ b/tests/gdb_sharedlib2_test.c
@@ -44,7 +44,7 @@ static void __attribute__((noinline)) hit_breakpoint(void* symvalue)
    printf("time returns %ld, symvalue %p\n", time(NULL), symvalue);
 }
 
-static void __attribute__((noinline))got_symbol_breakpoint(void)
+static void __attribute__((noinline)) got_symbol_breakpoint(void)
 {
    printf("do something to trick the compiler\n");
 }
@@ -60,7 +60,9 @@ int main(int argc, char* argv[])
    // Dynamically load our test shared library
    void* c = dlopen(SHARED_LIB, RTLD_LAZY);
    if (c == NULL) {
-      printf("Couldn't dlopen() %s, does your LD_LIBRARY_PATH env var contain the tests directory\n", SHARED_LIB);
+      printf("Couldn't dlopen() %s, does your LD_LIBRARY_PATH env var contain the tests "
+             "directory\n",
+             SHARED_LIB);
    } else {
       dlerror();
       symvalue = dlsym(c, SHARED_LIB_SYMBOL);

--- a/tests/hcallargs_test.c
+++ b/tests/hcallargs_test.c
@@ -29,10 +29,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include "greatest/greatest.h"
-#include <sys/mman.h>
 #include <syscall.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include "greatest/greatest.h"
 
 #define GIB (1024 * 1024 * 1024ul)
 

--- a/tests/itimer_test.c
+++ b/tests/itimer_test.c
@@ -18,9 +18,9 @@
  * Simple test to exercise setitimer() and getitimer().
  */
 
-#include <stdio.h>
 #include <errno.h>
 #include <signal.h>
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -48,8 +48,8 @@ int main(int argc, char* argv[])
 
    // Setup an ITIMER_REAL interval timer
    struct itimerval new = {
-       { 0, 50000 },		// interval (50ms)
-       { 0, 20000 }             // time to next expiration
+       {0, 50000},   // interval (50ms)
+       {0, 20000}    // time to next expiration
    };
    if (setitimer(ITIMER_REAL, &new, NULL) < 0) {
       fprintf(stderr, "setitimer( ITIMER_REAL ) failed, %s\n", strerror(errno));
@@ -62,9 +62,12 @@ int main(int argc, char* argv[])
       fprintf(stderr, "getitimer( ITIMER_REAL ) failed, %s\n", strerror(errno));
       return 1;
    }
-   fprintf(stdout, "it_interval = { %ld.%06ld sec }, it_value = { %ld.%06ld sec }\n",
-           current.it_interval.tv_sec, current.it_interval.tv_usec,
-           current.it_value.tv_sec, current.it_value.tv_usec);
+   fprintf(stdout,
+           "it_interval = { %ld.%06ld sec }, it_value = { %ld.%06ld sec }\n",
+           current.it_interval.tv_sec,
+           current.it_interval.tv_usec,
+           current.it_value.tv_sec,
+           current.it_value.tv_usec);
 
    /*
     * wait for the timer to fire.  Note that azure can block this process/thread for

--- a/tests/mmap_test.h
+++ b/tests/mmap_test.h
@@ -41,7 +41,7 @@ static inline int KM_PAYLOAD(void)
 #define ASSERT_MMAPS_COUNT(_expected_count, _query)                                                \
    {                                                                                               \
       int ret = maps_count(_expected_count, _query);                                               \
-      ASSERT_NEQm("Expected mmaps counts does not match", -1, ret);                             \
+      ASSERT_NEQm("Expected mmaps counts does not match", -1, ret);                                \
    }
 
 /*
@@ -56,7 +56,7 @@ static inline int KM_PAYLOAD(void)
    {                                                                                               \
       initial_busy = INITIAL_BUSY_MEMORY_REGIONS;                                                  \
       int ret = maps_count(initial_busy, BUSY_MMAPS);                                              \
-      ASSERT_NEQm("Expected mmaps init does not match", -1, ret);                               \
+      ASSERT_NEQm("Expected mmaps init does not match", -1, ret);                                  \
    }
 
 // Check to see if busy memory region count is as expected.
@@ -64,7 +64,7 @@ static inline int KM_PAYLOAD(void)
    {                                                                                               \
       int expected_count = expected_change + initial_busy;                                         \
       int ret = maps_count(expected_count, TOTAL_MMAPS);                                           \
-      ASSERT_NEQm("Expected mmaps change does not match", -1, ret);                             \
+      ASSERT_NEQm("Expected mmaps change does not match", -1, ret);                                \
    }
 
 // Type of operation invoked by a single line in test tables

--- a/tests/pipetarget_test.c
+++ b/tests/pipetarget_test.c
@@ -23,8 +23,8 @@
  *  pipetarget_test writetopipe sourcefile
  */
 
-#include <stdio.h>
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 
 static char* PIPEWRITE = "writetoparent";
@@ -32,8 +32,7 @@ static char* PIPEREAD = "readfromparent";
 
 void usage(void)
 {
-   fprintf(stderr, "pipetarget_test {%s|%s} filename\n",
-           PIPEWRITE, PIPEREAD);
+   fprintf(stderr, "pipetarget_test {%s|%s} filename\n", PIPEWRITE, PIPEREAD);
 }
 
 int main(int argc, char* argv[])
@@ -43,7 +42,7 @@ int main(int argc, char* argv[])
       usage();
       return 1;
    }
-   if (strcmp(argv[1], PIPEREAD) == 0) {  // read from pipe, write into file
+   if (strcmp(argv[1], PIPEREAD) == 0) {   // read from pipe, write into file
       FILE* o = fopen(argv[2], "w");
       if (o != NULL) {
          while (fgets(linebuf, sizeof(linebuf), stdin) != NULL) {
@@ -54,7 +53,7 @@ int main(int argc, char* argv[])
          fprintf(stderr, "couldn't open %s for write, %s\n", argv[2], strerror(errno));
          return 1;
       }
-   } else if (strcmp(argv[1], PIPEWRITE) == 0) {  // open file for read, write into pipe
+   } else if (strcmp(argv[1], PIPEWRITE) == 0) {   // open file for read, write into pipe
       FILE* i = fopen(argv[2], "r");
       if (i != NULL) {
          while (fgets(linebuf, sizeof(linebuf), i) != NULL) {
@@ -66,10 +65,7 @@ int main(int argc, char* argv[])
          return 1;
       }
    } else {
-      fprintf(stderr, "Unknown operation %s, must be either %s or %s\n",
-              argv[1],
-              PIPEWRITE,
-              PIPEREAD);
+      fprintf(stderr, "Unknown operation %s, must be either %s or %s\n", argv[1], PIPEWRITE, PIPEREAD);
       return 1;
    }
    return 0;

--- a/tests/popen_test.c
+++ b/tests/popen_test.c
@@ -17,14 +17,14 @@
 /*
  * A small program to test popen() in 2 ways:
  * - write the contents of a file to pipetarget_test via a pipe amd cat writes the data to a file
- * - pipetarget_test reads a file and writes to stdout which is a pipe and this program reads the data and
- *   writes to a file.
+ * - pipetarget_test reads a file and writes to stdout which is a pipe and this program reads the
+ * data and writes to a file.
  */
 
-#include <stdio.h>
-#include <string.h>
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 char* progname;

--- a/tests/print_argenv_test.c
+++ b/tests/print_argenv_test.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-
 int main(int argc, char** argv)
 {
    for (int i = 0; i < argc; i++) {

--- a/tests/pthread_cancel_test.c
+++ b/tests/pthread_cancel_test.c
@@ -120,11 +120,13 @@ static long thread_func(void* arg)
                                                          : PTHREAD_CANCEL_ASYNCHRONOUS,
                              NULL);
    ASSERT_EQ(0, s);
-   // if all works async test will get cancelled in the middle, longer wait to make sure cancel comes at the right time
-   // deferred will wait all the way - to make the test duration reasonble the wait is shorter
+   // if all works async test will get cancelled in the middle, longer wait to make sure cancel
+   // comes at the right time deferred will wait all the way - to make the test duration reasonble
+   // the wait is shorter
    my_busysleep(arg == DEFERRED_CANCEL_TEST ? 5 : 60);
    /* Should get canceled while we sleep if ASYNC_CANCEL_TEST */
-   print_msg(arg == DEFERRED_CANCEL_TEST ? "PTHREAD_CANCEL_DEFERRED\n" : "PTHREAD_CANCEL_ASYNCHRONOUS\n");
+   print_msg(arg == DEFERRED_CANCEL_TEST ? "PTHREAD_CANCEL_DEFERRED\n"
+                                         : "PTHREAD_CANCEL_ASYNCHRONOUS\n");
    while (1) {
       usleep(1000);
    }

--- a/tests/regions_test.c
+++ b/tests/regions_test.c
@@ -18,13 +18,13 @@
  * Test IO crossing boundary between memory regions
  */
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include "greatest/greatest.h"
 #include "syscall.h"
-#include <limits.h>
 
 /*
  * First memort regions are: 2mb - 4mb, 4mb - 8mb, 8mb - 16mb ...
@@ -59,7 +59,7 @@ TEST region(void)
       perror(kmtest_data_path);
    }
    if (SYS_break(top) != top) {
-      fprintf(stderr, "break "); 
+      fprintf(stderr, "break ");
       perror(kmtest_data_path);
    }
    ptr = top - MiB - 8000;   // one full page and one partial page below the region boundary

--- a/tests/signal_test.c
+++ b/tests/signal_test.c
@@ -20,6 +20,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdint.h>
@@ -28,12 +29,11 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <sys/syscall.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 
 #include "greatest/greatest.h"
@@ -463,7 +463,12 @@ TEST test_sigttou()
       // wait for the child to exit.
       int wstatus;
       pid_t reaped_pid = wait4(child, &wstatus, 0, NULL);
-      fprintf(stderr, "parent: reaped_pid %d, errno %d, expected pid %d, wstatus 0x%x\n", reaped_pid, errno, child, wstatus);
+      fprintf(stderr,
+              "parent: reaped_pid %d, errno %d, expected pid %d, wstatus 0x%x\n",
+              reaped_pid,
+              errno,
+              child,
+              wstatus);
       ASSERT_EQ(reaped_pid, child);
       ASSERT_NEQ(WIFEXITED(wstatus), 0);
       ASSERT_EQ(WEXITSTATUS(wstatus), 0);

--- a/tests/sigsuspend_test.c
+++ b/tests/sigsuspend_test.c
@@ -21,16 +21,16 @@
  * Test by sending SIGUSR1 and then SIGUSR2.
  * You should see the SIGUSR2 message on stdout first and then the SIGUSR1 message.
  */
-#include <stdio.h>
-#include <signal.h>
 #include <assert.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 #include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 void sighandler_usr1(int signo)
 {

--- a/tests/snapshot_test.c
+++ b/tests/snapshot_test.c
@@ -38,7 +38,7 @@
 #include "km_hcalls.h"
 
 #ifndef SA_RESTORER
-#define SA_RESTORER   0x04000000
+#define SA_RESTORER 0x04000000
 #endif
 
 char* cmdname = "???";

--- a/tests/syscallexer_test.c
+++ b/tests/syscallexer_test.c
@@ -37,18 +37,17 @@
  */
 
 #define _GNU_SOURCE
-#include <stdio.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/syscall.h>
-#include <stdlib.h>
-#include <sys/stat.h>
-#include <linux/futex.h>
-#include <time.h>
-#include <pthread.h>
 #include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <linux/futex.h>
 
 #define ITERATIONS (5 * 1000 * 1000)
 
@@ -105,7 +104,7 @@ void* dosyscalls(void* arg)
    clock_gettime(CLOCK_MONOTONIC, &start);
    for (i = 0; i < ITERATIONS; i++) {
       errno = 0;
-      int rc = syscall(SYS_futex, &fut, FUTEX_WAIT, fut-1, NULL, NULL, 43);
+      int rc = syscall(SYS_futex, &fut, FUTEX_WAIT, fut - 1, NULL, NULL, 43);
       if (rc != -1 || errno != EAGAIN) {
          fprintf(stderr, "SYS_futex didn't fail as expected\n");
          __builtin_trap();
@@ -133,7 +132,9 @@ int main(int argc, char* argv[])
       nthreads = NTHREADS;
    }
    if (nthreads > NTHREADS) {
-      fprintf(stderr, "Maximum number of threads is %d, if you need more change this programs\n", NTHREADS);
+      fprintf(stderr,
+              "Maximum number of threads is %d, if you need more change this programs\n",
+              NTHREADS);
       return 1;
    }
    printf("Running tests with %d threads, %d iterations\n", nthreads, ITERATIONS);

--- a/tests/xstate_test.c
+++ b/tests/xstate_test.c
@@ -180,8 +180,8 @@ void set_xtended_registers(child_t* cptr)
       /* AVX (YMM registers) */
       ymm_t ymm_values[AVX_TEST_REG_COUNT] __attribute__((aligned(32)));
       for (int index = 0; index < AVX_TEST_REG_COUNT; index++) {
-         ymm_values[index].d3 = ymm_values[index].d2 =
-         ymm_values[index].d1 = ymm_values[index].d0 = get_value(cptr->index, index);
+         ymm_values[index].d3 = ymm_values[index].d2 = ymm_values[index].d1 = ymm_values[index].d0 =
+             get_value(cptr->index, index);
       }
       __asm__ volatile("vmovdqa (%0), %%ymm6\n"
                        "vmovdqa 0x20(%0), %%ymm7\n"
@@ -195,10 +195,9 @@ void set_xtended_registers(child_t* cptr)
       /* AVX (ZMM0-ZMM15 registers) */
       zmm_t zmm_values[ZMM_HI256_TEST_REG_COUNT] __attribute__((aligned(64)));
       for (int index = 0; index < ZMM_HI256_TEST_REG_COUNT; index++) {
-         zmm_values[index].d7 = zmm_values[index].d6 =
-         zmm_values[index].d5 = zmm_values[index].d4 =
-         zmm_values[index].d3 = zmm_values[index].d2 =
-         zmm_values[index].d1 = zmm_values[index].d0 = get_value(cptr->index, index);
+         zmm_values[index].d7 = zmm_values[index].d6 = zmm_values[index].d5 = zmm_values[index].d4 =
+             zmm_values[index].d3 = zmm_values[index].d2 = zmm_values[index].d1 =
+                 zmm_values[index].d0 = get_value(cptr->index, index);
       }
       __asm__ volatile("vmovdqa32 (%0), %%zmm8\n"
                        "vmovdqa32 0x40(%0), %%zmm9\n"
@@ -212,10 +211,9 @@ void set_xtended_registers(child_t* cptr)
       /* AVX512 (ZMM16-ZMM31 registers) */
       zmm_t zmm_values[HI16_ZMM_TEST_REG_COUNT] __attribute__((aligned(64)));
       for (int index = 0; index < HI16_ZMM_TEST_REG_COUNT; index++) {
-         zmm_values[index].d7 = zmm_values[index].d6 =
-         zmm_values[index].d5 = zmm_values[index].d4 =
-         zmm_values[index].d3 = zmm_values[index].d2 =
-         zmm_values[index].d1 = zmm_values[index].d0 = get_value(cptr->index, index);
+         zmm_values[index].d7 = zmm_values[index].d6 = zmm_values[index].d5 = zmm_values[index].d4 =
+             zmm_values[index].d3 = zmm_values[index].d2 = zmm_values[index].d1 =
+                 zmm_values[index].d0 = get_value(cptr->index, index);
       }
       __asm__ volatile("vmovdqa32 (%0), %%zmm16\n"
                        "vmovdqa32 0x40(%0), %%zmm17\n"
@@ -303,7 +301,7 @@ void verify_xtended_registers(child_t* cptr)
       for (int index = 0; index < AVX_TEST_REG_COUNT; index++) {
          u_int64_t expected = get_value(cptr->index, index);
          if ((ymm_values[index].d3 != expected) || (ymm_values[index].d2 != expected) ||
-            (ymm_values[index].d1 != expected) || (ymm_values[index].d0 != expected)) {
+             (ymm_values[index].d1 != expected) || (ymm_values[index].d0 != expected)) {
             cptr->failed_count++;
          }
       }
@@ -321,9 +319,9 @@ void verify_xtended_registers(child_t* cptr)
       for (int index = 0; index < ZMM_HI256_TEST_REG_COUNT; index++) {
          u_int64_t expected = get_value(cptr->index, index);
          if ((zmm_values[index].d7 != expected) || (zmm_values[index].d6 != expected) ||
-            (zmm_values[index].d5 != expected) || (zmm_values[index].d4 != expected) ||
-            (zmm_values[index].d3 != expected) || (zmm_values[index].d2 != expected) ||
-            (zmm_values[index].d1 != expected) || (zmm_values[index].d0 != expected)) {
+             (zmm_values[index].d5 != expected) || (zmm_values[index].d4 != expected) ||
+             (zmm_values[index].d3 != expected) || (zmm_values[index].d2 != expected) ||
+             (zmm_values[index].d1 != expected) || (zmm_values[index].d0 != expected)) {
             cptr->failed_count++;
          }
       }
@@ -353,9 +351,9 @@ void verify_xtended_registers(child_t* cptr)
       for (int index = 0; index < HI16_ZMM_TEST_REG_COUNT; index++) {
          u_int64_t expected = get_value(cptr->index, index);
          if ((zmm_values[index].d7 != expected) || (zmm_values[index].d6 != expected) ||
-            (zmm_values[index].d5 != expected) || (zmm_values[index].d4 != expected) ||
-            (zmm_values[index].d3 != expected) || (zmm_values[index].d2 != expected) ||
-            (zmm_values[index].d1 != expected) || (zmm_values[index].d0 != expected)) {
+             (zmm_values[index].d5 != expected) || (zmm_values[index].d4 != expected) ||
+             (zmm_values[index].d3 != expected) || (zmm_values[index].d2 != expected) ||
+             (zmm_values[index].d1 != expected) || (zmm_values[index].d0 != expected)) {
             cptr->failed_count++;
          }
       }


### PR DESCRIPTION
Our coding standard claims we adhere to clang-format rules. These files didn't. I ran `clang-format -i` on the `km` and `tests` directories. These are the changes.