### PR TITLE
Remove dependency on libelf - process elf 64 ourselves

### DIFF
--- a/km/Makefile
+++ b/km/Makefile
@@ -25,9 +25,9 @@ SOURCES := load_elf.c km_cpu_init.c km_main.c km_vcpu_run.c km_hcalls.c km_mem.c
 		km_kkm.c km_vmdriver.c km_exec_fd_save_recover.c
 VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info changes
 INCLUDES := ${TOP}/include
-LLIBS := elf z
+LLIBS := z
 COVERAGE := yes
-LOCAL_COPTS := -Werror -D_GNU_SOURCE
+LOCAL_COPTS := -Werror -D_GNU_SOURCE 
 LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd
 
 include ${TOP}/make/actions.mk

--- a/km/Makefile
+++ b/km/Makefile
@@ -25,9 +25,8 @@ SOURCES := load_elf.c km_cpu_init.c km_main.c km_vcpu_run.c km_hcalls.c km_mem.c
 		km_kkm.c km_vmdriver.c km_exec_fd_save_recover.c
 VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info changes
 INCLUDES := ${TOP}/include
-LLIBS := 
 COVERAGE := yes
-LOCAL_COPTS := -Werror -D_GNU_SOURCE 
+LOCAL_COPTS := -Werror -D_GNU_SOURCE
 LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd
 
 include ${TOP}/make/actions.mk

--- a/km/Makefile
+++ b/km/Makefile
@@ -25,7 +25,7 @@ SOURCES := load_elf.c km_cpu_init.c km_main.c km_vcpu_run.c km_hcalls.c km_mem.c
 		km_kkm.c km_vmdriver.c km_exec_fd_save_recover.c
 VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info changes
 INCLUDES := ${TOP}/include
-LLIBS := z
+LLIBS := 
 COVERAGE := yes
 LOCAL_COPTS := -Werror -D_GNU_SOURCE 
 LOCAL_LDOPTS := -Wl,--script=km_guest_ldcmd

--- a/km/km_elf.h
+++ b/km/km_elf.h
@@ -48,13 +48,16 @@ typedef struct km_payload {
 extern km_payload_t km_guest;
 extern km_payload_t km_dynlinker;
 
-// Open elf file descriptor
-typedef struct km_elf {
-   Elf* elf;
-   int fd;
-   GElf_Ehdr ehdr;
-   const char* filename;
+typedef struct km_elf_s {
+   const char *path;
+   FILE *file;
+   Elf64_Ehdr *ehdr;
+   Elf64_Phdr *phdr;
+   Elf64_Shdr *shdr;
+   int symidx;
+   int stridx;
 } km_elf_t;
+
 
 /*
  * Translate ELF region protection mmap to mmap protection flag

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -676,7 +676,7 @@ int main(int argc, char* argv[])
    km_elf_t* elf = km_open_elf_file(payload_name);
 
    // snapshot file is type ET_CORE. We check for additional notes in restore
-   if (elf->ehdr.e_type == ET_CORE) {
+   if (elf->ehdr->e_type == ET_CORE) {
       // check for incompatible options
       if (envp != NULL) {
          km_errx(1, "cannot set new environment when resuming a snapshot");

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -282,21 +282,21 @@ km_open_elf_file(const char *path)
       km_errx(2, "Not current ELF version %s", path);
    }
 
-   elf->phdr = malloc(elf->ehdr->e_phentsize * elf->ehdr->e_phnum);
+   elf->phdr = malloc((size_t) elf->ehdr->e_phentsize * (size_t) elf->ehdr->e_phnum);
    if (fseek(elf->file, elf->ehdr->e_phoff, SEEK_SET) != 0) {
       km_err(2, "Cannot seek to PHDR %s", path);
    }
-   nread = fread(elf->phdr, 1, elf->ehdr->e_phentsize * elf->ehdr->e_phnum, elf->file);
+   nread = fread(elf->phdr, 1, (size_t) elf->ehdr->e_phentsize * (size_t) elf->ehdr->e_phnum, elf->file);
    if (nread < elf->ehdr->e_phentsize * elf->ehdr->e_phnum) {
       km_err(2, "Cannot read PHDR %s", path);
    }
 
    // Read Section Headers
-   elf->shdr = malloc(elf->ehdr->e_shentsize * elf->ehdr->e_shnum);
+   elf->shdr = malloc((size_t) elf->ehdr->e_shentsize * (size_t) elf->ehdr->e_shnum);
    if (fseek(elf->file, elf->ehdr->e_shoff, SEEK_SET) != 0) {
       km_err(2, "Cannot seek to SHDR %s", path);
    }
-   nread = fread(elf->shdr, 1, elf->ehdr->e_shentsize * elf->ehdr->e_shnum, elf->file);
+   nread = fread(elf->shdr, 1, (size_t) elf->ehdr->e_shentsize * (size_t) elf->ehdr->e_shnum, elf->file);
    if (nread < elf->ehdr->e_shentsize * elf->ehdr->e_shnum) {
       km_err(2, "Cannot read SHDR %s", path);
    }

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -244,12 +244,12 @@ uint64_t km_load_elf(km_elf_t* e)
 /*
  * Open ELF file for KM.
  * Note: This is a place where we need to really validate what we are looking
- * at since. Potentially a bad actor could give us a bad elf file for the guest
+ * at since potentially a bad actor could give us a bad elf file for the guest
  * in an attempt to corrupt KM. We need to prevent that.
- * For now there are bsic tests. 
+ * For now there are basic tests. 
  *
  * TODO: This algorithm is memory inefficient. Don't need to hold everthing in
- *       core. Could use stdio buffering to get one at  time efficiently since 
+ *       core. Could use stdio buffering to get one at a time efficiently since 
  *       we mainly sequentially scan.
  */
 km_elf_t*

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -247,6 +247,10 @@ uint64_t km_load_elf(km_elf_t* e)
  * at since. Potentially a bad actor could give us a bad elf file for the guest
  * in an attempt to corrupt KM. We need to prevent that.
  * For now there are bsic tests. 
+ *
+ * TODO: This algorithm is memory inefficient. Don't need to hold everthing in
+ *       core. Could use stdio buffering to get one at  time efficiently since 
+ *       we mainly sequentially scan.
  */
 km_elf_t*
 km_open_elf_file(const char *path)
@@ -302,9 +306,7 @@ km_open_elf_file(const char *path)
    for (int i = 0; i < elf->ehdr->e_shnum; i++) {
       if (elf->shdr[i].sh_type == SHT_SYMTAB) {
          elf->symidx = i;
-      }
-      if (elf->shdr[i].sh_type == SHT_STRTAB && i != elf->ehdr->e_shstrndx) {
-         elf->stridx = i;
+         elf->stridx = elf->shdr[i].sh_link;
       }
    }
 

--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -73,7 +73,7 @@ RUN dnf install -y \
    gcc gcc-c++ make gdb git-core gcovr \
    time patch file findutils diffutils which procps-ng python2 \
    glibc-devel glibc-static libstdc++-static \
-   elfutils-libelf-devel bzip2-devel \
+   bzip2-devel \
    zlib-static bzip2-static xz-static xz \
    openssl-devel openssl-static jq googler \
    python3-markupsafe libffi-devel parallel \
@@ -81,13 +81,6 @@ RUN dnf install -y \
    python3-libmount libtool cmake makeself \
    systemd-devel \
    && dnf upgrade -y && dnf clean all && rm -rf /var/cache/{dnf,yum}
-
-FROM buildenv-early AS buildlibelf
-
-RUN dnf install -y flex bison zstd gettext-devel bsdtar xz-devel
-RUN git clone git://sourceware.org/git/elfutils.git -b elfutils-0.182 && cd elfutils && \
-   autoreconf -i -f && \
-   ./configure --enable-maintainer-mode --disable-libdebuginfod --disable-debuginfod && make -j && make install
 
 FROM buildenv-early AS buildenv
 ARG USER=appuser
@@ -102,7 +95,6 @@ ENV USER=$USER
 ENV PREFIX=/opt/kontain
 WORKDIR /home/$USER
 
-COPY --from=buildlibelf /usr/local /usr/local/
 COPY --from=alpine-lib-image $PREFIX $PREFIX/
 RUN for i in runtime alpine-lib ; do \
        mkdir -p $PREFIX/$i && chgrp users $PREFIX/$i && chmod 777 $PREFIX/$i ; \

--- a/tests/buildenv-ubuntu.dockerfile
+++ b/tests/buildenv-ubuntu.dockerfile
@@ -27,7 +27,7 @@ ARG UID=1001
 ARG GID=117
 
 RUN apt-get update; apt-get upgrade -y; \
-   apt-get install -y make git gdb libelf-dev gcc-8 g++-8 libc-dev curl vim time python; \
+   apt-get install -y make git gdb gcc-8 g++-8 libc-dev curl vim time python; \
    apt-get clean; \
    ln -s `which gcc-8` /bin/cc; \
    ln -s `which gcc-8` /bin/gcc; \


### PR DESCRIPTION
libelf is a 20K line library that we use a time amout of to read elf files.
We don't use it for writing elf files (core/snapshot). This commit
moves all ELF processing into KM and removes any dependency on libelf.