### PR TITLE
km_assert to use our km_log_file instead of stderr

### DIFF
--- a/km/gdb_kvm_x86_64.c
+++ b/km/gdb_kvm_x86_64.c
@@ -185,7 +185,7 @@ static int kvm_arch_remove_sw_breakpoint(struct breakpoint_t* bp)
       }
    }
 
-   assert(*insn == int3);
+   km_assert(*insn == int3);
    *insn = bp->saved_insn;
 
    if ((prot & PROT_WRITE) == 0) {
@@ -288,7 +288,7 @@ static struct breakpoint_t* bp_list_find(gdb_breakpoint_type_t type, km_gva_t ad
          break;
 
       default:
-         assert(0);
+         km_assert(0);
    }
 
    return NULL;
@@ -362,7 +362,7 @@ static struct breakpoint_t* bp_list_insert(gdb_breakpoint_type_t type, km_gva_t 
          break;
 
       default:
-         assert("Unknown breakpoint type in insert" == NULL);
+         km_abortx("Unknown breakpoint type in insert");
    }
 
    return bp;
@@ -397,7 +397,7 @@ static int bp_list_remove(gdb_breakpoint_type_t type, km_gva_t addr, size_t len)
          break;
 
       default:
-         assert("Unknown breakpoint type in remove" == NULL);
+         km_abortx("Unknown breakpoint type in remove");
    }
    free(bp);
    return 0;
@@ -609,9 +609,9 @@ int km_gdb_write_registers(km_vcpu_t* vcpu, uint8_t* registers, size_t len)
     * notion of x86_64 but our CPU model sets the segments once and they never
     * change after that.
     */
-   assert(vcpu->sregs.cs.selector == gregs->cs && vcpu->sregs.ss.selector == gregs->ss &&
-          vcpu->sregs.ds.selector == gregs->ds && vcpu->sregs.es.selector == gregs->es &&
-          vcpu->sregs.fs.selector == gregs->fs && vcpu->sregs.gs.selector == gregs->gs);
+   km_assert(vcpu->sregs.cs.selector == gregs->cs && vcpu->sregs.ss.selector == gregs->ss &&
+             vcpu->sregs.ds.selector == gregs->ds && vcpu->sregs.es.selector == gregs->es &&
+             vcpu->sregs.fs.selector == gregs->fs && vcpu->sregs.gs.selector == gregs->gs);
 
    km_write_registers(vcpu);
    return 0;

--- a/km/km.h
+++ b/km/km.h
@@ -17,6 +17,7 @@
 #ifndef __KM_H__
 #define __KM_H__
 
+#include <assert.h>
 #include <errno.h>
 #include <getopt.h>
 #include <pthread.h>
@@ -569,6 +570,18 @@ static inline int km_trace_tag_enabled(const char* tag)
       __km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__);                               \
       abort();                                                                                     \
    } while (0)
+
+#define km_assert_msgx(expr, fmt, ...)                                                               \
+   do {                                                                                              \
+      (expr) ? (void)(0) : (__km_trace(errno, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__), abort()); \
+   } while (0)
+
+#define km_assert_msg(expr, fmt, ...)                                                              \
+   do {                                                                                            \
+      (expr) ? (void)(0) : (__km_trace(0, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__), abort());   \
+   } while (0)
+
+#define km_assert(expr) km_assert_msgx(expr, "Assertion `%s' failed", #expr)
 
 #define km_mutex_lock(mutex)                                                                       \
    do {                                                                                            \

--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -445,8 +445,8 @@ static inline int km_core_dump_payload_note(km_payload_t* payload, int tag, char
 
 static inline int km_core_write_notes(km_vcpu_t* vcpu,
                                       int fd,
-                                      char* label,
-                                      char* description,
+                                      const char* label,
+                                      const char* description,
                                       off_t offset,
                                       char* buf,
                                       size_t size,
@@ -550,7 +550,7 @@ static inline int km_core_write_notes(km_vcpu_t* vcpu,
       remain -= strlen(description) + 1;
    }
 
-   assert(cur <= buf + size);
+   km_assert(cur <= buf + size);
    // TODO: Other notes sections in real core files.
    //  NT_PRPSINFO (prpsinfo structure)
    //  NT_SIGINFO (siginfo_t data)
@@ -603,7 +603,7 @@ static inline void km_guestmem_write(int fd, km_gva_t base, size_t length)
  * Returns buffer allocation size for core PT_NOTES section based on the
  * number of active vcpu's (threads).
  */
-static inline size_t km_core_notes_length(km_vcpu_t* vcpu, char* label, char* description)
+static inline size_t km_core_notes_length(km_vcpu_t* vcpu, const char* label, const char* description)
 {
    int nvcpu = km_vcpu_run_cnt();
    int nvcpu_inc = (vcpu == NULL) ? 0 : 1;
@@ -728,8 +728,8 @@ static inline void km_core_write_phdrs(km_vcpu_t* vcpu,
                                        km_gva_t end_load,
                                        char* notes_buffer,
                                        size_t notes_length,
-                                       char* label,
-                                       char* description,
+                                       const char* label,
+                                       const char* description,
                                        size_t* offsetp,
                                        km_coredump_type_t dumptype)
 {
@@ -804,8 +804,8 @@ static int km_snapshot_ok(void)
 void km_dump_core(char* core_path,
                   km_vcpu_t* vcpu,
                   x86_interrupt_frame_t* iframe,
-                  char* label,
-                  char* description,
+                  const char* label,
+                  const char* description,
                   km_coredump_type_t dumptype)
 {
    // char* core_path = km_get_coredump_path();

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -199,8 +199,8 @@ typedef enum { KM_DO_CORE, KM_DO_SNAP } km_coredump_type_t;
 void km_dump_core(char* filename,
                   km_vcpu_t* vcpu,
                   x86_interrupt_frame_t* iframe,
-                  char* label,
-                  char* description,
+                  const char* label,
+                  const char* description,
                   km_coredump_type_t dumptype);
 void km_set_coredump_path(char* path);
 char* km_get_coredump_path();

--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -99,7 +99,7 @@ void km_vcpu_fini(km_vcpu_t* vcpu)
 void km_machine_fini(void)
 {
    close(machine.shutdown_fd);
-   assert(km_vcpu_run_cnt() == 0);
+   km_assert(km_vcpu_run_cnt() == 0);
    free(machine.auxv);
    if (km_guest.km_filename != NULL) {
       free((void*)km_guest.km_filename);
@@ -195,7 +195,7 @@ static void km_init_tsc(km_vcpu_t* vcpu)
 
 void kvm_vcpu_init_sregs(km_vcpu_t* vcpu)
 {
-   assert(machine.idt != 0);
+   km_assert(machine.idt != 0);
    vcpu->sregs = (kvm_sregs_t){
        .cr0 = X86_CR0_PE | X86_CR0_PG | X86_CR0_WP | X86_CR0_NE,
        .cr3 = RSV_MEM_START,
@@ -291,7 +291,7 @@ km_vcpu_t* km_vcpu_get(void)
 
    km_mutex_lock(&machine.vm_vcpu_mtx);
    if ((vcpu = SLIST_FIRST(&machine.vm_idle_vcpus.head)) != 0) {
-      assert(vcpu->state == PARKED_IDLE);
+      km_assert(vcpu->state == PARKED_IDLE);
       SLIST_REMOVE_HEAD(&machine.vm_idle_vcpus.head, next_idle);
       machine.vm_vcpu_run_cnt++;
       vcpu->state = STARTING;
@@ -435,7 +435,7 @@ void km_vcpu_pause_all(km_vcpu_t* vcpu, km_pause_t type)
             nanosleep(&_1ms, NULL);
             km_infox(KM_TRACE_VCPU, "waiting for KVM_RUN to exit - %d", i);
          }
-         assert(count == 0);
+         km_assert(count == 0);
          return;
       case ALL:
          while (km_vcpu_apply_all(km_vcpu_not_paused, vcpu) != 0) {
@@ -471,7 +471,7 @@ void km_vcpu_put(km_vcpu_t* vcpu)
 int km_vcpu_set_to_run(km_vcpu_t* vcpu, km_gva_t start, uint64_t arg)
 {
    km_gva_t sp = vcpu->stack_top;   // where we put argv
-   assert((sp & 0x7) == 0);
+   km_assert((sp & 0x7) == 0);
 
    kvm_vcpu_init_sregs(vcpu);
    vcpu->regs = (kvm_regs_t){
@@ -691,7 +691,7 @@ void km_machine_setup(km_machine_init_params_t* params)
    if (machine.pdpe1g == 0) {
       /*
        * In the absence of 1gb pages we can only support 2GB, first for text+data, and the second
-       * for the stack. See assert() in set_pml4_hierarchy()
+       * for the stack. See km_assert() in set_pml4_hierarchy()
        */
       km_infox(KM_TRACE_MEM,
                "KVM: 1gb pages are not supported (pdpe1g=0), setting VM max mem to 2 GiB");

--- a/km/km_exec.c
+++ b/km/km_exec.c
@@ -315,7 +315,7 @@ char** km_exec_build_env(char** envp)
       j++;
    }
    newenvp[i + j] = NULL;
-   assert(i + j == envc - 1 + KM_EXEC_VARS + gdb_vars);
+   km_assert(i + j == envc - 1 + KM_EXEC_VARS + gdb_vars);
 
    // Return pointer to the new env.
    return newenvp;
@@ -422,14 +422,14 @@ static int km_exec_get_vmfds(char* vmfds)
    char* saveptr;
    char* p;
    p = strtok_r(pi, ",", &saveptr);
-   assert(p != NULL);
+   km_assert(p != NULL);
    pi = NULL;
    p = strtok_r(pi, ",", &saveptr);
-   assert(p != NULL);
+   km_assert(p != NULL);
    int vcpu_num = 0;
    while ((p = strtok_r(pi, ",", &saveptr)) != NULL) {
       execstatep->kvm_vcpu_fd[vcpu_num] = atoi(p);
-      assert(execstatep->kvm_vcpu_fd[vcpu_num] >= 0);
+      km_assert(execstatep->kvm_vcpu_fd[vcpu_num] >= 0);
       vcpu_num++;
    }
    execstatep->kvm_vcpu_fd[vcpu_num] = -1;
@@ -461,7 +461,7 @@ static int km_exec_get_guestfds(char* guestfds)
  */
 static void km_exec_vmclean(void)
 {
-   assert(execstatep != NULL);
+   km_assert(execstatep != NULL);
    close(execstatep->intr_fd);
    close(execstatep->shutdown_fd);
    for (int i = 0; i < KVM_MAX_VCPUS && execstatep->kvm_vcpu_fd[i] >= 0; i++) {
@@ -489,7 +489,8 @@ int km_exec_recover_kmstate(void)
    if (vernum == NULL || vmfds == NULL || eventfds == NULL || guestfds == NULL || pidinfo == NULL) {
       // If we don't have them all, then this isn't an exec().
       // And, if one is missing they all need to be missing.
-      assert(vernum == NULL && vmfds == NULL && eventfds == NULL && guestfds == NULL && pidinfo == NULL);
+      km_assert(vernum == NULL && vmfds == NULL && eventfds == NULL && guestfds == NULL &&
+                pidinfo == NULL);
       return 0;
    }
 

--- a/km/km_exec_fd_save_recover.c
+++ b/km/km_exec_fd_save_recover.c
@@ -336,7 +336,7 @@ static int km_exec_restore_file(int fd, int how, int flags, int index)
    km_exec_get_file_pointer(fd, &file, NULL);
    TAILQ_INIT(&file->events);
 
-   assert(km_is_file_used(file) == 0);
+   km_assert(km_is_file_used(file) == 0);
    km_set_file_used(file, 1);
    file->how = how;
    file->flags = flags;
@@ -376,7 +376,7 @@ static int km_exec_restore_eventfd(int fd, int flags)
    km_exec_get_file_pointer(fd, &file, NULL);
    TAILQ_INIT(&file->events);
 
-   assert(km_is_file_used(file) == 0);
+   km_assert(km_is_file_used(file) == 0);
    km_set_file_used(file, 1);
    file->how = KM_FILE_HOW_EVENTFD;
    file->flags = flags;

--- a/km/km_fork.c
+++ b/km/km_fork.c
@@ -111,9 +111,7 @@ static void km_fork_setup_child_vmstate(sigset_t* formermask)
 
    // km signal system is ready to handle signals
    int rc = sigprocmask(SIG_SETMASK, formermask, NULL);
-   if (rc != 0) {
-      km_abort("Couldn't restore child's signal mask");
-   }
+   km_assert_msgx(rc == 0, "Couldn't restore child's signal mask");
 
    // No need to call km_init_guest_idt(). Use what was inherited from the parent process.
 
@@ -337,9 +335,7 @@ int km_dofork(int* in_child)
    sigaddset(&blockthese, SIGUSR1);
    sigaddset(&blockthese, SIGCHLD);   // block SIGCHLD until the child's pid is entered into the pid map
    int rc = sigprocmask(SIG_BLOCK, &blockthese, &formermask);
-   if (rc != 0) {
-      km_abort("Couldn't block signals before fork/clone");
-   }
+   km_assert_msgx(rc == 0, "Couldn't block signals before fork/clone");
 
    km_trace_include_pid(1);   // include the pid in trace output
    if (km_fork_state.is_clone != 0) {
@@ -396,7 +392,7 @@ int km_dofork(int* in_child)
 
       // unblock the signals we blocked earlier
       rc = sigprocmask(SIG_SETMASK, &formermask, NULL);
-      assert(rc == 0);
+      km_assert(rc == 0);
    }
 
    if (need_to_wait == 0) {

--- a/km/km_guest.h
+++ b/km/km_guest.h
@@ -56,8 +56,8 @@ extern uint8_t km_guest_end;
 static inline km_gva_t km_guest_kma_to_gva(km_kma_t km_guest_addr)
 {
    km_gva_t gva;
-   assert((uint64_t)km_guest_addr >= (uint64_t)&km_guest_start &&
-          (uint64_t)km_guest_addr < (uint64_t)&km_guest_end);
+   km_assert((uint64_t)km_guest_addr >= (uint64_t)&km_guest_start &&
+             (uint64_t)km_guest_addr < (uint64_t)&km_guest_end);
    gva = GUEST_KMGUESTMEM_BASE_VA + ((uint64_t)km_guest_addr - (uint64_t)&km_guest_start);
    return gva;
 }

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1687,7 +1687,7 @@ static km_hc_ret_t execveat_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    }
    // Get the filename for the open km payload executable.
    char* exe_path = km_guestfd_name(vcpu, km_fs_h2g_fd(exefd));
-   assert(exe_path != NULL);
+   km_assert(exe_path != NULL);
    if (exefd != dirfd) {
       close(exefd);
    }

--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -191,7 +191,7 @@ km_gva_t km_init_main(km_vcpu_t* vcpu, int argc, char* const argv[], int envc, c
          }
       }
    }
-   assert(phdr_found != 0);
+   km_assert(phdr_found != 0);
    NEW_AUXV_ENT(AT_CLKTCK, sysconf(_SC_CLK_TCK));
    NEW_AUXV_ENT(AT_PAGESZ, KM_PAGE_SIZE);
    // TODO: AT_HWCAP
@@ -203,7 +203,7 @@ km_gva_t km_init_main(km_vcpu_t* vcpu, int argc, char* const argv[], int envc, c
    // A safe copy of auxv for coredump (if needed)
    machine.auxv_size = auxv_end - stack_top_kma;
    machine.auxv = malloc(machine.auxv_size);
-   assert(machine.auxv);
+   km_assert(machine.auxv);
    memcpy(machine.auxv, stack_top_kma, machine.auxv_size);
 
    // place envp array
@@ -277,7 +277,7 @@ int km_clone(km_vcpu_t* vcpu,
              km_gva_t ctid,
              unsigned long newtls)
 {
-   assert((flags & CLONE_THREAD) != 0);   // we only have thread clone here.
+   km_assert((flags & CLONE_THREAD) != 0);   // we only have thread clone here.
 
    child_stack &= ~0x7;
    if (km_gva_to_kma(child_stack - 8) == NULL) {   // check if the stack points to legitimate memory

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -221,7 +221,7 @@ char* km_parse_shebang(const char* payload_file, char** extra_arg)
    int fd;
    int count;
 
-   assert(payload_file != NULL);
+   km_assert(payload_file != NULL);
    km_infox(KM_TRACE_EXEC, "input payload_file %s", payload_file);
    *extra_arg = NULL;
 
@@ -289,7 +289,7 @@ static void km_mimic_payload_argv(int argc, char** argv, int pl_index)
       char* end = argv[argc - 1] + strlen(argv[argc - 1]) + 1;
       int size = end - argv[pl_index];
       int shift = argv[pl_index] - argv[0];
-      assert(shift + size == end - argv[0]);
+      km_assert(shift + size == end - argv[0]);
 
       memmove(argv[0], argv[pl_index], size);
       memset(argv[0] + size, 0, shift);

--- a/km/km_mem.h
+++ b/km/km_mem.h
@@ -150,7 +150,7 @@ static const km_kma_t KM_USER_MEM_BASE = (void*)0x100000000000ul;
 // memreg index for an addr in the bottom half of the PA (after that the geometry changes)
 static inline int MEM_IDX(km_gva_t addr)
 {
-   assert(addr > 0);   // clzl fails when there are no 1's
+   km_assert(addr > 0);   // clzl fails when there are no 1's
    // 43 is "64 - __builtin_clzl(2*MIB)"
    return (43 - __builtin_clzl(addr));
 }
@@ -167,15 +167,15 @@ static inline km_gva_t gva_to_gpa_nocheck(km_gva_t gva)
 static inline km_gva_t gva_to_gpa(km_gva_t gva)
 {
    // gva must be in the bottom or top "max_physmem", but not in between
-   assert((GUEST_MEM_START_VA - 1 <= gva && gva < GUEST_MEM_ZONE_SIZE_VA) ||
-          (GUEST_VA_OFFSET <= gva && gva <= GUEST_MEM_TOP_VA));
+   km_assert((GUEST_MEM_START_VA - 1 <= gva && gva < GUEST_MEM_ZONE_SIZE_VA) ||
+             (GUEST_VA_OFFSET <= gva && gva <= GUEST_MEM_TOP_VA));
    return gva_to_gpa_nocheck(gva);
 }
 
 // helper to convert physical to virtual in the top of VA
 static inline km_gva_t gpa_to_upper_gva(uint64_t gpa)
 {
-   assert(GUEST_MEM_START_VA <= gpa && gpa < machine.guest_max_physmem);
+   km_assert(GUEST_MEM_START_VA <= gpa && gpa < machine.guest_max_physmem);
    return gpa + GUEST_VA_OFFSET;
 }
 

--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -575,7 +575,7 @@ void km_deliver_signal(km_vcpu_t* vcpu, siginfo_t* info)
 
       // Signals that get here terminate the process. The only question is: core or no core?
       int core_dumped = 0;
-      assert(info->si_signo != SIGCHLD);   // KM does not support
+      km_assert(info->si_signo != SIGCHLD);   // KM does not support
       km_vcpu_pause_all(vcpu, GUEST_ONLY);
       if ((km_sigismember(&perror_signals, info->si_signo) != 0) || (info->si_signo == SIGQUIT)) {
          extern int debug_dump_on_err;
@@ -613,7 +613,7 @@ void km_deliver_signal(km_vcpu_t* vcpu, siginfo_t* info)
       km_abortx("signal %d didn't terminate this instance of km?", info->si_signo);
    }
 
-   assert(act->handler != (km_gva_t)SIG_IGN);
+   km_assert(act->handler != (km_gva_t)SIG_IGN);
    do_guest_handler(vcpu, info, act);
 
    // Reset the signal action to default if requested.

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -193,7 +193,7 @@ static inline char* km_snapshot_read_notes(int fd, size_t* notesize, km_payload_
       Elf64_Phdr* phdr = &payload->km_phdr[i];
       if (phdr->p_type == PT_NOTE) {
          char* notebuf = malloc(phdr->p_filesz);
-         assert(notebuf != NULL);
+         km_assert(notebuf != NULL);
          int rc;
          if ((rc = pread(fd, notebuf, phdr->p_filesz, phdr->p_offset)) != phdr->p_filesz) {
             if (rc < 0) {

--- a/km/km_trace.c
+++ b/km/km_trace.c
@@ -174,7 +174,7 @@ void km_trace_set_log_file_name(char* kmlog_file_name)
  * The command line args take precedence over the KM_VERBOSE variable's value if both
  * are present when invoked from the shell.
  * When invoked from a km payload we ignore km command line trace settings and use the
- * inherited trace fd and use trace categoeries from the KM_VERBOSE envrionment variable.
+ * inherited trace fd and use trace categories from the KM_VERBOSE envrionment variable.
  */
 void km_trace_setup(int argc, char* argv[])
 {

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -562,7 +562,7 @@ static inline void km_vcpu_handle_pause(km_vcpu_t* vcpu, int hc_ret)
 {
    if (machine.exit_group != 0) {   // exit_group() - we are done.
       km_vcpu_stopped(vcpu);        // Clean up and exit the current VCPU thread
-      assert("Reached the unreachable" == NULL);
+      km_abortx("Reached the unreachable");
    }
    if (machine.pause_requested == 0 && km_gdb_client_is_attached() == 0) {
       return;
@@ -602,7 +602,7 @@ static inline void km_vcpu_handle_pause(km_vcpu_t* vcpu, int hc_ret)
    // if exit_group() or equivalent happened while we were sleeping, like destructive snapshot, handle it
    if (machine.exit_group != 0) {   // exit_group() - we are done.
       km_vcpu_stopped(vcpu);        // Clean up and exit the current VCPU thread
-      assert("Reached the unreachable" == NULL);
+      km_abortx("Reached the unreachable");
    }
 }
 

--- a/km/load_elf.c
+++ b/km/load_elf.c
@@ -70,7 +70,7 @@ static void load_extent(int fd, const Elf64_Phdr* phdr, km_gva_t base)
     *
     * We also have a test in the test suite to check for 2MB start.
     */
-   assert(top >= GUEST_MEM_START_VA);
+   km_assert(top >= GUEST_MEM_START_VA);
 
    /* Extent memory if necessary */
    if (top >= km_mem_brk(0)) {

--- a/tests/memslot_test.c
+++ b/tests/memslot_test.c
@@ -26,6 +26,10 @@
 
 km_machine_t machine;
 
+void __km_trace(int errnum, const char* function, int linenumber, const char* fmt, ...)
+{
+}
+
 static char* out_sz(uint64_t val)
 {
    char* buf = malloc(64);   // yeah. leak it


### PR DESCRIPTION
Regular assert uses stderr which is closed. All km messages redirected to km_log_file. This makes asserts use the same file. Without this assert actually segfaults trying to write a message.