### PR TITLE
enable codeql extended security checks

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -603,8 +603,8 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # TODO: Enable enhanced security checks.
-        # queries: security-extended
+        # enhanced security checks.
+        queries: security-extended
 
     - run: |
        make -C km all

--- a/km/km.h
+++ b/km/km.h
@@ -577,6 +577,11 @@ static inline void km_warnx(const char *fmt, ...)
   __km_trace(0, __FUNCTION__, __LINE__, fmt, ap);
 }
 
+static inline void km_warnx_va(const char *fmt, va_list ap)
+{
+  __km_trace(0, __FUNCTION__, __LINE__, fmt, ap);
+}
+
 __attribute__((__format__(__printf__, 1, 2)))
 static inline void km_warn(const char *fmt, ...)
 {

--- a/km/km.h
+++ b/km/km.h
@@ -22,6 +22,7 @@
 #include <pthread.h>
 #include <regex.h>
 #include <signal.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -429,8 +430,7 @@ static inline void km_vcpu_sync_rip(km_vcpu_t* vcpu)
 
 extern FILE* km_log_file;
 
-void __km_trace(int errnum, const char* function, int linenumber, const char* fmt, ...)
-    __attribute__((__format__(__printf__, 4, 5)));
+void __km_trace(int errnum, const char* function, int linenumber, const char* fmt, va_list ap);
 void km_trace_include_pid(uint8_t trace_pid);
 uint8_t km_trace_include_pid_value(void);
 void km_trace_set_noninteractive(void);
@@ -492,73 +492,116 @@ void km_trace_setup(int argc, char* argv[], char* payload_name);
 
 extern int km_collect_hc_stats;
 
-#define km_trace_enabled() (km_info_trace.level != KM_TRACE_NONE)      // 1 for yes, 0 for no
-#define km_trace_enabled_tag() (km_info_trace.level == KM_TRACE_TAG)   // 1 for yes, 0 for no
+static inline int km_trace_enabled()
+{
+  return (km_info_trace.level != KM_TRACE_NONE);      // 1 for yes, 0 for no
+}
 
-#define km_trace_tag_enabled(tag)                                                                  \
-   (km_trace_enabled() &&                                                                          \
-    (km_trace_enabled_tag() == 0 || regexec(&km_info_trace.tags, tag, 0, NULL, 0) == 0))
+static inline int km_trace_enabled_tag()
+{
+  return (km_info_trace.level == KM_TRACE_TAG);   // 1 for yes, 0 for no
+}
+
+static inline int km_trace_tag_enabled(const char *tag)
+{
+   return (km_trace_enabled() &&
+          (km_trace_enabled_tag() == 0 || regexec(&km_info_trace.tags, tag, 0, NULL, 0) == 0));
+}
 
 // Trace something if tag matches, and add perror() output to end of the line.
-#define km_info(tag, fmt, ...)                                                                     \
-   do {                                                                                            \
-      if (km_trace_tag_enabled(tag) != 0)                                                          \
-         __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                            \
-   } while (0)
+__attribute__((__format__(__printf__, 2, 3)))
+static inline void km_info(const char *tag, const char *fmt, ...)
+{
+  if (km_trace_tag_enabled(tag) != 0) {
+    va_list ap;
+    va_start(ap, fmt);
+    __km_trace(errno, __FUNCTION__, __LINE__, fmt, ap);
+  }
+}
 
 // Trace something to stderr but don't include perror() output.
-#define km_infox(tag, fmt, ...)                                                                    \
-   do {                                                                                            \
-      if (km_trace_tag_enabled(tag) != 0)                                                          \
-         __km_trace(0, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                                \
-   } while (0)
+__attribute__((__format__(__printf__, 2, 3)))
+static inline void km_infox(const char *tag, const char *fmt, ...)
+{
+  if (km_trace_tag_enabled(tag) != 0) {
+    va_list ap;
+    va_start(ap, fmt);
+    __km_trace(0, __FUNCTION__, __LINE__, fmt, ap);
+  }
+}
 
 // trace no matter what the tag is, but only if -V is enabled
-#define km_trace(fmt, ...)                                                                         \
-   do {                                                                                            \
-      if (km_trace_enabled() != 0)                                                                 \
-         __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                            \
-   } while (0)
+__attribute__((__format__(__printf__, 1, 2)))
+static inline void km_trace(const char *fmt, ...)
+{
+  if (km_trace_enabled() != 0) {
+    va_list ap;
+    va_start(ap, fmt);
+    __km_trace(errno, __FUNCTION__, __LINE__, fmt, ap);
+  }
+}
 
-#define km_tracex(fmt, ...)                                                                        \
-   do {                                                                                            \
-      if (km_trace_enabled() != 0)                                                                 \
-         __km_trace(0, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                                \
-   } while (0)
+__attribute__((__format__(__printf__, 1, 2)))
+static inline void km_tracex(const char *fmt, ...)
+{
+  if (km_trace_enabled() != 0) {
+    va_list ap;
+    va_start(ap, fmt);
+    __km_trace(0, __FUNCTION__, __LINE__, fmt, ap);
+  }
+}
 
-#define km_errx(exit_status, fmt, ...)                                                             \
-   do {                                                                                            \
-      __km_trace(0, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                                   \
-      exit(exit_status);                                                                           \
-   } while (0)
+__attribute__((__format__(__printf__, 2, 3)))
+static inline void  km_errx(int exit_status, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  __km_trace(exit_status, __FUNCTION__, __LINE__, fmt, ap);
+  exit(exit_status);
+}
 
-#define km_err(exit_status, fmt, ...)                                                              \
-   do {                                                                                            \
-      __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                               \
-      exit(exit_status);                                                                           \
-   } while (0)
+__attribute__((__format__(__printf__, 2, 3)))
+static inline void  km_err(int exit_status, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  __km_trace(errno, __FUNCTION__, __LINE__, fmt, ap);
+  exit(exit_status);
+}
 
-#define km_warnx(fmt, ...)                                                                         \
-   do {                                                                                            \
-      __km_trace(0, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                                   \
-   } while (0)
+__attribute__((__format__(__printf__, 1, 2)))
+static inline void km_warnx(const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  __km_trace(0, __FUNCTION__, __LINE__, fmt, ap);
+}
 
-#define km_warn(fmt, ...)                                                                          \
-   do {                                                                                            \
-      __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                               \
-   } while (0)
+__attribute__((__format__(__printf__, 1, 2)))
+static inline void km_warn(const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  __km_trace(errno, __FUNCTION__, __LINE__, fmt, ap);
+}
 
-#define km_abortx(fmt, ...)                                                                        \
-   do {                                                                                            \
-      __km_trace(0, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                                   \
-      abort();                                                                                     \
-   } while (0)
+__attribute__((__format__(__printf__, 1, 2)))
+static inline void km_abortx(const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  __km_trace(0, __FUNCTION__, __LINE__, fmt, ap);
+  abort();
+}
 
-#define km_abort(fmt, ...)                                                                         \
-   do {                                                                                            \
-      __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                               \
-      abort();                                                                                     \
-   } while (0)
+__attribute__((__format__(__printf__, 1, 2)))
+static inline void km_abort(const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  __km_trace(errno, __FUNCTION__, __LINE__, fmt, ap);
+  abort();
+}
 
 #define km_mutex_lock(mutex)                                                                       \
    do {                                                                                            \

--- a/km/km.h
+++ b/km/km.h
@@ -138,7 +138,7 @@ typedef enum {
 } __attribute__((__packed__)) km_vcpu_state_t;
 
 typedef struct km_vcpu {
-   int vcpu_id;                        // uniq ID
+   short vcpu_id;                        // uniq ID
    int kvm_vcpu_fd;                    // this VCPU file descriptor
    kvm_run_t* cpu_run;                 // run control region
    pthread_t vcpu_thread;              // km pthread

--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -815,7 +815,7 @@ void km_dump_core(char* core_path,
    km_gva_t end_load = 0;
    int phnum = km_core_count_phdrs(vcpu, &end_load);
 
-   if ((fd = open(core_path, O_RDWR | O_CREAT | O_TRUNC, 0666)) < 0) {
+   if ((fd = open(core_path, O_RDWR | O_CREAT | O_TRUNC, 0600)) < 0) {
       km_err(2, "Cannot open corefile '%s', exiting", core_path);
    }
    km_warnx("Write %s to '%s'", dumptype == KM_DO_SNAP ? "snapshot" : "coredump", core_path);

--- a/km/km_exec.c
+++ b/km/km_exec.c
@@ -756,6 +756,10 @@ int km_exec_recover_kmstate(void)
       km_infox(KM_TRACE_EXEC, "exec state verion mismatch, got %d, expect %d", version, KM_EXEC_VERNUM);
       return -1;
    }
+   if (nfdmap > MAX_OPEN_FILES - MAX_KM_FILES) {
+      km_infox(KM_TRACE_EXEC, "exec stat too many open files %d", nfdmap);
+      return -1;
+   }
    if ((execstatep = calloc(1, sizeof(*execstatep) + (sizeof(km_file_t) * nfdmap))) == NULL) {
       km_infox(KM_TRACE_EXEC, "couldn't allocate fd map, nfdmap %d", nfdmap);
       return -1;

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -54,9 +54,6 @@
 #include "km_snapshot.h"
 #include "km_syscall.h"
 
-static const int MAX_OPEN_FILES = 1024;
-static const int MAX_KM_FILES = KVM_MAX_VCPUS + 2 + 2 + 2 + 2 + 1;   // eventfds, kvm, gdb, snap, log
-
 static const int KM_GDB_LISTEN = MAX_OPEN_FILES - MAX_KM_FILES;
 static const int KM_GDB_ACCEPT = MAX_OPEN_FILES - MAX_KM_FILES + 1;
 static const int KM_MGM_LISTEN = MAX_OPEN_FILES - MAX_KM_FILES + 2;

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -46,6 +46,9 @@
 #include "km_mem.h"
 #include "km_syscall.h"
 
+static const int MAX_OPEN_FILES = 1024;
+static const int MAX_KM_FILES = KVM_MAX_VCPUS + 2 + 2 + 2 + 2 + 1;   // eventfds, kvm, gdb, snap, log
+
 // types for file names conversion
 typedef int (*km_file_open_t)(const char* guest_fn, char* host_fn, size_t host_fn_sz);
 typedef int (*km_file_readlink_t)(const char* guest_fn, char* buf, size_t buf_sz);

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -63,7 +63,7 @@ typedef struct {
 } km_file_ops_t;
 
 typedef struct {
-   char* const pattern;
+   const char* const pattern;
    km_file_ops_t ops;
    regex_t regex;
 } km_filename_table_t;

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -63,7 +63,7 @@ typedef struct {
 } km_file_ops_t;
 
 typedef struct {
-   char* pattern;
+   const char* pattern;
    km_file_ops_t ops;
    regex_t regex;
 } km_filename_table_t;

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -63,7 +63,7 @@ typedef struct {
 } km_file_ops_t;
 
 typedef struct {
-   const char* pattern;
+   char* const pattern;
    km_file_ops_t ops;
    regex_t regex;
 } km_filename_table_t;

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -2751,7 +2751,9 @@ static void gdb_handle_remote_commands(gdb_event_t* gep)
          }
          case 'M': {   // Write memory content
             assert(strlen(packet) <= sizeof(obuf));
-            if (sscanf(packet, "M%" PRIx64 ",%zx:%s", &addr, &len, obuf) != 3) {
+            char format[32];
+            snprintf(format, sizeof(format), "M%%" PRIx64 ",%%zx:%%%lds", sizeof(obuf) - 1);
+            if (sscanf(packet, format, &addr, &len, obuf) != 3) {
                send_error_msg();
                break;
             }

--- a/km/km_management.c
+++ b/km/km_management.c
@@ -70,7 +70,7 @@ void km_mgt_init(char* path)
    if (strlen(path) + 1 > sizeof(addr.sun_path)) {
       km_errx(2, "mgmt path too long");
    }
-   strcpy(addr.sun_path, path);
+   strncpy(addr.sun_path, path, sizeof(addr.sun_path));
 
    if ((sock = km_mgt_listen(AF_UNIX, SOCK_STREAM, 0)) < 0) {
       km_err(2, "mgt socket(2)");

--- a/km/km_trace.c
+++ b/km/km_trace.c
@@ -64,7 +64,7 @@ static inline void km_trace_open_log_on_demand(void)
  * which we feed to fputs() in the hope that trace lines are not broken when multiple threads are
  * tracing concurrently.
  */
-void __km_trace(int errnum, const char* function, int linenumber, const char* fmt, ...)
+void __km_trace(int errnum, const char* function, int linenumber, const char* fmt, va_list ap)
 {
    char traceline[512];
    char threadname[16];
@@ -72,11 +72,8 @@ void __km_trace(int errnum, const char* function, int linenumber, const char* fm
    struct timespec ts;
    struct tm tm;
    char* p;
-   va_list ap;
 
    km_trace_open_log_on_demand();
-
-   va_start(ap, fmt);
 
    km_getname_np(pthread_self(), threadname, sizeof(threadname));
    clock_gettime(CLOCK_REALTIME, &ts);

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -38,37 +38,19 @@
 int vcpu_dump = 0;
 int km_collect_hc_stats = 0;
 
-static const_string_t fx = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
+#define fx "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx "
 
-#define __run_err(vcpu, __s, __f, ...)                                                                 \
-   do {                                                                                                \
-      char fmt[strlen(__f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];                        \
-      fmt[0] = 0;                                                                                      \
-      strcat(fmt, __f);                                                                                \
-      strcat(fmt, fx);                                                                                 \
-      km_err(__s, fmt, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2); \
-   } while (0)
+#define __run_err(vcpu, __s, __f, ...)                                                             \
+   km_err(__s, __f fx, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2);
 
-#define __run_errx(vcpu, __s, __f, ...)                                                                 \
-   do {                                                                                                 \
-      char fmt[strlen(__f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];                         \
-      fmt[0] = 0;                                                                                       \
-      strcat(fmt, __f);                                                                                 \
-      strcat(fmt, fx);                                                                                  \
-      km_errx(__s, fmt, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2); \
-   } while (0)
+#define __run_errx(vcpu, __s, __f, ...)                                                            \
+   km_errx(__s, __f fx, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2);
 
 #define run_err(__s, __f, ...) __run_err(vcpu, __s, __f, ##__VA_ARGS__)
 #define run_errx(__s, __f, ...) __run_errx(vcpu, __s, __f, ##__VA_ARGS__)
 
-#define __run_warn(vcpu, __f, ...)                                                                  \
-   do {                                                                                             \
-      char fmt[strlen(__f) + strlen(fx) + 3 * strlen("1234567890123456") + 64];                     \
-      fmt[0] = 0;                                                                                   \
-      strcat(fmt, __f);                                                                             \
-      strcat(fmt, fx);                                                                              \
-      km_warnx(fmt, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2); \
-   } while (0)
+#define __run_warn(vcpu, __f, ...)                                                                 \
+   km_warnx(__f fx, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2);
 
 
 // only show this for verbose ('-V') runs

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -70,7 +70,6 @@ static const_string_t fx = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
       km_warnx(fmt, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2); \
    } while (0)
 
-#define run_warn(__f, ...) __run_warn(vcpu, __f, ##__VA_ARGS__)
 
 // only show this for verbose ('-V') runs
 #define run_info(__f, ...)                                                                         \
@@ -85,6 +84,13 @@ static const_string_t fx = "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx ";
                                  regexec(&km_info_trace.tags, KM_TRACE_KVM, 0, NULL, 0) == 0))     \
          __run_warn(vcpu, __f, ##__VA_ARGS__);                                                     \
    } while (0)
+
+static inline void run_warn(const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  km_warnx_va(fmt, args);
+}
 
 static const char* kvm_reason_name(int reason)
 {

--- a/km/km_vmdriver.c
+++ b/km/km_vmdriver.c
@@ -169,8 +169,7 @@ void km_vmdriver_clone(km_vcpu_t* vcpu, km_vcpu_t* new_vcpu)
 
    if (machine.vm_type == VM_TYPE_KKM) {
       // copy KKM blob from parent to child currently 8 bytes
-      *(uint64_t*)((km_kma_t)new_vcpu->cpu_run + offset) =
-          *(uint64_t*)((km_kma_t)vcpu->cpu_run + offset);
+      memcpy((char*)new_vcpu->cpu_run + offset, (char*)vcpu->cpu_run + offset, 8);
       new_vcpu->regs.rax = 0;
    }
 }


### PR DESCRIPTION
1. Turn on extended security checks.

2. Fix issues it identifies.

Fixes #1511 