### PR TITLE
#1528 added krun shim to /bin for GKE and EKS

### DIFF
--- a/cloud/k8s/deploy/kontain-deploy/overlays/kkm/cm-install-lib-kkm.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/overlays/kkm/cm-install-lib-kkm.yaml
@@ -52,9 +52,8 @@ data:
 
       mkdir -p ${ROOT_MOUNT_DIR}/opt/kontain/shim
       cp ${ROOT_MOUNT_DIR}/kontain-artifacts/cloud/k8s/deploy/shim/containerd-shim-krun-v2 ${ROOT_MOUNT_DIR}/opt/kontain/shim/containerd-shim-krun-v2
-      cp ${ROOT_MOUNT_DIR}/kontain-artifacts/cloud/k8s/deploy/shim/containerd-shim-krun-v2 ${ROOT_MOUNT_DIR}/bin/containerd-shim-krun-v2
       chmod +x ${ROOT_MOUNT_DIR}/opt/kontain/shim/containerd-shim-krun-v2
-      chmod +x ${ROOT_MOUNT_DIR}/bin/containerd-shim-krun-v2
+      chroot ${ROOT_MOUNT_DIR} ln -sf /opt/kontain/shim/containerd-shim-krun-v2 /usr/bin/containerd-shim-krun-v2
 
       chmod +x ${ROOT_MOUNT_DIR}/kontain-artifacts/kkm.run
       chroot ${ROOT_MOUNT_DIR}   /kontain-artifacts/kkm.run -- --force-install

--- a/cloud/k8s/deploy/kontain-deploy/overlays/kkm/cm-install-lib-kkm.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/overlays/kkm/cm-install-lib-kkm.yaml
@@ -52,7 +52,9 @@ data:
 
       mkdir -p ${ROOT_MOUNT_DIR}/opt/kontain/shim
       cp ${ROOT_MOUNT_DIR}/kontain-artifacts/cloud/k8s/deploy/shim/containerd-shim-krun-v2 ${ROOT_MOUNT_DIR}/opt/kontain/shim/containerd-shim-krun-v2
+      cp ${ROOT_MOUNT_DIR}/kontain-artifacts/cloud/k8s/deploy/shim/containerd-shim-krun-v2 ${ROOT_MOUNT_DIR}/bin/containerd-shim-krun-v2
       chmod +x ${ROOT_MOUNT_DIR}/opt/kontain/shim/containerd-shim-krun-v2
+      chmod +x ${ROOT_MOUNT_DIR}/bin/containerd-shim-krun-v2
 
       chmod +x ${ROOT_MOUNT_DIR}/kontain-artifacts/kkm.run
       chroot ${ROOT_MOUNT_DIR}   /kontain-artifacts/kkm.run -- --force-install


### PR DESCRIPTION
added krun containerd shim to /bin folder else GKE and EKS give the following problem when deploying kontain based Apps because it can't find the shim.

Events:
Type     Reason                  Age               From               Message

---

Normal   Scheduled               75s               default-scheduler  Successfully assigned default/flaskappkontain-789d6fcd7b-v2tmb to gke-kdocscluster-gke-default-pool-4a60915d-76f3
Warning  FailedCreatePodSandBox  9s (x6 over 75s)  kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: runtime "io.containerd.krun.v2" binary not installed "containerd-shim-krun-v2": file does not exist: unknown