### PR TITLE
switch to ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ It also executes a smoke test of the unikernel virtual machine.
 Currently, the only way run Kontain on MacOS or Windows is to run it in a Linux VM[<sup>2</sup>](#2).
 To simplify running Kontain we provide pre-configured VMs available from Vagrant Cloud:
 
-* Ubuntu 20.10 – https://app.vagrantup.com/kontain/boxes/ubuntu2010-kkm-beta3
+* Ubuntu 20.04 – https://app.vagrantup.com/kontain/boxes/ubuntu2004-kkm-beta3
 * Fedora 32 – https://app.vagrantup.com/kontain/boxes/fedora32-kkm-beta3
 
 You’ll need Vagrant ([https://www.vagrantup.com](https://www.vagrantup.com))
 and VirtualBox ([https://www.VirtualBox.org](https://www.VirtualBox.org)) installed on your machine.
 
-Once the VM is up (`vagrant init kontain/ubuntu2010-kkm-beta3; vagrant up`) and logged in (`vagrant ssh`),
+Once the VM is up (`vagrant init kontain/ubuntu2004-kkm-beta3; vagrant up`) and logged in (`vagrant ssh`),
 you have Kontain installed and configured.
 
 ## Starting with Kontain

--- a/cloud/azure/scripts/L0-image-provision.sh
+++ b/cloud/azure/scripts/L0-image-provision.sh
@@ -57,7 +57,7 @@ usermod -aG docker $USER
 #  need to defined in makefile and pass around as env
 
 # uncomment this to preinstall vagrant boxes
-# preinstall_boxes="generic/ubuntu2010 generic/fedora32"
+# preinstall_boxes="generic/ubuntu2004 generic/fedora32"
 for box in $preinstall_boxes
 do
    vagrant box add  $box --provider=virtualbox --box-version 3.2.24

--- a/cloud/azure/scripts/vagrant-box.sh
+++ b/cloud/azure/scripts/vagrant-box.sh
@@ -21,7 +21,7 @@
 # cp files from /tmp
 # make sure Makefile does not try to build
 # move boxes pre-load to local shell provisioner from Makefile
-#      if (missing) vagrant box add generic/ubuntu2010 --provider=virtualbox
+#      if (missing) vagrant box add generic/ubuntu2004 --provider=virtualbox
 # pass GITHUB_TOKEN and VAGRANT_CLOUD_TOKEN
 # clone
 # preload proper boxes in base image

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@
 
     Kontain code is open source under Apache 2.0 license.
 
-    We also maintain binary releases in the form of vagrant boxes (Fedora 32 and Ubuntu 2010) and an EC2 AMI.
+    We also maintain binary releases in the form of vagrant boxes (Fedora 32 and Ubuntu 2004) and an EC2 AMI.
 
     We are more than happy to collaborate with people who would like to hack on the code with us! Get in touch by opening an issue or emailing us: community@kontain.app
 
@@ -16,7 +16,7 @@
 
 *   Is the Kontain Vagrant box only available through VirtualBox?
 
-    Currently, VirtualBox is the only provider for the `kontain/ubuntu2010-kkm-beta3` and `kontain/fedora32-kkm-beta3` boxes.
+    Currently, VirtualBox is the only provider for the `kontain/ubuntu2004-kkm-beta3` and `kontain/fedora32-kkm-beta3` boxes.
     If you'd like to suggest a different provider, please submit an issue.
 
 *   What can I use for virtualization if I don’t have access to KVM?

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -122,7 +122,7 @@ What’s in this section:
 For a quick and easy way to start exploring Kontain, we prepared Ubuntu and Fedora VMs in Vagrant Cloud: [https://app.vagrantup.com/kontain](https://app.vagrantup.com/kontain)
 We recommend that you run one of the prepared VMs.
 The Vagrant VM brings a fully functional Kontain environment onto your desktop or laptop and provides a stable platform for exploration and validation:
-*   Ubuntu 20.10 (or Fedora32)
+*   Ubuntu 20.04 (or Fedora32)
 *   Kontain pre-installed
 *   KKM (Kontain kernel module) to support nested virtualization
 *   Docker pre-installed and configured for use with Kontain
@@ -134,9 +134,9 @@ Prerequisite: Both [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https:
     mkdir try-kontain
     cd try-kontain
     ```
-2. Run `kontain/ubuntu2010-kkm-beta3` (there is also `kontain/fedora32-kkm-beta3 if preferred`) from Vagrant Cloud:
+2. Run `kontain/ubuntu2004-kkm-beta3` (there is also `kontain/fedora32-kkm-beta3 if preferred`) from Vagrant Cloud:
     ```
-    vagrant init kontain/ubuntu2010-kkm-beta3 (or kontain/fedora32-kkm-beta3)
+    vagrant init kontain/ubuntu2004-kkm-beta3 (or kontain/fedora32-kkm-beta3)
     vagrant up --provider=virtualbox
     vagrant ssh
     ```
@@ -712,7 +712,7 @@ For more information about Kontain debugging, see this guide: [*Debugging Kontai
 
 ### Using a Kontain AMI on AWS
 
-For AWS non-metal installations, Kontain provides an AWS AMI with Ubuntu 20.10, Kontain, and Docker pre-installed. A KKM module (included) enables virtualization.
+For AWS non-metal installations, Kontain provides an AWS AMI with Ubuntu 20.04, Kontain, and Docker pre-installed. A KKM module (included) enables virtualization.
 
 This is a public AMI with the following attributes:
 

--- a/docs/vms_packer_in_ci_and_more.md
+++ b/docs/vms_packer_in_ci_and_more.md
@@ -198,7 +198,7 @@ Packer configs for creating vagrant box and AMI with KM preinstalled, and upload
 ./tools/hashicorp/aws_ami_templates/ubuntu-aws.pkr.hcl
 ./tools/hashicorp/aws_ami_templates/config.pkr.hcl
 ./tools/hashicorp/test_box_upload.pkr.hcl
-./tools/hashicorp/box_images_templates/ubuntu2010.pkrvars.hcl
+./tools/hashicorp/box_images_templates/ubuntu2004.pkrvars.hcl
 ./tools/hashicorp/box_images_templates/build_km_images.pkr.hcl
 ./tools/hashicorp/box_images_templates/fedora32.pkrvars.hcl
 ./tools/hashicorp/test_ami_upload.pkr.hcl

--- a/tools/hashicorp/Makefile
+++ b/tools/hashicorp/Makefile
@@ -22,7 +22,7 @@ include ${TOP}/make/actions.mk
 all: vm-images
 
 # Use these boxes as sources for our boxes builds. (`generic/$os' is the box)
-SRC_OS := ubuntu2010 fedora32
+SRC_OS := ubuntu2004 fedora32
 # Note: SRC_OS needs to be synced with os_name in *pkrvars.hcl files
 ARTIFACTS := ${TOP}/build/kkm.run ${TOP}/build/kontain.tar.gz
 
@@ -34,13 +34,13 @@ product: ${ARTIFACTS} ## Prepares KM packaging artifacts (e.g. km tarball and kk
 	echo $(MAKE) MAKEFLAGS=$(MAKEFLAGS) -C ${TOP} release
 
 vm-images: .check_packer .check_tools product ## loads source boxes and creates boxes with KM installed
-	@set -x ; for os in ${SRC_OS} ; \
+	@set -ex ; for os in ${SRC_OS} ; \
 	do \
 		${PACKER_BUILD} -var-file box_images_templates/$$os.pkrvars.hcl box_images_templates ; \
 	done
 
 upload-boxes: .check_tools ## uploads pre-created boxes to vagrant cloud
-	for os in ${SRC_OS} ; \
+	@set -ex ; for os in ${SRC_OS} ; \
 	do \
 		vagrant cloud publish --force --no-private --release --description "$$os with Kontain installed" --short-description "$$os with KKM" \
 			kontain/$${os}-kkm-beta3 $${RELEASE_TAG#v} virtualbox output_box_$${os}/package.box ; \

--- a/tools/hashicorp/box_images_templates/ubuntu2004.pkrvars.hcl
+++ b/tools/hashicorp/box_images_templates/ubuntu2004.pkrvars.hcl
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 os = "ubuntu"
-os_name = "ubuntu2010"
-box_name = "generic/ubuntu2010"
+os_name = "ubuntu2004"
+box_name = "generic/ubuntu2004"
 box_version = "3.2.24"

--- a/tools/hashicorp/scripts/ubuntu.install_km.sh
+++ b/tools/hashicorp/scripts/ubuntu.install_km.sh
@@ -27,6 +27,7 @@ ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
 # Install Docker
 # docker repo
+apt-get update -y -q
 apt-get install -y -q apt-transport-https ca-certificates \
       curl gnupg-agent software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 2>&1

--- a/tools/hashicorp/test_ami_upload.pkr.hcl
+++ b/tools/hashicorp/test_ami_upload.pkr.hcl
@@ -40,7 +40,7 @@ packer {
 variable "ova_name" {
   type        = string
   description = "name of OVA file to upload as AMI"
-  default     = "output_ova_ubuntu2010-kkm/ubuntu2010-kkm.ova"
+  default     = "output_ova_ubuntu2004-kkm/ubuntu2004-kkm.ova"
 }
 
 locals {

--- a/tools/hashicorp/test_box_upload.pkr.hcl
+++ b/tools/hashicorp/test_box_upload.pkr.hcl
@@ -17,7 +17,7 @@
 // to run: packer build <this_file_name>
 
 locals {
-  box       = "box/ubuntu2010-kkm.box" // Local box file name to upload to cloud
+  box       = "box/ubuntu2004-kkm.box" // Local box file name to upload to cloud
   box_tag   = "kontain/upload-test"    // Box to upload to - must already exist
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
 }


### PR DESCRIPTION
Ubuntu 2010 is deprecated. Our release box for ubuntu didn't build for v0.9.4 because repositories are closed. We also use 2010 in some internal builds. I'm replacing it with 20.04 which is LTS. Also rebuilding the base image for tests.

The failure was hidden, hopefully it won't be any more