### PR TITLE
remove reference to gelf.h and libelf types

### DIFF
--- a/km/km_elf.h
+++ b/km/km_elf.h
@@ -22,7 +22,7 @@
 
 #include "km.h"
 
-#include <gelf.h>
+#include <elf.h>
 #include <stdint.h>
 #include <sys/mman.h>
 

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -142,9 +142,9 @@ km_ss_recover_memory_limits(km_payload_t* payload, km_gva_t* mingvap, km_gva_t* 
    km_gva_t mingva = -1;
    km_gva_t rbrk = 0;
    km_gva_t rtbrk = -1;
-   GElf_Ehdr* ehdr = &payload->km_ehdr;
+   Elf64_Ehdr* ehdr = &payload->km_ehdr;
    for (int i = 0; i < ehdr->e_phnum; i++) {
-      GElf_Phdr* phdr = &payload->km_phdr[i];
+      Elf64_Phdr* phdr = &payload->km_phdr[i];
       if (phdr->p_type == PT_LOAD) {
          km_infox(KM_TRACE_SNAPSHOT,
                   "%d PT_LOAD offset=0x%lx vaddr=0x%lx msize=0x%lx fsize=0x%lx flags=0x%x",
@@ -179,7 +179,7 @@ km_ss_recover_memory_limits(km_payload_t* payload, km_gva_t* mingvap, km_gva_t* 
 
 static inline void km_ss_recover_memory(int fd, km_payload_t* payload)
 {
-   GElf_Ehdr* ehdr = &payload->km_ehdr;
+   Elf64_Ehdr* ehdr = &payload->km_ehdr;
 
    /*
     * recover brk and tbrk
@@ -207,7 +207,7 @@ static inline void km_ss_recover_memory(int fd, km_payload_t* payload)
       km_errx(2, "tbrk recover failure: expect=0x%lx got=0x%lx", rtbrk, ptr);
    }
    for (int i = 0; i < ehdr->e_phnum; i++) {
-      GElf_Phdr* phdr = &payload->km_phdr[i];
+      Elf64_Phdr* phdr = &payload->km_phdr[i];
       if (phdr->p_type == PT_LOAD) {
          // Skip guest VDSO and KM unikernel
          if (km_vdso_gva(phdr->p_vaddr) != 0 || km_guestmem_gva(phdr->p_vaddr) != 0) {
@@ -265,9 +265,9 @@ static inline void km_ss_recover_memory(int fd, km_payload_t* payload)
  */
 static inline char* km_snapshot_read_notes(int fd, size_t* notesize, km_payload_t* payload)
 {
-   GElf_Ehdr* ehdr = &payload->km_ehdr;
+   Elf64_Ehdr* ehdr = &payload->km_ehdr;
    for (int i = 0; i < ehdr->e_phnum; i++) {
-      GElf_Phdr* phdr = &payload->km_phdr[i];
+      Elf64_Phdr* phdr = &payload->km_phdr[i];
       if (phdr->p_type == PT_NOTE) {
          char* notebuf = malloc(phdr->p_filesz);
          assert(notebuf != NULL);

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -47,7 +47,7 @@ static void my_mmap(int fd, void* buf, size_t count, off_t offset)
  * - adjust break so there is enough memory
  * - loop over memory regions this extent covering, read/memset the content and set mprotect.
  */
-static void load_extent(int fd, const GElf_Phdr* phdr, km_gva_t base)
+static void load_extent(int fd, const Elf64_Phdr* phdr, km_gva_t base)
 {
    km_gva_t top = phdr->p_paddr + phdr->p_memsz + base;
    /*
@@ -189,7 +189,7 @@ uint64_t km_load_elf(km_elf_t* e)
     */
    km_guest.km_min_vaddr = -1U;
    for (int i = 0; i < km_guest.km_ehdr.e_phnum; i++) {
-      GElf_Phdr* phdr = &km_guest.km_phdr[i];
+      Elf64_Phdr* phdr = &km_guest.km_phdr[i];
       *phdr = e->phdr[i];
 
       if (phdr->p_type == PT_LOAD && phdr->p_vaddr < km_guest.km_min_vaddr) {
@@ -227,7 +227,7 @@ uint64_t km_load_elf(km_elf_t* e)
     * process PT_LOAD program headers
     */
    for (int i = 0; i < km_guest.km_ehdr.e_phnum; i++) {
-      GElf_Phdr* phdr = &km_guest.km_phdr[i];
+      Elf64_Phdr* phdr = &km_guest.km_phdr[i];
       if (phdr->p_type == PT_LOAD) {
          load_extent(fileno(e->file), phdr, adjust);
       }


### PR DESCRIPTION
Previous attempt to remove dependency on libelf did not remove use of `gelf.h` and associated types. This PR replaces `gelf.h` with `elf.h` and uses `Elf64` types directly instead of GElf types.