### PR TITLE
dynamic glibc plus some tests

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -730,6 +730,7 @@ static inline void km_signal_unlock(void)
 #define KM_TRACE_EXEC "exec"
 #define KM_TRACE_FORK "fork"   // also clone() for a process.
 #define KM_TRACE_ARGS "args"
+#define KM_TRACE_LOAD "load"
 
 /*
  * The km definition of the link_map structure in runtime/musl/include/link.h

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -114,7 +114,8 @@ static void km_find_dlopen(km_elf_t* e, km_gva_t adjust)
       }
    }
    if (found == 0) {
-      km_err(2, "Cannot find symbol table");
+      km_infox(KM_TRACE_LOAD, "Cannot find symbol table in file=%s", e->path);
+      return;
    }
 
    int nsym = sym_shdr.sh_size / sym_shdr.sh_entsize;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,7 +2,7 @@ km-bats-*.*
 gdb.txt
 .native*
 *.fedora
-*.fedora.glibc
+*.fedora.dyn
 *.ubuntu
 *.alpine
 km_*.log

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,6 +2,7 @@ km-bats-*.*
 gdb.txt
 .native*
 *.fedora
+*.fedora.glibc
 *.ubuntu
 *.alpine
 km_*.log

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -81,7 +81,7 @@ LDFLAGS := ${DEBUG}
 
 DEPS = ${SRC_C:%.c=%.d} ${SRC_SHR:%.c=%.d} ${SRC_CPP:%.cpp=%.d} ${HELPER_SRC:%.c=%.d}
 
-SUFFIXES := .km .kmd .km.so .alpine.km .alpine.kmd .${DTYPE}
+SUFFIXES := .km .kmd .km.so .alpine.km .alpine.kmd .${DTYPE} .${DTYPE}.glibc
 TESTS := ${SRC_C:%.c=%} ${SRC_CPP:%.cpp=%}
 EXECS := ${TESTS} $(abspath hello_test_link) \
 	$(foreach s,${SUFFIXES},$(addsuffix ${s},${TESTS}))
@@ -114,6 +114,7 @@ KCXX := kontain-g++
 
 # use g++ link libs when sources were C++
 # ${SRC_CPP:%.cpp=%}: CC=${CXX}
+${SRC_CPP:%.cpp=%.fedora.glibc}: CC=${CXX}
 ${SRC_CPP:%.cpp=%.fedora}: CC=${CXX} -static
 ${SRC_C:%.c=%.fedora}: LDLIBS += -static
 ${SRC_CPP:%.cpp=%.km}: KCC=${KCXX}
@@ -123,6 +124,9 @@ ${SRC_CPP:%.cpp=%.alpine.kmd}: KCC=${KCXX}
 ${SRC_CPP:%.cpp=%.km.so}: KCC=${KCXX}
 
 %.${DTYPE}: %.o
+	${CC} ${LDFLAGS} $< ${LDLIBS} -o $@
+
+%.${DTYPE}.glibc: %.o
 	${CC} ${LDFLAGS} $< ${LDLIBS} -o $@
 
 %_test: ${KM_BIN}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -81,7 +81,7 @@ LDFLAGS := ${DEBUG}
 
 DEPS = ${SRC_C:%.c=%.d} ${SRC_SHR:%.c=%.d} ${SRC_CPP:%.cpp=%.d} ${HELPER_SRC:%.c=%.d}
 
-SUFFIXES := .km .kmd .km.so .alpine.km .alpine.kmd .${DTYPE} .${DTYPE}.glibc
+SUFFIXES := .km .kmd .km.so .alpine.km .alpine.kmd .${DTYPE} .${DTYPE}.dyn
 TESTS := ${SRC_C:%.c=%} ${SRC_CPP:%.cpp=%}
 EXECS := ${TESTS} $(abspath hello_test_link) \
 	$(foreach s,${SUFFIXES},$(addsuffix ${s},${TESTS}))
@@ -114,7 +114,7 @@ KCXX := kontain-g++
 
 # use g++ link libs when sources were C++
 # ${SRC_CPP:%.cpp=%}: CC=${CXX}
-${SRC_CPP:%.cpp=%.fedora.glibc}: CC=${CXX}
+${SRC_CPP:%.cpp=%.fedora.dyn}: CC=${CXX}
 ${SRC_CPP:%.cpp=%.fedora}: CC=${CXX} -static
 ${SRC_C:%.c=%.fedora}: LDLIBS += -static
 ${SRC_CPP:%.cpp=%.km}: KCC=${KCXX}
@@ -126,7 +126,7 @@ ${SRC_CPP:%.cpp=%.km.so}: KCC=${KCXX}
 %.${DTYPE}: %.o
 	${CC} ${LDFLAGS} $< ${LDLIBS} -o $@
 
-%.${DTYPE}.glibc: %.o
+%.${DTYPE}.dyn: %.o
 	${CC} ${LDFLAGS} $< ${LDLIBS} -o $@
 
 %_test: ${KM_BIN}

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -42,7 +42,7 @@ todo_alpine_static='dl_iterate_phdr gdb_forkexec'
 
 # glibc native
 not_needed_glibc_static='cpuid setup_link setup_load gdb_sharedlib readlink_argv km_identity dlopen exec_sh'
-not_needed_glibc_dynamic='cpuid setup_link setup_load gdb_sharedlib readlink_argv km_identity dlopen exec_sh mem_brk'
+not_needed_glibc_dynamic='cpuid setup_link setup_load gdb_sharedlib readlink_argv km_identity dlopen exec_sh'
 
 # exception - extra segment in kmcore
 # dl_iterate_phdr - load starts at 4MB instead of 2MB
@@ -54,6 +54,8 @@ not_needed_glibc_dynamic='cpuid setup_link setup_load gdb_sharedlib readlink_arg
 todo_glibc_static='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
 todo_glibc_dynamic='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
 
+# TODO: figure out why mem_brk doesn't work
+todo_glibc_dynamic="${todo_glibc_dynamic} mem_brk"
 # note: this bunch are all gdb related. The issue here is the tricks we use to
 # get around in a live musl dynamic linker don't work with the glibc dynamic linker
 # because it isn't bundled with LIBC like it is with MUSL.

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -52,7 +52,7 @@ not_needed_glibc_dynamic='cpuid setup_link setup_load gdb_sharedlib readlink_arg
 # gdb_forkexec - gdb stack trace needs symbols when in a hypercall
 
 todo_glibc_static='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
-todo_glibc_dynamic='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
+todo_glibc_dynamic='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files sigaltstack'
 
 # TODO: figure out why mem_brk doesn't work
 todo_glibc_dynamic="${todo_glibc_dynamic} mem_brk"

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -42,6 +42,7 @@ todo_alpine_static='dl_iterate_phdr gdb_forkexec'
 
 # glibc native
 not_needed_glibc_static='cpuid setup_link setup_load gdb_sharedlib readlink_argv km_identity dlopen exec_sh'
+not_needed_glibc_dynamic='cpuid setup_link setup_load gdb_sharedlib readlink_argv km_identity dlopen exec_sh mem_brk'
 
 # exception - extra segment in kmcore
 # dl_iterate_phdr - load starts at 4MB instead of 2MB
@@ -51,6 +52,12 @@ not_needed_glibc_static='cpuid setup_link setup_load gdb_sharedlib readlink_argv
 # gdb_forkexec - gdb stack trace needs symbols when in a hypercall
 
 todo_glibc_static='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
+todo_glibc_dynamic='exception dl_iterate_phdr filesys gdb_nextstep raw_clone xstate_test threads_basic_tsd threads_exit_grp gdb_forkexec km_exec_guest_files'
+
+# note: this bunch are all gdb related. The issue here is the tricks we use to
+# get around in a live musl dynamic linker don't work with the glibc dynamic linker
+# because it isn't bundled with LIBC like it is with MUSL.
+todo_glibc_dynamic="${todo_glibc_dynamic} mem_mmap monitor_maps semaphore gdb_protected_mem mmap_1"
 
 not_needed_alpine_dynamic=$not_needed_alpine_static
 todo_alpine_dynamic=$todo_alpine_static

--- a/tests/run_bats_tests.sh
+++ b/tests/run_bats_tests.sh
@@ -25,7 +25,7 @@ set -e
 [ "$TRACE" ] && set -x
 
 DEFAULT_TESTS="km_core_tests.bats"
-DEFAULT_TEST_TYPE="static dynamic so alpine_static glibc_static"
+DEFAULT_TEST_TYPE="static dynamic so alpine_static glibc_static glibc_dynamic"
 
 usage() {
 cat <<EOF

--- a/tests/sigaltstack_test.c
+++ b/tests/sigaltstack_test.c
@@ -181,7 +181,7 @@ int main(int argc, char** argv)
    printf("=== %d %d\n", SIGSTKSZ, MINSIGSTKSZ);
 
    GREATEST_MAIN_BEGIN();   // init & parse command-line args
-   // greatest_set_verbosity(1);
+   greatest_set_verbosity(1);
 
    /* Tests can be run as suites, or directly. Lets run directly. */
    RUN_TEST(sas_lj);

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -92,8 +92,12 @@ case $test_type in
       ext=.fedora
       port_range_start=19777
       ;;
+   glibc_dynamic)
+      ext=.fedora.glibc
+      port_range_start=20777
+      ;;
    *)
-      echo "Unknown test type: $test_type, should be 'static', 'dynamic', 'alpine_static', 'glibc_static', 'alpine_dynamic' or 'so'."
+      echo "Unknown test type: $test_type, should be 'static', 'dynamic', 'alpine_static', 'glibc_static', 'glibc_dynamic', 'alpine_dynamic' or 'so'."
       export KM_BIN=fail
       return 1
       ;;

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -93,7 +93,7 @@ case $test_type in
       port_range_start=19777
       ;;
    glibc_dynamic)
-      ext=.fedora.glibc
+      ext=.fedora.dyn
       port_range_start=20777
       ;;
    *)


### PR DESCRIPTION
- Support programs linked against GLIBC dynamic linker.
- Add tests

Currently the GBD server does not work with programs linked against the GLIBC dynamic linker. This is due to the linker
and LIBC being separate files in GLIBC vs one file in MUSL.