### PR TITLE
CI: run minikube tests before sending status

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -538,7 +538,7 @@ jobs:
     if: (failure() && github.ref == 'refs/heads/master') ||
       contains(github.workflow, 'noisy')
     # Dependencies. (A skipped dependency is considered satisfied)
-    needs: [km-build, krun-static-build, kkm-build, km-test, km-test-withpacker, kkm-test, kkm-test-vms, km-krun-validate-runenv, km-krun-kkm-validate-runenv, km-test-all]
+    needs: [km-build, krun-static-build, kkm-build, km-test, km-test-withpacker, kkm-test, kkm-test-vms, km-krun-validate-runenv, km-krun-kkm-validate-runenv, km-test-all, minikube-testing]
     steps:
       - name: Send notification to slack
         uses: Gamesight/slack-workflow-status@master


### PR DESCRIPTION
Fixed #1451 