### PR TITLE
TRIVIAL: Move to codeql v2

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -639,7 +639,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # enhanced security checks.
@@ -649,7 +649,7 @@ jobs:
           make -C km all
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2
 
   slack-workflow-status:
     name: Notify slack, if needed


### PR DESCRIPTION
Per https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

The CI run fails because of krun.static artifact issue, but we can see the codeql works.