### PR TITLE
save km core in CI

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -352,7 +352,7 @@ jobs:
           make -C payloads -j pull-testenv-image
 
       - name: KM with KVM Test - Azure
-        run: make -C tests test-withdocker DOCKER_INTERACTIVE=
+        run: make -C tests test-withdocker DOCKER_INTERACTIVE= DOCKER_RUN_CLEANUP=
         timeout-minutes: 20
 
       - name: KM with KVM Payloads Test - Azure
@@ -462,7 +462,7 @@ jobs:
           make -C payloads -j pull-testenv-image
 
       - name: KM with KKM Test - AWS
-        run: make -C tests test-withdocker HYPERVISOR_DEVICE=/dev/kkm DOCKER_INTERACTIVE=
+        run: make -C tests test-withdocker HYPERVISOR_DEVICE=/dev/kkm DOCKER_INTERACTIVE= DOCKER_RUN_CLEANUP=
         timeout-minutes: 20
 
       - name: KM with KKM Payloads Test - AWS

--- a/cloud/scripts/L0-image-provision.sh
+++ b/cloud/scripts/L0-image-provision.sh
@@ -53,6 +53,8 @@ useradd -m -s /bin/bash -G docker $1
 echo "kontain ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/kontain && chmod 440 /etc/sudoers.d/kontain
 echo | su $1 -c 'ssh-keygen -N "" -q'
 
+sysctl -w kernel.core_pattern=core_%P
+
 # TODO - this needs to be in another base image (VagrantPreloadedBaseImage)
 #  in the vast majority of cases these extra few GiB for boxes are not needed
 # TODO box version and OS List is currently defined in multiple places


### PR DESCRIPTION
There are two changes here. First we change the `kernel.core_pattern` in the L0 base image to `core_%P`, so the km core files are written in the test directory in case km crashed. And second, we keep container after the run completes `DOCKER_RUN_CLEANUP=` so we can copy the files from it for inspection.