### PR TITLE
Trivial: Back to VM size we have reservation for

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -97,7 +97,7 @@ jobs:
           az-tenant-id: ${{ secrets.SP_TENANT }}
           az-image: "auto-github-runner:L0BaseImage"
           az-location: "westus"
-          az-vm-size: "Standard_D4s_v4"
+          az-vm-size: "Standard_D4s_v3"
 
   km-build:
     name: Build KM, push test image


### PR DESCRIPTION
I updated for newer faster VM size (v4) without realizing we are paying for v3 reservation. Revert back.