### PR TITLE
Ez leka/krun separation

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -183,8 +183,7 @@ jobs:
   # parallel with the rest of KM build and test.
   krun-static-build:
     name: Build static KRUN binary
-    runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
-    needs: start-runners
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -228,10 +227,6 @@ jobs:
         with:
           name: krun-static
           path: /tmp/krun-static
-
-      - name: cleanup
-        if: always()
-        run: rm -rf km
 
   # Build the k8s release artifact. Static KRUN is built separately and
   # in parallel from the rest of KM. The k8s artifact contains:
@@ -638,7 +633,7 @@ jobs:
   stop-runner:
     if: always()
     name: Terminate self-hosted cloud runners
-    needs: [start-runners, krun-static-build, km-test, kkm-test-vms]
+    needs: [start-runners, km-test, kkm-test-vms]
     runs-on: ubuntu-latest
     steps:
       - name: Stop runners

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -198,6 +198,7 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN }}
           artifact-name: ${{ env.CRUN_SHA}}
           path: /tmp/krun-static
+          debug: true
 
       - uses: actions/cache@v2
         if: ${{ steps.check-artifact.outputs.artifact-status != 'available' }}

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -189,13 +189,26 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Set env
+        run: echo "CRUN_SHA=$(cd container-runtime/crun/ && git rev-parse --short=12 HEAD)" >> $GITHUB_ENV
+
+      - name: check artifact
+        id: check-artifact
+        uses: ez-leka/persistent-artifact@v1
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          artifact-name: ${{ env.CRUN_SHA}}
+          path: /tmp/krun-static
 
       - uses: actions/cache@v2
+        if: ${{ steps.check-artifact.outputs.artifact-status != 'available' }}
         with:
           path: .cache
           key: nix-v1-${{ hashFiles('container-runtime/crun/nix/nixpkgs.json') }}
 
-      - run: |
+      - name: Build krun
+        if: ${{ steps.check-artifact.outputs.artifact-status != 'available' }}
+        run: |
           set -x
           CRUN_DIR=$(pwd)/container-runtime/crun
           # These next two lines were taken from the crun release.yaml and build-aux/release.sh
@@ -204,6 +217,12 @@ jobs:
           sudo docker run --rm --privileged -v /nix:/nix -v ${CRUN_DIR}:${CRUN_DIR} -w ${CRUN_DIR} nixos/nix:2.3.12 nix build --print-build-logs --file nix/
           mkdir -p /tmp/krun-static
           cp ${CRUN_DIR}/result/bin/crun /tmp/krun-static/krun.static
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ steps.check-artifact.outputs.artifact-status != 'available' }}
+        with:
+          name: ${{ env.CRUN_SHA}}
+          path: /tmp/krun-static
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -193,7 +193,7 @@ jobs:
 
       - name: check artifact
         id: check-artifact
-        uses: ez-leka/persistent-artifact@v1
+        uses: kontainapp/persistent-artifact@v1
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           artifact-name: ${{ env.CRUN_SHA}}


### PR DESCRIPTION
Krun-static build job now stores persistent artifact. KRUN  is only built if submodule  have been changed, otherwise the exiting artifact from previous build is retrieved and used. 

Job uses new custom action to retrieve and maintain persistent artifact:  ez-leka/persistent-artifact@v1. This custom action will attempt to retrieve  artifact. If found, will download it just like standard download-artifact action and will set output variable of the step 'artifact-status' to 'available'. It will also re-upload artifact to prevent if from expiring. If there is no requested artifact, it will set 'artifact-status' to 'not-found' and return without error. 

'artifact-status' is then used as a condition to determine whether to start run build or if a buid is already available. 

For KRUN-static purposes the name of the persistent artifact is derived from submodule SHA. That way , artifact name will automatically change when there are changes to the KRUN and persist otherwise. 