### PR TITLE
WIP: (Doesn't compile) Share with Serge: Move KM to > 512 GB VA

### DIFF
--- a/km/Makefile
+++ b/km/Makefile
@@ -28,7 +28,7 @@ INCLUDES := ${TOP}/include
 LLIBS := elf z
 COVERAGE := yes
 LOCAL_COPTS := -Werror -D_GNU_SOURCE
-LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd
+LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd -Wl,--no-relax
 
 include ${TOP}/make/actions.mk
 

--- a/km/km_guest_ldcmd
+++ b/km/km_guest_ldcmd
@@ -24,6 +24,32 @@
  */
 SECTIONS
 {
+   . = 0x8000000000;
+   .init : { *(.init) }
+   .plt : { *(.plt) }
+   .fini : { *(.fini) }
+   .text : { *(.text*) }
+   .__libc_freeres_fn : { *(.__libc_freeres_fn) }
+   .fini : { *(.fini) }
+   .rodata : { *(.rodata) }
+   .stapsdt.base : { *(.stapsdt.base) }
+   .eh_frame : { *(.eh_frame) }
+   .gcc_except_table : { *(.gcc_except_table) }
+   .tdata : { *(.tdata) }
+   .tbss : { *(.tbss) }
+   .init_array : { *(.init_array) }
+   .fini_array : { *(.fini_array) }
+   .data.rel.ro : { *(.data.rel.ro) }
+   .got : { *(.got) }
+   .got.plt : { *(.got.plt) }
+   .data : { *(.data*) }
+   .__libc_subfreeres : { *(.__libc_subfreeres) }
+   .__libc_IO_vtables : { *(.__libc_IO_vtables) }
+   .__libc_atexit : { *(.__libc_atexit) }
+   .bss : { *(.bss*) }
+   .__libc_freeres_fn_section : { *(.__libc_freeres_fn_section) }
+   .__libc_freeres_fn_section : { *(.__libc_freeres_fn_section) }
+
    .km_guest_text ALIGN(CONSTANT (COMMONPAGESIZE)) :
    {
       km_guest_start = .;


### PR DESCRIPTION
Doesn't work. `make -C km` gives:
```
cc -O2  -Werror -D_GNU_SOURCE -Wall -ggdb3 -pthread -I /home/muth/workspace/km/include -ffile-prefix-map=/home/muth/workspace/km/km/= /home/muth/workspace/km/build/km/gdb_kvm_x86_64.o /home/muth/workspace/km/build/km/km_coredump.o /home/muth/workspace/km/build/km/km_cpu_init.o /home/muth/workspace/km/build/km/km_decode.o /home/muth/workspace/km/build/km/km_exec.o /home/muth/workspace/km/build/km/km_exec_fd_save_recover.o /home/muth/workspace/km/build/km/km_filesys.o /home/muth/workspace/km/build/km/km_fork.o /home/muth/workspace/km/build/km/km_gdb_stub.o /home/muth/workspace/km/build/km/km_guest_asmcode.o /home/muth/workspace/km/build/km/km_hc_name.o /home/muth/workspace/km/build/km/km_hcalls.o /home/muth/workspace/km/build/km/km_init_guest.o /home/muth/workspace/km/build/km/km_intr.o /home/muth/workspace/km/build/km/km_kkm.o /home/muth/workspace/km/build/km/km_main.o /home/muth/workspace/km/build/km/km_management.o /home/muth/workspace/km/build/km/km_mem.o /home/muth/workspace/km/build/km/km_mmap.o /home/muth/workspace/km/build/km/km_musl_related.o /home/muth/workspace/km/build/km/km_proc.o /home/muth/workspace/km/build/km/km_signal.o /home/muth/workspace/km/build/km/km_snapshot.o /home/muth/workspace/km/build/km/km_trace.o /home/muth/workspace/km/build/km/km_vcpu_run.o /home/muth/workspace/km/build/km/km_vmdriver.o /home/muth/workspace/km/build/km/load_elf.o -static -Wl,--script=km_guest_ldcmd -Wl,--no-relax -l elf -l z -o /home/muth/workspace/km/build/km/km
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../lib64/libpthread.a(libpthread.o): in function `__libpthread_freeres':
(.text+0x4f4): relocation truncated to fit: R_X86_64_PLT32 against undefined symbol `__nptl_unwind_freeres'
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../lib64/libpthread.a(libpthread.o): in function `start_thread':
(.text+0x15dd): relocation truncated to fit: R_X86_64_PLT32 against undefined symbol `__call_tls_dtors'
/usr/lib/gcc/x86_64-redhat-linux/11/crtbeginT.o: in function `deregister_tm_clones':
crtstuff.c:(.text+0x1): relocation truncated to fit: R_X86_64_32 against symbol `__TMC_END__' defined in __libc_subfreeres section in /home/muth/workspace/km/build/km/km
crtstuff.c:(.text+0x7): relocation truncated to fit: R_X86_64_32S against `.tm_clone_table'
crtstuff.c:(.text+0x18): relocation truncated to fit: R_X86_64_32 against `.tm_clone_table'
/usr/lib/gcc/x86_64-redhat-linux/11/crtbeginT.o: in function `register_tm_clones':
crtstuff.c:(.text+0x31): relocation truncated to fit: R_X86_64_32 against symbol `__TMC_END__' defined in __libc_subfreeres section in /home/muth/workspace/km/build/km/km
crtstuff.c:(.text+0x38): relocation truncated to fit: R_X86_64_32S against `.tm_clone_table'
crtstuff.c:(.text+0x5a): relocation truncated to fit: R_X86_64_32 against `.tm_clone_table'
/usr/lib/gcc/x86_64-redhat-linux/11/crtbeginT.o: in function `__do_global_dtors_aux':
crtstuff.c:(.text+0x87): relocation truncated to fit: R_X86_64_32 against symbol `__deregister_frame_info' defined in .text section in /usr/lib/gcc/x86_64-redhat-linux/11/libgcc_eh.a(unwind-dw2-fde-dip.o)
crtstuff.c:(.text+0x91): relocation truncated to fit: R_X86_64_32 against `.eh_frame'
/usr/lib/gcc/x86_64-redhat-linux/11/crtbeginT.o: in function `frame_dummy':
crtstuff.c:(.text+0xb5): additional relocation overflows omitted from the output
collect2: error: ld returned 1 exit status
make: *** [/home/muth/workspace/km/make/actions.mk:95: /home/muth/workspace/km/build/km/km] Error 1
```