### PR TITLE
Automatic ENOTSUP for unimplemented system calls

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -462,9 +462,13 @@ static const struct timespec _1ms = {
     .tv_sec = 0, .tv_nsec = 1000000, /* 1 millisec */
 };
 
+/*
+ * Environment Variables
+ */
 static const_string_t KM_VERBOSE = "KM_VERBOSE";
 static const_string_t KM_DO_SHELL = "KM_DO_SHELL";
 static const_string_t KM_MGTPIPE = "KM_MGTPIPE";
+static const_string_t KM_KILL_UNIMPL_SCALL = "KM_KILL_UNIMPL_SCALL";
 
 extern int km_do_shell;   // enable symlink trick and minimal shell parsing in KM itself
 

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -386,6 +386,10 @@ static char* km_parse_args(
    char** envp = NULL;   // NULL terminated array of env pointers
    int envc = 1;   // count of elements in envp (including NULL), see realloc below in case 'e'
 
+   // pick up env variable. explicit option can override.
+   if (getenv(KM_KILL_UNIMPL_SCALL) != NULL) {
+      kill_unimpl_hcall = 1;
+   }
    if (pl_name == NULL) {   // regular KM invocation - parse KM args
       optind = 0;           // reinit getopt
       while ((opt = getopt_long(argc, argv, km_cmd_short_options, km_cmd_long_options, &longopt_index)) !=

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -92,6 +92,7 @@ static inline void usage()
 "\t--hcall-stats (-S)                  - Collect and print hypercall stats\n"
 "\t--coredump=file_name                - File name for coredump\n"
 "\t--snapshot=file_name                - File name for snapshot\n"
+"\t--kill-unimpl-hcall                 - Kill guest in unimplemented hypercall.\n"
 "\n"
 "\tOverride auto detection:\n"
 "\t--membus-width=size (-Psize)        - Set guest physical memory bus size in bits, i.e. 32 means 4GiB, 33 8GiB, 34 16GiB, etc.\n"
@@ -149,6 +150,7 @@ int debug_dump_on_err = 0;   // if 1, will abort() instead of err()
 static char* mgtpipe = NULL;
 static int log_to_fd = -1;
 extern int set_cpu_vendor_id;
+extern int kill_unimpl_hcall;
 
 struct option km_cmd_long_options[] = {
     {"wait-for-signal", no_argument, &wait_for_signal, 1},
@@ -174,6 +176,7 @@ struct option km_cmd_long_options[] = {
     {"input-data", required_argument, 0, 'I'},
     {"output-data", required_argument, 0, 'O'},
     {"mgtpipe", required_argument, 0, 'm'},
+    {"kill-unimpl-scall", no_argument, &(kill_unimpl_hcall), KM_FLAG_FORCE_ENABLE},
 
     {0, 0, 0, 0},
 };

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -481,6 +481,11 @@ static void km_vcpu_exit_all(km_vcpu_t* vcpu)
    // TODO - consider an unforced solution
    if (km_vcpu_run_cnt() > 1) {
       km_infox(KM_TRACE_VCPU, "Forcing exit_group() without cleanup");
+      /*
+       * Even though we are forcing exit, do a hcalls fini since that will report
+       * statistics is requested.
+       */
+      km_hcalls_fini();
       exit(machine.exit_status);
    }
    km_vcpu_stopped(vcpu);

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -438,12 +438,11 @@ static int hypercall(km_vcpu_t* vcpu, int* hc_ret)
    km_hc_ret_t ret = HC_CONTINUE;
    if (km_hcalls_table[hc] != NULL) {
       ret = km_hcalls_table[hc](vcpu, hc, ga_kma);
-      *hc_ret = ga_kma->hc_ret;
    } else {
       km_infox(KM_TRACE_HC, "Unimplemented hypercall %d (%s)", hc, km_hc_name_get(hc));
-      ga_kma->hc_ret = (uint64_t) -ENOTSUP;
-      *hc_ret = -ENOTSUP;
+      ga_kma->hc_ret = (uint64_t) -ENOSYS;
    }
+   *hc_ret = ga_kma->hc_ret;
    if (km_collect_hc_stats != 0) {
       clock_gettime(CLOCK_MONOTONIC, &stop);
       uint64_t msecs = (stop.tv_sec - start.tv_sec) * 1000000000 + stop.tv_nsec - start.tv_nsec;

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -440,7 +440,7 @@ static int hypercall(km_vcpu_t* vcpu, int* hc_ret)
       ret = km_hcalls_table[hc](vcpu, hc, ga_kma);
    } else {
       km_infox(KM_TRACE_HC, "Unimplemented hypercall %d (%s)", hc, km_hc_name_get(hc));
-      ga_kma->hc_ret = (uint64_t) -ENOSYS;
+      ga_kma->hc_ret = (uint64_t) -ENOTSUP;
    }
    *hc_ret = ga_kma->hc_ret;
    if (km_collect_hc_stats != 0) {

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -419,8 +419,8 @@ static int hypercall(km_vcpu_t* vcpu, int* hc_ret)
          km_post_signal(vcpu, &info);
          return -1;
       }
+      vcpu->hypercall = hc;
    }
-   vcpu->hypercall = hc;
    // We assume hypercall args are built are on stack in the guest, but nothing in km depends on this.
    ga = (km_gva_t)km_hcargs[HC_ARGS_INDEX(vcpu->vcpu_id)];
    km_hc_args_t* ga_kma = km_gva_to_kma(ga);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -139,7 +139,7 @@ fi
 @test "hc_check($test_type): invoke wrong hypercall (hc_test$ext)" {
    # Default is ENOTSUP
    run km_with_timeout stray_test$ext hc 400
-   assert_failure 95
+   assert_failure 38
 
    # Debug option kills with SIGSYS
    run km_with_timeout --kill-unimpl-scall stray_test$ext hc 400

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -146,6 +146,11 @@ fi
    assert_failure $(( $signal_flag + 31))  #SIGSYS
    assert_output --partial "Bad system call"
 
+   # Debug option kills with SIGSYS
+   KM_KILL_UNIMPL_SCALL=1 run km_with_timeout stray_test$ext hc 400
+   assert_failure $(( $signal_flag + 31))  #SIGSYS
+   assert_output --partial "Bad system call"
+
    run km_with_timeout stray_test$ext -- hc -10
    assert_failure $(( $signal_flag + 7))   #SIGBUS
    assert_output --partial "Bus error"

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -137,7 +137,12 @@ fi
 }
 
 @test "hc_check($test_type): invoke wrong hypercall (hc_test$ext)" {
+   # Default is ENOTSUP
    run km_with_timeout stray_test$ext hc 400
+   assert_failure 95
+
+   # Debug option kills with SIGSYS
+   run km_with_timeout --kill-unimpl-scall stray_test$ext hc 400
    assert_failure $(( $signal_flag + 31))  #SIGSYS
    assert_output --partial "Bad system call"
 
@@ -743,7 +748,7 @@ fi
 
    # bad hcall
    assert [ ! -f ${CORE} ]
-   run km_with_timeout --coredump=${CORE} stray_test$ext hc 400
+   run km_with_timeout --kill-unimpl-scall --coredump=${CORE} stray_test$ext hc 400
    assert_failure $(( $signal_flag + 31)) # SIGSYS
    echo $output | grep -F 'Bad system call (core dumped)'
    assert [ -f ${CORE} ]

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -139,7 +139,7 @@ fi
 @test "hc_check($test_type): invoke wrong hypercall (hc_test$ext)" {
    # Default is ENOTSUP
    run km_with_timeout stray_test$ext hc 400
-   assert_failure 38
+   assert_failure 95
 
    # Debug option kills with SIGSYS
    run km_with_timeout --kill-unimpl-scall stray_test$ext hc 400

--- a/tests/stray_test.c
+++ b/tests/stray_test.c
@@ -222,7 +222,9 @@ int hc_test(int optind, int optarg, char* argv[])
       usage();
       return 100;
    }
-   syscall(callid, 0);
+   if (syscall(callid, 0) < 0) {
+      return errno;
+   }
    return 0;
 }
 


### PR DESCRIPTION
This is a proposal to change the default for handling unimplemented systems calls from the current behavior, killing the guest with a `SIGSYS` signal, to returning `-ENOSYS`. (Not Supported). The reasoning for this is experiments in bringing up new apps that attempt to use system calls but are tolerant of ENOSYS. They would have come right up with this implemented where with current behavior, each new system call required a hander to return `-ENOSYS`.

I've included a command line option to go back to the old behavior.