### PR TITLE
km with GVA == KMA

### DIFF
--- a/km/Makefile
+++ b/km/Makefile
@@ -27,11 +27,12 @@ VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info
 INCLUDES := ${TOP}/include
 COVERAGE := yes
 LOCAL_COPTS := -Werror -D_GNU_SOURCE
-LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd
+LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd -static-pie
 
 include ${TOP}/make/actions.mk
 
-${BLDDIR}/km_guest_asmcode.o: CFLAGS += -fPIC
+${BLDDIR}/km_guest_asmcode.o: CFLAGS += -fpic
+CFLAGS += -fpic
 
 # Package KM and libs+tools+docs for release
 KM_RELEASE := ${BLDTOP}/kontain.tar.gz

--- a/km/km_guest_asmcode.s
+++ b/km/km_guest_asmcode.s
@@ -89,7 +89,7 @@ intr_hand CP, 21
 /*
  * Table used by KM to build IDT entries.
  */
-    .section .km_guest_data, "da", @progbits
+    .section .km_guest_data, "dwa", @progbits
     .align 16
     .type __km_interrupt_table, @object
     .global __km_interrupt_table

--- a/km/km_mmap.c
+++ b/km/km_mmap.c
@@ -79,10 +79,6 @@ void km_guest_mmap_fini(void)
 static inline int
 mmap_check_params(km_gva_t addr, size_t size, int prot, int flags, int fd, off_t offset)
 {
-   if (size >= GUEST_MEM_ZONE_SIZE_VA) {
-      km_infox(KM_TRACE_MMAP, "*** size is too large");
-      return -ENOMEM;
-   }
    if ((flags & MAP_FIXED_NOREPLACE) != 0) {
       km_infox(KM_TRACE_MMAP, "*** MAP_FIXED_NOREPLACE is not supported");
       return -EINVAL;

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -140,7 +140,7 @@ static inline void km_ss_recover_memory(int fd, km_gva_t tbrk_gva, km_payload_t*
          if (km_vdso_gva(phdr->p_vaddr) != 0 || km_guestmem_gva(phdr->p_vaddr) != 0) {
             continue;
          }
-         if (phdr->p_vaddr >= gpa_to_upper_gva(GUEST_MEM_START_VA)) {
+         if (phdr->p_vaddr >= 256 * GIB) {   // TODO: HACK to tell upper VA from lower
             // upper: Skip addresses loaded by machine initialization.
             if (phdr->p_vaddr + phdr->p_filesz <= tbrk_gva) {
                int prot = prot_elf_to_mmap(phdr->p_flags);
@@ -321,7 +321,7 @@ static int km_ss_recover_file_maps(char* ptr, size_t length)
    for (uint64_t i = 0; i < nfile; i++) {
       km_gva_t base = current[0];
       km_gva_t limit = current[1];
-      if (limit >= gpa_to_upper_gva(GUEST_MEM_START_VA)) {
+      if (limit >= 256 * GIB) {   // TODO: HACK to tell upper VA from lower
          /*
           * There are NT_FILE records for all mappings, including the one
           * in low virtual memory create by load_elf. We want to skip those

--- a/make/custom.mk
+++ b/make/custom.mk
@@ -18,4 +18,4 @@
 
 # default optimization flag
 COPTS ?= -O2 #-Wunused-parameter
-LDOPTS ?= -static
+LDOPTS ?= 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -27,7 +27,7 @@ load test_helper
 
 # not_needed_{generic,static,dynamic,shared} - skip since it's not needed
 # todo_{generic,static,dynamic,shared} - skip since it's a TODO
-not_needed_generic=''
+not_needed_generic=
 # TODO: gdb_delete_breakpoint and gdb_server_race are caused by race described in https://github.com/kontainapp/km/issues/821.
 # Disable them for now to improve signal/noise ratio
 todo_generic='gdb_delete_breakpoint gdb_server_race clock_gettime'
@@ -584,9 +584,11 @@ fi
       --ex="target remote :$km_gdb_port" \
       --ex="source cmd_for_protected_mem_test.gdb" --ex=q
    assert_success
-   assert_line --partial "first word  0x7fffffbfc000:	0x1111111111111111"
-   assert_line --partial "spanning pages  0x7fffffbfcffc:	0xff0000ffff0000ff"
-   assert_line --partial "last word  0x7fffffbfdff8:	0xeeeeeeeeeeeeeeee"
+   # Depending on the guest virtual memory layout the addresses could be either like
+   # 0x7fffffbfc000 (KM_HIGH_GVA) or 0x7fffbfc000
+   assert_line --regexp "first word  0x7ffff?f?bfc000:	0x1111111111111111"
+   assert_line --regexp "spanning pages  0x7ffff?f?bfcffc:	0xff0000ffff0000ff"
+   assert_line --regexp "last word  0x7ffff?f?bfdff8:	0xeeeeeeeeeeeeeeee"
    wait_and_check $pid 0
 }
 
@@ -928,7 +930,9 @@ fi
    run gdb_with_timeout -ex="set pagination off" -ex="handle SIG63 nostop"\
       -ex="source gdb_simple_test.py" -ex="run-test" -ex="q" --args ${KM_BIN} ${KM_ARGS} munmap_monitor_maps_test$ext
    assert_success
-   assert_line --partial "conflicts with monitor region 0x7fffffdfe000 size 0x2000"
+   # Depending on the guest virtual memory layout the addresses could be either like
+   # 0x7fffffbfc000 (KM_HIGH_GVA) or 0x7fffbfc000
+   assert_line --regexp "conflicts with monitor region 0x7ffff?f?dfe000 size 0x2000"
    assert_line --partial 'fail: 0'
 }
 


### PR DESCRIPTION
This builds KM as a static PIE, which has the effect of loading in very high memory due to Linux ASLR.

This allows allocating guest memory in KM at address 0, so that physical guest address (PVA) is the same as in km. This is controlled by KM_GPA_AT_16T macro. If defined, km reverts to old physical address schema.

If KM_HIGH_GVA macro is not defined, the virtual guest addresses (GVA) are equal to PVA. If it is defined km reverts to old schema with high GVA up at 128T.

Which means no virtual address translation needed in KM.

Also cleaned up and (I think) simplified memory management code.

Note that the kkm code is not adapted to this yet, so many tests fail. Hence this PR is still WIP.

I'd appreciate a review to make sure I'm not doing something crazy.