### PR TITLE
Change km to use krun based on crun 1.4.2

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -177,7 +177,7 @@ jobs:
           # These next two lines were taken from the crun release.yaml and build-aux/release.sh
           # to setup and execute a nix based build of stripped static
           if [[ -z $(ls -A /nix) ]]; then sudo docker run --rm --privileged -v /:/mnt nixos/nix:2.3.12 cp -rfT /nix /mnt/nix; fi
-          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix:2.3.12 nix build --print-build-logs --file nix/ --arg enableSystemd false
+          sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix:2.3.12 nix build --print-build-logs --file nix/
           mkdir -p /tmp/krun-static
           cp ${CRUN_DIR}/result/bin/crun /tmp/krun-static/krun.static
 

--- a/container-runtime/Makefile
+++ b/container-runtime/Makefile
@@ -46,7 +46,7 @@ all:	$(CRUNDIR)/Makefile .makefile_check
 	ln -f ${BLDDIR}/crun ${BLDDIR}/krun
 
 $(CRUNDIR)/Makefile:
-	cd $(CRUNDIR); ./autogen.sh; ./configure --disable-systemd
+	cd $(CRUNDIR); ./autogen.sh; ./configure
 
 # Run crun's tests
 test:	all


### PR DESCRIPTION
In addition we now build krun with systemd support enabled.
Change krun static build to include systemd support too.
This requires a buildenv-image that contains the systemd-devel package.
Another PR was used to add systemd-devel to buildenv-image.
And, that buildenv-image has been pushed to our azure container repository.