### PR TITLE
clang-format 12 updates

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,46 +14,184 @@
 # limitations under the License.
 #
 BasedOnStyle: LLVM
-ColumnLimit: 100
-IndentWidth: 3
-BreakBeforeBraces: Linux
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: InlineOnly
-IndentCaseLabels: true
-PointerAlignment: Left
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
 BinPackArguments: false
 BinPackParameters: false
-PenaltyBreakBeforeFirstCallParameter: 250
-PenaltyBreakFirstLessLess: 200
-PenaltyBreakComment: 50
-PenaltyBreakString: 60
-PenaltyExcessCharacter: 5
-PenaltyReturnTypeOnItsOwnLine: 0
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Linux
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
 ForEachMacros:
-  - 'SLIST_FOREACH'
-  - 'SLIST_FOREACH_SAFE'
-  - 'LIST_FOREACH'
-  - 'LIST_FOREACH_SAFE'
-  - 'SIMPLEQ_FOREACH'
-  - 'SIMPLEQ_FOREACH_SAFE'
-  - 'TAILQ_FOREACH'
-  - 'TAILQ_FOREACH_SAFE'
-  - 'TAILQ_FOREACH_REVERSE'
-  - 'TAILQ_FOREACH_REVERSE_SAFE'
-  - 'STAILQ_FOREACH'
-  - 'STAILQ_FOREACH_SAFE'
-KeepEmptyLinesAtTheStartOfBlocks: false
-SpacesBeforeTrailingComments: 3
-SortIncludes: true
+  - SLIST_FOREACH
+  - SLIST_FOREACH_SAFE
+  - LIST_FOREACH
+  - LIST_FOREACH_SAFE
+  - SIMPLEQ_FOREACH
+  - SIMPLEQ_FOREACH_SAFE
+  - TAILQ_FOREACH
+  - TAILQ_FOREACH_SAFE
+  - TAILQ_FOREACH_REVERSE
+  - TAILQ_FOREACH_REVERSE_SAFE
+  - STAILQ_FOREACH
+  - STAILQ_FOREACH_SAFE
+StatementAttributeLikeMacros:
+  - Q_EMIT
+IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^<[^/]+>'
     Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^<sys/[^/]+>'
     Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^<.+/.+>'
     Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^".+/.+"'
     Priority:        4
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        5
-# AlignConsecutiveAssignments: true
-# AlignConsecutiveDeclarations: true
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     3
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 250
+PenaltyBreakComment: 50
+PenaltyBreakFirstLessLess: 200
+PenaltyBreakString: 60
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 5
+PenaltyReturnTypeOnItsOwnLine: 0
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 3
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/km/gdb_kvm_x86_64.c
+++ b/km/gdb_kvm_x86_64.c
@@ -77,7 +77,7 @@ static struct breakpoints_head hw_breakpoints;
  */
 #define MAX_HW_BREAKPOINTS 4   // DR7 has space for 4 breakpoints
 #define DR dbg.arch.debugreg   // generic debug register
-#define DR7 DR[7]   // debug control register
+#define DR7 DR[7]              // debug control register
 
 static uint32_t nr_hw_breakpoints = 0;
 

--- a/km/km.h
+++ b/km/km.h
@@ -491,7 +491,7 @@ void km_trace_setup(int argc, char* argv[], char* payload_name);
 
 extern int km_collect_hc_stats;
 
-#define km_trace_enabled() (km_info_trace.level != KM_TRACE_NONE)   // 1 for yes, 0 for no
+#define km_trace_enabled() (km_info_trace.level != KM_TRACE_NONE)      // 1 for yes, 0 for no
 #define km_trace_enabled_tag() (km_info_trace.level == KM_TRACE_TAG)   // 1 for yes, 0 for no
 
 #define km_trace_tag_enabled(tag)                                                                  \

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -88,8 +88,8 @@ typedef struct km_nt_vcpu {
 /*
  * fp_format values for km_nt_vcpu
  */
-#define NT_KM_VCPU_FPDATA_NONE 0 /* No fp data follows */
-#define NT_KM_VCPU_FPDATA_KVM_FPU 1 /* KVM_GET_FPU follows*/
+#define NT_KM_VCPU_FPDATA_NONE 0      /* No fp data follows */
+#define NT_KM_VCPU_FPDATA_KVM_FPU 1   /* KVM_GET_FPU follows*/
 #define NT_KM_VCPU_FPDATA_KVM_XSAVE 2 /* KVM_GET_XSAVE follows*/
 #define NT_KM_VCPU_FPDATA_KKM_XSAVE 3 /* KKM_GET_XSAVE follows*/
 
@@ -103,7 +103,7 @@ typedef struct km_nt_guest {
    Elf64_Ehdr ehdr;
    // Followed by PHDR list and filename
 } km_nt_guest_t;
-#define NT_KM_GUEST 0x4b4d4754   // "KMGT" no null term
+#define NT_KM_GUEST 0x4b4d4754       // "KMGT" no null term
 #define NT_KM_DYNLINKER 0x4b4d444c   // "KMDL" no null term
 
 /*

--- a/km/km_filesys_private.h
+++ b/km/km_filesys_private.h
@@ -61,9 +61,9 @@ typedef struct km_file {
 } km_file_t;
 
 // Valid values for the how field in km_file_t
-#define KM_FILE_HOW_OPEN 0 /* Regular open */
-#define KM_FILE_HOW_PIPE_0 1 /* read half of pipe */
-#define KM_FILE_HOW_PIPE_1 2 /* write half of pipe */
+#define KM_FILE_HOW_OPEN 0    /* Regular open */
+#define KM_FILE_HOW_PIPE_0 1  /* read half of pipe */
+#define KM_FILE_HOW_PIPE_1 2  /* write half of pipe */
 #define KM_FILE_HOW_EPOLLFD 3 /* epoll_create() */
 #define KM_FILE_HOW_SOCKET 4
 #define KM_FILE_HOW_ACCEPT 5

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -109,7 +109,7 @@ gdbstub_info_t gdbstub = {
     .notify_mutex = PTHREAD_MUTEX_INITIALIZER,
     .event_queue = TAILQ_HEAD_INITIALIZER(gdbstub.event_queue),
 };
-#define BUFMAX (16 * 1024)   // buffer for gdb protocol
+#define BUFMAX (16 * 1024)       // buffer for gdb protocol
 static char in_buffer[BUFMAX];   // TODO: malloc/free these two
 static unsigned char registers[BUFMAX];
 

--- a/km/km_musl_related.c
+++ b/km/km_musl_related.c
@@ -82,8 +82,9 @@ int km_link_map_walk(link_map_visit_function_t* callme, void* visitargp)
        *((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR + 1) == 0x8b) {
       // Fetch offset relative to the rip.
       rip_offset_of_head = *(uint32_t*)((char*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR + 3);
-      adderss_of_linkmaphead_kma = (km_kma_t)(
-          (uint64_t)dlopen_kma + KM_DLOPEN_OFFSET_TO_POST_LOAD_HEAD_INSTR + rip_offset_of_head);
+      adderss_of_linkmaphead_kma =
+          (km_kma_t)((uint64_t)dlopen_kma + KM_DLOPEN_OFFSET_TO_POST_LOAD_HEAD_INSTR +
+                     rip_offset_of_head);
       km_infox(KM_TRACE_KVM,
                "addr of link map head: gva 0x%lx, kma %p",
                km_guest.km_dlopen + KM_DLOPEN_OFFSET_TO_POST_LOAD_HEAD_INSTR + rip_offset_of_head,

--- a/km/x86_cpu.h
+++ b/km/x86_cpu.h
@@ -165,12 +165,12 @@ typedef struct x86_pte_4k {
 /*
  * CR0
  */
-#define X86_CR0_PE (1ul << 0)   // Protection Enable
-#define X86_CR0_MP (1ul << 1)   // Monitor Coprocessor
-#define X86_CR0_EM (1ul << 2)   // Emulation
-#define X86_CR0_TS (1ul << 3)   // Task Switched
-#define X86_CR0_ET (1ul << 4)   // Extension Type
-#define X86_CR0_NE (1ul << 5)   // Numeric Error
+#define X86_CR0_PE (1ul << 0)    // Protection Enable
+#define X86_CR0_MP (1ul << 1)    // Monitor Coprocessor
+#define X86_CR0_EM (1ul << 2)    // Emulation
+#define X86_CR0_TS (1ul << 3)    // Task Switched
+#define X86_CR0_ET (1ul << 4)    // Extension Type
+#define X86_CR0_NE (1ul << 5)    // Numeric Error
 #define X86_CR0_WP (1ul << 16)   // Write Protect
 #define X86_CR0_AM (1ul << 18)   // Alignment Mask
 #define X86_CR0_NW (1ul << 29)   // Not Write-through
@@ -190,58 +190,58 @@ typedef struct x86_pte_4k {
 /*
  * CR4
  */
-#define X86_CR4_VME (1ul << 0)   // enable vm86 extensions
-#define X86_CR4_PVI (1ul << 1)   // virtual interrupts flag enable
-#define X86_CR4_TSD (1ul << 2)   // disable time stamp at ipl 3
-#define X86_CR4_DE (1ul << 3)   // enable debugging extensions
-#define X86_CR4_PSE (1ul << 4)   // enable page size extensions
-#define X86_CR4_PAE (1ul << 5)   // enable physical address extensions
-#define X86_CR4_MCE (1ul << 6)   // Machine check enable
-#define X86_CR4_PGE (1ul << 7)   // enable global pages
-#define X86_CR4_PCE (1ul << 8)   // enable performance counters at ipl 3
-#define X86_CR4_OSFXSR (1ul << 9)   // enable fast FPU save and restore
+#define X86_CR4_VME (1ul << 0)           // enable vm86 extensions
+#define X86_CR4_PVI (1ul << 1)           // virtual interrupts flag enable
+#define X86_CR4_TSD (1ul << 2)           // disable time stamp at ipl 3
+#define X86_CR4_DE (1ul << 3)            // enable debugging extensions
+#define X86_CR4_PSE (1ul << 4)           // enable page size extensions
+#define X86_CR4_PAE (1ul << 5)           // enable physical address extensions
+#define X86_CR4_MCE (1ul << 6)           // Machine check enable
+#define X86_CR4_PGE (1ul << 7)           // enable global pages
+#define X86_CR4_PCE (1ul << 8)           // enable performance counters at ipl 3
+#define X86_CR4_OSFXSR (1ul << 9)        // enable fast FPU save and restore
 #define X86_CR4_OSXMMEXCPT (1ul << 10)   // enable unmasked SSE exceptions
-#define X86_CR4_UMIP (1ul << 11)   // enable UMIP support
-#define X86_CR4_VMXE (1ul << 13)   // enable VMX virtualization
-#define X86_CR4_SMXE (1ul << 14)   // enable safer mode (TXT)
-#define X86_CR4_FSGSBASE (1ul << 16)   // enable RDWRFSGS support
-#define X86_CR4_PCIDE (1ul << 17)   // enable PCID support
-#define X86_CR4_OSXSAVE (1ul << 18)   // enable xsave and xrestore
-#define X86_CR4_SMEP (1ul << 20)   // enable SMEP support
-#define X86_CR4_SMAP (1ul << 21)   // enable SMAP support
-#define X86_CR4_PKE (1ul << 22)   // enable Protection Keys support
+#define X86_CR4_UMIP (1ul << 11)         // enable UMIP support
+#define X86_CR4_VMXE (1ul << 13)         // enable VMX virtualization
+#define X86_CR4_SMXE (1ul << 14)         // enable safer mode (TXT)
+#define X86_CR4_FSGSBASE (1ul << 16)     // enable RDWRFSGS support
+#define X86_CR4_PCIDE (1ul << 17)        // enable PCID support
+#define X86_CR4_OSXSAVE (1ul << 18)      // enable xsave and xrestore
+#define X86_CR4_SMEP (1ul << 20)         // enable SMEP support
+#define X86_CR4_SMAP (1ul << 21)         // enable SMAP support
+#define X86_CR4_PKE (1ul << 22)          // enable Protection Keys support
 
 /*
  * Intel SDM, Vol3. Figure 2-5. EFLAGS bits, same RFLAGS per 2.3.1
  */
-#define X86_RFLAGS_CF (1ul << 0)   // Carry Flag
+#define X86_RFLAGS_CF (1ul << 0)      // Carry Flag
 #define X86_RFLAGS_FIXED (1ul << 1)   // Bit 1 - always on
-#define X86_RFLAGS_PF (1ul << 2)   // Parity Flag
-#define X86_RFLAGS_AF (1ul << 4)   // Auxiliary carry Flag
-#define X86_RFLAGS_ZF (1ul << 6)   // Zero Flag
-#define X86_RFLAGS_SF (1ul << 7)   // Sign Flag
-#define X86_RFLAGS_TF (1ul << 8)   // Trap Flag
-#define X86_RFLAGS_IF (1ul << 9)   // Interrupt Flag
-#define X86_RFLAGS_DF (1ul << 10)   // Direction Flag
-#define X86_RFLAGS_OF (1ul << 11)   // Overflow Flag
-#define X86_RFLAGS_IOPL (3ul << 3)   // I/O Privilege Level (2 bits)
-#define X86_RFLAGS_NT (1ul << 14)   // Nested Task
-#define X86_RFLAGS_RF (1ul << 16)   // Resume Flag
-#define X86_RFLAGS_VM (1ul << 17)   // Virtual Mode
-#define X86_RFLAGS_AC (1ul << 18)   // Alignment Check/Access Control
-#define X86_RFLAGS_VIF (1ul << 19)   // Virtual Interrupt Flag
-#define X86_RFLAGS_VIP (1ul << 20)   // Virtual Interrupt Pending
-#define X86_RFLAGS_ID (1ul << 21)   // CPUID detection
+#define X86_RFLAGS_PF (1ul << 2)      // Parity Flag
+#define X86_RFLAGS_AF (1ul << 4)      // Auxiliary carry Flag
+#define X86_RFLAGS_ZF (1ul << 6)      // Zero Flag
+#define X86_RFLAGS_SF (1ul << 7)      // Sign Flag
+#define X86_RFLAGS_TF (1ul << 8)      // Trap Flag
+#define X86_RFLAGS_IF (1ul << 9)      // Interrupt Flag
+#define X86_RFLAGS_DF (1ul << 10)     // Direction Flag
+#define X86_RFLAGS_OF (1ul << 11)     // Overflow Flag
+#define X86_RFLAGS_IOPL (3ul << 3)    // I/O Privilege Level (2 bits)
+#define X86_RFLAGS_NT (1ul << 14)     // Nested Task
+#define X86_RFLAGS_RF (1ul << 16)     // Resume Flag
+#define X86_RFLAGS_VM (1ul << 17)     // Virtual Mode
+#define X86_RFLAGS_AC (1ul << 18)     // Alignment Check/Access Control
+#define X86_RFLAGS_VIF (1ul << 19)    // Virtual Interrupt Flag
+#define X86_RFLAGS_VIP (1ul << 20)    // Virtual Interrupt Pending
+#define X86_RFLAGS_ID (1ul << 21)     // CPUID detection
 
-#define X86_XCR0_X87 (1ul << 0)   // x87 FPU/MMU state
-#define X86_XCR0_SSE (1ul << 1)   // SSE state
-#define X86_XCR0_AVX (1ul << 2)   // AVX state
-#define X86_XCR0_BNDREGS (1ul << 3)   // BNDREG state
-#define X86_XCR0_BNDCSR (1ul << 4)   // BMDCSR state
-#define X86_XCR0_OPMASK (1ul << 5)   // OPMASK state
+#define X86_XCR0_X87 (1ul << 0)         // x87 FPU/MMU state
+#define X86_XCR0_SSE (1ul << 1)         // SSE state
+#define X86_XCR0_AVX (1ul << 2)         // AVX state
+#define X86_XCR0_BNDREGS (1ul << 3)     // BNDREG state
+#define X86_XCR0_BNDCSR (1ul << 4)      // BMDCSR state
+#define X86_XCR0_OPMASK (1ul << 5)      // OPMASK state
 #define X86_XCR0_ZMM_HI256 (1ul << 6)   // ZMM HI256 FPU/MMU
-#define X86_XCR0_HI16_ZMM (1ul << 7)   // HI16 ZMM state
-#define X86_XCR0_PKRU (1ul << 9)   // PKRU state
+#define X86_XCR0_HI16_ZMM (1ul << 7)    // HI16 ZMM state
+#define X86_XCR0_PKRU (1ul << 9)        // PKRU state
 
 #define X86_XCR0_MASK                                                                              \
    (X86_XCR0_PKRU | X86_XCR0_HI16_ZMM | X86_XCR0_ZMM_HI256 | X86_XCR0_OPMASK | X86_XCR0_BNDCSR |   \
@@ -250,24 +250,24 @@ typedef struct x86_pte_4k {
 /*
  * Intel CPU features in EFER
  */
-#define X86_EFER_SCE (1ul << 0)   // SYSCALL/SYSRET
-#define X86_EFER_LME (1ul << 8)   // Long mode enable (R/W)
+#define X86_EFER_SCE (1ul << 0)    // SYSCALL/SYSRET
+#define X86_EFER_LME (1ul << 8)    // Long mode enable (R/W)
 #define X86_EFER_LMA (1ul << 10)   // Long mode active (R/O)
-#define X86_EFER_NX (1ul << 11)   // No execute enable
+#define X86_EFER_NX (1ul << 11)    // No execute enable
 
 /*
  * Protected-Mode Exceptions and Interrupts
  * Intel SDM Table 6-1
  */
-#define X86_INTR_DE (0)   // Divide Error
-#define X86_INTR_DB (1)   // Debug Exception
+#define X86_INTR_DE (0)    // Divide Error
+#define X86_INTR_DB (1)    // Debug Exception
 #define X86_INTR_NMI (2)   // NMI
-#define X86_INTR_BP (3)   // Breakpoint
-#define X86_INTR_OF (4)   // Overflow
-#define X86_INTR_BR (5)   // BOUND Range Exceeded
-#define X86_INTR_UD (6)   // Invalid Opcode (Undefined Opcode)
-#define X86_INTR_NM (7)   // Device Not Available (No Math Coprocessor)
-#define X86_INTR_DF (8)   // Double Fault (includes error, always 0)
+#define X86_INTR_BP (3)    // Breakpoint
+#define X86_INTR_OF (4)    // Overflow
+#define X86_INTR_BR (5)    // BOUND Range Exceeded
+#define X86_INTR_UD (6)    // Invalid Opcode (Undefined Opcode)
+#define X86_INTR_NM (7)    // Device Not Available (No Math Coprocessor)
+#define X86_INTR_DF (8)    // Double Fault (includes error, always 0)
 // 9 Intel Reserved. Post 386 processors do not generate.
 #define X86_INTR_TS (10)   // Invalid TSS (includes error)
 #define X86_INTR_NP (11)   // Segment Not Present (includes error)


### PR DESCRIPTION
Upgraded my local Linux system from Fedora 33 to Fedora 34. That upgraded me to clang-format 12 which gave a bunch more checks. This is fixes from running `clang-format -i km/*.h km/*.c`.