### PR TITLE
make snapshot kontainer for spingboot demo

### DIFF
--- a/demo/spring-boot/Makefile
+++ b/demo/spring-boot/Makefile
@@ -51,7 +51,6 @@ DEMO_CONTAINER ?= kontainapp_sprint_boot_demo
 # Docker requires relative path to the building context
 build/demo: TARGET_JAR_PATH := $(shell realpath --canonicalize-missing --relative-to="${CURRENT_DIR}" "${APP_JAR}")
 build/demo: clean/image
-	mkdir -p empty_tmp
 	${DOCKER_BUILD} -t ${DEMO_IMAGE} --build-arg TARGET_JAR_PATH=${TARGET_JAR_PATH} -f kontain.dockerfile ${CURRENT_DIR}
 
 run_demo = ${DOCKER_RUN} ${DOCKER_KRUN_RUNTIME} -d -v $$(pwd):/mnt:z -p ${DEFAULT_DEMO_PORT}:8080 --name ${DEMO_CONTAINER} ${DEMO_IMAGE} /run.sh

--- a/demo/spring-boot/README.md
+++ b/demo/spring-boot/README.md
@@ -75,6 +75,49 @@ Inside the container run
 
 Same as before, the time difference between the first response and the server start will be printed as `Response time 1.432 secs`
 
+## How to package snapshot as a kontainer
+
+### Step 1 - Build Everything
+
+Same as in the demo
+
+### Step 2 - Start the kontainer
+
+```bash
+docker run --runtime=krun --name=KM_SpringBoot_Demo \
+  -v /opt/kontain/bin/km_cli:/opt/kontain/bin/km_cli \
+  -v $(pwd):/mnt:rw -p8080:8080 kontainapp/spring-boot-demo
+```
+
+### Step 3 - Serve a request, take a snapshot, and make snap kontainer
+
+Send a request using curl, one or a few times:
+
+```bash
+curl http://localhost:8080/greeting | jq .
+```
+
+Make a snapshot and copy it from the container:
+
+```bash
+docker exec KM_SpringBoot_Demo /opt/kontain/bin/km_cli -s /tmp/km.sock
+docker cp KM_SpringBoot_Demo:kmsnap .
+chmod +x kmsnap
+docker build -t kontainapp/snap_spring-boot-demo -f snap_kontain.dockerfile .
+```
+
+### Step4 - Run the new kontainer
+
+```bash
+docker run --runtime=krun --rm -it --name=KM_Snap_SpringBoot_Demo -p8080:8080 kontainapp/snap_spring-boot-demo
+```
+
+Verify the response, confirm the id number continues from the initial run
+
+```bash
+curl http://localhost:8080/greeting | jq .
+```
+
 ## References:
 
 `https://spring.io/quickstart`

--- a/demo/spring-boot/kontain.dockerfile
+++ b/demo/spring-boot/kontain.dockerfile
@@ -17,6 +17,6 @@ FROM kontainapp/runenv-jdk-11.0.8:latest
 ARG TARGET_JAR_PATH
 COPY ${TARGET_JAR_PATH} /app.jar
 COPY run.sh run_snap.sh /
-ADD empty_tmp /tmp/
 EXPOSE 8080/tcp
+ENV KM_MGTPIPE=/tmp/km.sock
 CMD ["/opt/kontain/java/bin/java", "-XX:-UseCompressedOops", "-jar", "/app.jar"]

--- a/demo/spring-boot/snap_kontain.dockerfile
+++ b/demo/spring-boot/snap_kontain.dockerfile
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM scratch
-ENV HOME /root
-# turn off km symlink trick and minimal shell interpretation
-ENV KM_DO_SHELL NO
-ADD --chown=0:0 busybox/_install /
-ADD empty_tmp /tmp/
+FROM kontainapp/spring-boot-demo
+ARG TARGET_SNAP=kmsnap
+COPY ${TARGET_SNAP} /kmsnap
+EXPOSE 8080/tcp
+ENV KM_MGTPIPE=/tmp/km.snap_sock
+CMD ["/kmsnap"]

--- a/payloads/busybox/.gitignore
+++ b/payloads/busybox/.gitignore
@@ -1,1 +1,2 @@
 busybox
+empty_tmp

--- a/payloads/busybox/Makefile
+++ b/payloads/busybox/Makefile
@@ -70,5 +70,6 @@ RUNENV_TAG := ${COMPONENT}
 
 export define runenv_prep
 	tar -cf - ${PAYLOAD_FILES} | tar -C $(RUNENV_PATH) -xf -
+	mkdir -p $(RUNENV_PATH)/empty_tmp && rm -rf $(RUNENV_PATH)/empty_tmp/* && chmod a+rwx $(RUNENV_PATH)/empty_tmp
 endef
 include ${TOP}/make/images.mk


### PR DESCRIPTION
Mostly documentation and snapshot container dockerfile. Minor cleanup in runenv-images - add `/tmp`to the base so no ned to add it separately for all payloads.