### PR TITLE
clang-format in CI

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -58,7 +58,6 @@ on:
 env:
   BUILDENV_IMAGE_VERSION: latest # use this for all buildenv containers
   IMAGE_VERSION: ci-${{ github.run_number }} # use this for all other containers
-  NIGHTLY_CLUSTER_NAME: "aks-kontain-nightly-ci-${{ github.run_number }}"
   SP_SUBSCRIPTION_ID: ${{ secrets.SP_SUBSCRIPTION_ID }}
   SP_APPID: ${{ secrets.SP_APPID }}
   SP_PASSWORD: ${{ secrets.SP_PASSWORD }}
@@ -128,6 +127,9 @@ jobs:
 
       - name: Prepare KM build env
         run: make -C tests pull-buildenv-image .buildenv-local-lib
+
+      - name: Check clang-format on source code
+        run: make withdocker TARGET=clang-format-check
 
       - name: Build KM and tests using buildenv image
         run: make -j withdocker RUN_IN_CI=1

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,13 @@ include ${TOP}/make/actions.mk
 # build VMM and runtime library before trying to build tests
 tests: km runtime container-runtime lib
 
+.PHONY: clang-format clang-format-check
+clang-format-check:
+	clang-format --dry-run -Werror km/*.h km/*.c tests/*.h tests/*.c tests/*.cpp
+
+clang-format:
+	clang-format -i km/*.h km/*.c tests/*.h tests/*.c tests/*.cpp
+
 # On mac $(MAKE) evaluates to '/Applications/Xcode.app/Contents/Developer/usr/bin/make'
 ifeq ($(shell uname), Darwin)
 MAKE := make


### PR DESCRIPTION
Added clang-format in the buildenv-image, building it from source. It is not static as I wasn't able to quickly build that with cmake. On the other hand since it is built in the buildenv it refers to all the right libs, so runs fine in CI.

Checked with broken alignment https://github.com/kontainapp/km/runs/6234274961?check_suite_focus=true#step:6:20 and with fixed one https://github.com/kontainapp/km/runs/6234522245?check_suite_focus=true#step:6:18

Also added top level makefile target `clang-format` to run format locally, for those who use the tools without auto formatting.