### PR TITLE
WIP: prototype glibc dynamic library support

### DIFF
--- a/km/km_mmap.c
+++ b/km/km_mmap.c
@@ -575,6 +575,28 @@ km_mmap_add_region(km_gva_t gva, size_t size, int prot, int flags, int hostfd, m
    return ret;
 }
 
+/*
+ * TODO: This is a gross hack.
+ */
+static km_gva_t km_mmap_do_fixed_mapping(
+    km_gva_t gva, size_t size, int prot, int flags, int fd, off_t offset, mmap_allocation_type_e type)
+{
+   if (gva_to_gpa(gva) < machine.guest_mid_physmem) {
+     // TODO: Hack city. Just move brk.
+     if (machine.brk >= gva + size) {
+        return gva;
+     }
+     km_mem_brk(gva + size);
+     if (fd != -1) {
+        if (mmap(km_gva_to_kma(gva), size, prot, flags, fd, offset) == MAP_FAILED) {
+           return -errno;
+        }
+     }
+     return 0;
+   }
+   return -EINVAL;
+}
+
 // Guest mmap implementation. Returns gva or -errno. Params should be already checked and locks taken...
 static km_gva_t km_guest_mmap_nolock(
     km_gva_t gva, size_t size, int prot, int flags, int fd, off_t offset, mmap_allocation_type_e type)
@@ -594,8 +616,12 @@ static km_gva_t km_guest_mmap_nolock(
    }
    if ((flags & MAP_FIXED) == MAP_FIXED) {
       if (km_mmap_busy_check_contiguous(gva, size) != 0) {
-         km_infox(KM_TRACE_MMAP, "Found not maped addresses in MAP_FIXED-requested range");
-         return -EINVAL;
+         // This bit of hack treats mmap to lower memory as a push to mem_brk by a dynmaic loader.
+         if ((ret = km_mmap_do_fixed_mapping(gva, size, prot, flags, hostfd, offset, type)) != 0) {
+            km_infox(KM_TRACE_MMAP, "Cannot do fixed mapping %d", ret);
+            return ret;
+         }
+         return gva;
       }
    } else {   // ignore the hint and grab an address range
       gva = km_mmap_add_region(0, size, prot, flags, hostfd, type);

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -231,9 +231,14 @@ uint64_t km_load_elf(km_elf_t* e)
     * loading PIE that doesn't matter, but we need to keep it for coredump and such. For dynamic
     * linking adjust is passed to the dynamic linker so it know how to do relocations.
     */
+#if 0
+   /*
+    * TODO: For this prototype adjust is disabled. Just trust the elf.
+    */
    if (km_guest.km_dynamic_vaddr != 0 && km_guest.km_dynamic_len != 0) {
       adjust = GUEST_MEM_START_VA - km_guest.km_min_vaddr;
    }
+#endif
    /*
     * process PT_LOAD program headers
     */

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -38,9 +38,14 @@ km_payload_t km_dynlinker;
 static void map_program_section(int fd, void* buf, size_t count, off_t offset)
 {
    if (count > 0) {
-      if (mmap(buf, roundup(count, KM_PAGE_SIZE), PROT_WRITE, MAP_PRIVATE | MAP_FIXED, fd, offset) ==
-          MAP_FAILED) {
+      if (mmap(buf, count, PROT_WRITE, MAP_PRIVATE | MAP_FIXED, fd, offset) == MAP_FAILED) {
          km_err(2, "error mmap elf");
+      }
+      /*
+       * If only mmaped partial last page, explicitly zero out the rest.
+       */
+      if (count != roundup(count, KM_PAGE_SIZE)) {
+         memset(buf + count, 0, roundup(count, KM_PAGE_SIZE) - count);
       }
    }
 }


### PR DESCRIPTION
These are the changes from the NVIDIA support effort to support binaries linked with glibc ld.so under KM. The changes required were:

1) support fixed mmap in low memory. This is hacked by moving `brk` unmap will just puke.
2) Don't try to load all ELF files at `GUEST_MEM_START_VA`. Do what the ELF file says. So what if a few MB is wasted?
3) Explicitly clear residual memory in mmap'ed page to support `ld.so` assumption.

I'm making this a PR to discuss with the group.