### PR TITLE
Ez leka/k8s release

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -528,6 +528,7 @@ jobs:
       - name: Install Kontain on minikube k8s
         run: |
           # merges and applies all the files for CI overlay
+          export RELEASE_TAG=current && envsubst < cloud/k8s/deploy/kontain-deploy/base/set_env.templ > cloud/k8s/deploy/kontain-deploy/base/set_env.yaml
           kubectl apply -k cloud/k8s/deploy/kontain-deploy/overlays/ci
           # kubectl apply -f cloud/k8s/deploy/runtime-class.yaml
           # kubectl apply -f cloud/k8s/deploy/cm-install-lib.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ cscope.out
 perf*.data
 perf*.data.old
 *.svg
+cloud/k8s/deploy/kontain-deploy/base/set_env.yaml

--- a/cloud/k8s/deploy/.gitignore
+++ b/cloud/k8s/deploy/.gitignore
@@ -1,1 +1,1 @@
-outputs/
+daemonset/

--- a/cloud/k8s/deploy/kontain-deploy/base/cm-install-lib.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/base/cm-install-lib.yaml
@@ -26,7 +26,7 @@ data:
     #!/usr/bin/env bash
 
     # This will get overridden be ENV definition in kontain-deploy.yaml
-    KONTAIN_RELEASE_URL="${KONTAIN_RELEASE_URL:-https://github.com/kontainapp/km/releases/download/latest/kontain_bin.tar.gz}"
+    KONTAIN_RELEASE_URL="${KONTAIN_RELEASE_URL:-https://github.com/kontainapp/km/releases/download/current/kontain_bin.tar.gz}"
 
     function install_kontain_artifacts() {
       echo "Install Kontain Runtime Artifacts (KM & KRUN)"

--- a/cloud/k8s/deploy/kontain-deploy/base/kontain-deploy.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/base/kontain-deploy.yaml
@@ -1,5 +1,5 @@
 # Copyright 2021 Kontain
-# Derived from: 
+# Derived from:
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ spec:
         - name: CONTAINERD_CFG_DIR
           value: /etc/containerd
         - name: KONTAIN_RELEASE_URL
-          value: https://github.com/kontainapp/km/releases/download/v0.9.5/kontain_bin.tar.gz
+          value: https://github.com/kontainapp/km/releases/download/current/kontain_bin.tar.gz
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/cloud/k8s/deploy/kontain-deploy/base/kustomization.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/base/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
   - kontain-deploy.yaml
   - cm-install-lib.yaml
   - cm-containerd-install.yaml
+
+patchesStrategicMerge:
+- set_env.yaml

--- a/cloud/k8s/deploy/kontain-deploy/base/set_env.templ
+++ b/cloud/k8s/deploy/kontain-deploy/base/set_env.templ
@@ -1,0 +1,27 @@
+# Copyright 2021 Kontain
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kontain-node-initializer
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: node-initializer
+          env:
+            - name: KONTAIN_RELEASE_URL
+              value:  https://github.com/kontainapp/km/releases/download/${RELEASE_TAG}/kontain_bin.tar.gz

--- a/cloud/k8s/deploy/kontain-deploy/overlays/kkm/cm-install-lib-kkm.yaml
+++ b/cloud/k8s/deploy/kontain-deploy/overlays/kkm/cm-install-lib-kkm.yaml
@@ -26,7 +26,7 @@ data:
     #!/usr/bin/env bash
 
     # This will get overridden be ENV definition in kontain-deploy.yaml
-    KONTAIN_RELEASE_URL="${KONTAIN_RELEASE_URL:-https://github.com/kontainapp/km/releases/download/v0.9.5/kontain_bin.tar.gz}"
+    KONTAIN_RELEASE_URL="${KONTAIN_RELEASE_URL:-https://github.com/kontainapp/km/releases/download/current/kontain_bin.tar.gz}"
 
     # we use chroot here because the host is rooted at /root
     # and kkm install looks for sudo and dkms in locations on the host

--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -74,6 +74,7 @@ RUN dnf install -y \
    time patch file findutils diffutils which procps-ng python2 \
    glibc-devel glibc-static libstdc++-static \
    bzip2-devel \
+   golang-sigs-k8s-kustomize \
    zlib-static bzip2-static xz-static xz \
    openssl-devel openssl-static jq googler \
    python3-markupsafe libffi-devel parallel \


### PR DESCRIPTION
Added 2 targets to top level makefile to automate updating and properly tagging deploy yamls:
1. deploy-config - builds yaml files using RELEASE_TAG specified. If none, v0.1.-test default is used
2. release-prep - depends on deploy-config. After all deployy yaml files are built, tags release using RELEASE_TAG specified. If none, v0.1.-test default is used

Also, I have  changed release document to reflect new way of creating release. Manual manipulation of k8s yaml files is no longer required. Please review and accept document changes as well.