### PR TITLE
fix testenv for node

### DIFF
--- a/payloads/node/.dockerignore
+++ b/payloads/node/.dockerignore
@@ -6,6 +6,7 @@
 !km
 !node/out/Release/*.km
 !node/out/Debug/*.km
+!node/benchmark
 !node/deps
 !node/tools
 !node/test

--- a/payloads/node/skip_unknown_hang
+++ b/payloads/node/skip_unknown_hang
@@ -1,1 +1,4 @@
 sequential/test-net-bytes-per-incoming-chunk-overhead.js
+
+parallel/test-cluster-primary-error.js
+parallel/test-cluster-primary-kill.js


### PR DESCRIPTION
Added files for one test.
Skip two more - they pass on the desktop and in the CI other than the new nightly cluster, suspecting just not enough time