### PR TITLE
vfork

### DIFF
--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -2104,6 +2104,7 @@ const km_hcall_fn_t km_hcalls_table[KM_MAX_HCALL] = {
     [SYS_execve] = execve_hcall,
     [SYS_execveat] = execveat_hcall,
     [SYS_fork] = fork_hcall,
+    [SYS_vfork] = fork_hcall,
     [SYS_wait4] = wait4_hcall,
     [SYS_waitid] = waitid_hcall,
     [SYS_times] = times_hcall,


### PR DESCRIPTION
Turns our java uses vfork hcall for java.lang.Runtime.exec(). This makes vfork do the same thing as fork.