### PR TITLE
ELF load cleanup

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -730,6 +730,7 @@ static inline void km_signal_unlock(void)
 #define KM_TRACE_EXEC "exec"
 #define KM_TRACE_FORK "fork"   // also clone() for a process.
 #define KM_TRACE_ARGS "args"
+#define KM_TRACE_LOAD "load"
 
 /*
  * The km definition of the link_map structure in runtime/musl/include/link.h

--- a/km/km.h
+++ b/km/km.h
@@ -730,7 +730,6 @@ static inline void km_signal_unlock(void)
 #define KM_TRACE_EXEC "exec"
 #define KM_TRACE_FORK "fork"   // also clone() for a process.
 #define KM_TRACE_ARGS "args"
-#define KM_TRACE_LOAD "load"
 
 /*
  * The km definition of the link_map structure in runtime/musl/include/link.h

--- a/km/km_elf.h
+++ b/km/km_elf.h
@@ -52,11 +52,12 @@ typedef struct km_elf_s {
    const char *path;
    FILE *file;
    Elf64_Ehdr ehdr;
-   Elf64_Phdr *phdr;
    Elf64_Shdr *shdr;
    int symidx;
    int stridx;
 } km_elf_t;
+
+int km_elf_get_phdr(km_elf_t *elf, int idx, Elf64_Phdr *phdr);
 
 
 /*

--- a/km/km_elf.h
+++ b/km/km_elf.h
@@ -52,12 +52,9 @@ typedef struct km_elf_s {
    const char *path;
    FILE *file;
    Elf64_Ehdr ehdr;
-   Elf64_Shdr *shdr;
-   int symidx;
-   int stridx;
 } km_elf_t;
-
 int km_elf_get_phdr(km_elf_t *elf, int idx, Elf64_Phdr *phdr);
+int km_elf_get_shdr(km_elf_t *elf, int idx, Elf64_Shdr *shdr);
 
 
 /*

--- a/km/km_elf.h
+++ b/km/km_elf.h
@@ -51,7 +51,7 @@ extern km_payload_t km_dynlinker;
 typedef struct km_elf_s {
    const char *path;
    FILE *file;
-   Elf64_Ehdr *ehdr;
+   Elf64_Ehdr ehdr;
    Elf64_Phdr *phdr;
    Elf64_Shdr *shdr;
    int symidx;

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -676,7 +676,7 @@ int main(int argc, char* argv[])
    km_elf_t* elf = km_open_elf_file(payload_name);
 
    // snapshot file is type ET_CORE. We check for additional notes in restore
-   if (elf->ehdr->e_type == ET_CORE) {
+   if (elf->ehdr.e_type == ET_CORE) {
       // check for incompatible options
       if (envp != NULL) {
          km_errx(1, "cannot set new environment when resuming a snapshot");

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -505,7 +505,9 @@ int km_snapshot_restore(km_elf_t* e)
       km_err(2, "no memory for elf program headers");
    }
    for (int i = 0; i < tmp_payload.km_ehdr.e_phnum; i++) {
-      tmp_payload.km_phdr[i] = e->phdr[i];
+      if (km_elf_get_phdr(e, i, &tmp_payload.km_phdr[i]) != 0) {
+         km_err(2, "cannot get phdr %d", i);
+      }
    }
 
    // disable mmap consolidation during recovery

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -498,10 +498,10 @@ int km_snapshot_restore(km_elf_t* e)
 {
    km_payload_t tmp_payload = {};
 
-   tmp_payload.km_ehdr = *e->ehdr;
+   tmp_payload.km_ehdr = e->ehdr;
 
    // Read ELF PHDR into tmp_payload.
-   if ((tmp_payload.km_phdr = alloca(sizeof(Elf64_Phdr) * e->ehdr->e_phnum)) == NULL) {
+   if ((tmp_payload.km_phdr = alloca(sizeof(Elf64_Phdr) * e->ehdr.e_phnum)) == NULL) {
       km_err(2, "no memory for elf program headers");
    }
    for (int i = 0; i < tmp_payload.km_ehdr.e_phnum; i++) {

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -110,7 +110,7 @@ static void km_find_dlopen(km_elf_t* e, km_gva_t adjust)
       }
    }
    if (found == 0) {
-      km_err(2, "Cannot find symbol table for DLOPEN");
+      km_err(2, "Cannot find symbol table");
    }
 
    int nsym = sym_shdr.sh_size / sym_shdr.sh_entsize;
@@ -316,6 +316,7 @@ km_close_elf_file(km_elf_t* elf)
          fclose(elf->file);
          elf->file = NULL;
       }
+      free(elf);
    }
 }
 
@@ -324,7 +325,7 @@ int km_elf_get_phdr(km_elf_t *elf, int idx, Elf64_Phdr *phdr)
    if (idx < 0 || idx >= elf->ehdr.e_phnum) {
       return -1;
    }
-   if (fseek(elf->file, elf->ehdr.e_phoff + idx * elf->ehdr.e_phentsize, SEEK_SET) != 0) {
+   if (fseek(elf->file, elf->ehdr.e_phoff + (off_t)idx * (off_t)elf->ehdr.e_phentsize, SEEK_SET) != 0) {
       return -1;
    }
    int nread = fread(phdr, 1, (size_t) elf->ehdr.e_phentsize, elf->file);
@@ -339,7 +340,7 @@ int km_elf_get_shdr(km_elf_t *elf, int idx, Elf64_Shdr *shdr)
    if (idx < 0 || idx >= elf->ehdr.e_shnum) {
       return -1;
    }
-   if (fseek(elf->file, elf->ehdr.e_shoff + idx * elf->ehdr.e_shentsize, SEEK_SET) != 0) {
+   if (fseek(elf->file, elf->ehdr.e_shoff + (off_t)idx * (off_t)elf->ehdr.e_shentsize, SEEK_SET) != 0) {
       return -1;
    }
    int nread = fread(shdr, 1, (size_t) elf->ehdr.e_shentsize, elf->file);


### PR DESCRIPTION
No need to buffer Phdr, Shdr, and symbol table string table. stdio is capable of doing that. 