### PR TITLE
Ez leka/build optimizations

### DIFF
--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 name: KM CI Pipeline
 on:
   pull_request:
@@ -187,9 +188,14 @@ jobs:
             build/opt/kontain/bin
             build/opt/kontain/lib
             build/opt/kontain/include
-            tests/hello_test.km
+            tests/hello_test.kmd
+            tests/hello_test
+            tests/hello_test.c
+            tests/hello_test.o
+            tests/libhelper.a
             container-runtime/docker_config.sh
             build/opt/kontain/runtime
+            build/cloud/k8s/deploy/shim/containerd-shim-krun-v2
           retention-days: 7
 
   km-build-payloads:
@@ -206,9 +212,10 @@ jobs:
           name: km-build
           path: .
 
-      - name: Checking download and creating build directory
+      - name: Changing permissions for build/opt/bintain/bin/* files
         run: |
           ls -R build
+          chmod +x build/opt/kontain/bin/*
 
       - run: make -C cloud/azure login-cli
 
@@ -234,6 +241,7 @@ jobs:
         run: |
           make -C payloads/python build-modules pack-modules CUSTOM_MODULES="markupsafe wrapt"
           make -C payloads/python custom CUSTOM_MODULES="markupsafe wrapt"
+
 
   # Builds a static linked, stripped binary for krun/crun
   # This uses the NIX virtual machine, just like the crun CI.
@@ -350,12 +358,16 @@ jobs:
 
           chmod 755 ${BLDTOP}/opt/kontain/bin/km
           chmod 755 ${BLDTOP}/opt/kontain/bin/krun
+          chmod 755 ${BLDTOP}/opt/kontain/bin/krun-label-trigger
           chmod 755 ${BLDTOP}/cloud/k8s/deploy/shim/containerd-shim-krun-v2
 
           tar -czvf ${BLDTOP}/kontain_bin.tar.gz \
-              -C ${BLDTOP} km/km container-runtime/krun container-runtime/krun-label-trigger \
-              cloud/k8s/deploy/shim/containerd-shim-krun-v2 kkm.run \
-              -C ${BLDTOP}/opt/kontain bin/docker_config.sh
+              -C ${BLDTOP} opt/kontain/bin/km \
+                opt/kontain/bin/krun \
+                opt/kontain/bin/krun-label-trigger \
+                opt/kontain/bin/docker_config.sh \
+                cloud/k8s/deploy/shim/containerd-shim-krun-v2 \
+                kkm.run
 
       - uses: actions/upload-artifact@v2
         with:
@@ -404,7 +416,7 @@ jobs:
         run: make -C payloads test-withdocker DOCKER_INTERACTIVE=
         timeout-minutes: 20
 
-      - name: KM with KVM Payloads Test - Azure
+      - name: KM with KVM Payloads Test All (on schedule) - Azure
         if: ${{ github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.run_type == 'nightly') }}
         run: make -C payloads test-all-withdocker DOCKER_INTERACTIVE=
@@ -445,7 +457,7 @@ jobs:
   kkm-test:
     name: KM tests, KKM on CI VM
     runs-on: ubuntu-20.04
-    needs: [km-build, kkm-build]
+    needs: [km-build, kkm-build, km-build-payloads]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -621,18 +633,18 @@ jobs:
       - name: Install KKM
         run: sudo insmod kkm/kkm/kkm.ko
 
-      - name: Untar release
-        run: tar -C /tmp/bin_release -xf /tmp/bin_release/kontain_bin.tar.gz
-
       - name: Stop Docker
         run: sudo systemctl stop docker
 
+      - name: Untar release
+        run: |
+          sudo tar -C / -xf /tmp/bin_release/kontain_bin.tar.gz
+          sudo ls -R /opt/kontain
+          sudo ls -R /cloud
+
       - name: Install KM and Reconfigure Docker
         run: |
-          sudo mkdir -p /opt/kontain/bin
-          sudo cp /tmp/bin_release/km/km /opt/kontain/bin/km
-          sudo cp /tmp/bin_release/container-runtime/krun /opt/kontain/bin/krun-label-trigger
-          sudo cp /tmp/bin_release/cloud/k8s/deploy/shim/containerd-shim-krun-v2 /usr/bin/containerd-shim-krun-v2
+          sudo mv /cloud/k8s/deploy/shim/containerd-shim-krun-v2 /usr/bin/containerd-shim-krun-v2
           cat << EOF | sudo tee /etc/docker/daemon.json
              {
                  "default-runtime": "krun",
@@ -705,7 +717,6 @@ jobs:
     needs:
       [
         km-build,
-        km-build-payloads,
         krun-static-build,
         kkm-build,
         km-test,

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -399,7 +399,7 @@ jobs:
   km-payloads-azure:
     name: Payloads on Azure
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
-    needs: [start-runners, km-build, km-build-payloads, km-test-azure]
+    needs: [km-build-payloads, km-test-azure]
     steps:
       # no need to checkout - just continue where tests left
       - name: Pull testenv images
@@ -522,7 +522,7 @@ jobs:
 
   kkm-payloads-aws:
     name: Payloads on AWS
-    needs: [start-runners, km-build, kkm-build, km-build-payloads, kkm-test-aws]
+    needs: [km-build-payloads, kkm-test-aws]
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
     steps:
       # no need to checkout - just continue where stopped after tests

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -160,8 +160,9 @@ jobs:
             build/opt/kontain/bin/shim
           retention-days: 7
 
+      # passign hello_test.kmd that is required by testenv of payloads - it already has correct RPATH.
       # passing hello_test.c and libhelper.a
-      # because we will need to rebuid hello_test.kmd with correct RPATH for test and runtime environments
+      # because we will need to rebuid hello_test.kmd with correct RPATH for runtime environments
       - uses: actions/upload-artifact@v2
         with:
           name: km-build
@@ -170,6 +171,7 @@ jobs:
             build/opt/kontain/bin
             build/opt/kontain/lib
             build/opt/kontain/include
+            tests/hello_test.kmd
             tests/hello_test.c
             tests/libhelper.a
             container-runtime/docker_config.sh

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -156,6 +156,7 @@ jobs:
           name: km
           path: |
             build/opt/kontain/bin/km
+            build/opt/kontain/bin/kontain-gcc
             build/opt/kontain/bin/krun
             build/opt/kontain/bin/shim
           retention-days: 7
@@ -395,12 +396,7 @@ jobs:
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
     needs: [start-runners, km-build, km-build-payloads]
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - run: make -C cloud/azure login-cli
-
+      # no need to checkout - just continue where tests left
       - name: Pull testenv images
         run: |
           make -C payloads -j pull-testenv-image
@@ -519,12 +515,7 @@ jobs:
     needs: [start-runners, km-build, kkm-build, km-build-payloads]
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - run: make -C cloud/azure login-cli
-
+      # no need to checkout - just continue where stopped after tests
       - name: Pull testenv image
         run: |
           make -C payloads -j pull-testenv-image

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -167,16 +167,16 @@ jobs:
       - name: Build shim
         run: |
           make -C cloud/k8s/deploy/shim
-          mkdir build/opt_kontain/bin/shim
-          cp -r build/cloud/k8s/deploy/shim/* build/opt_kontain/bin/shim
+          mkdir build/opt/kontain/bin/shim
+          cp -r build/cloud/k8s/deploy/shim/* build/opt/kontain/bin/shim
 
       - uses: actions/upload-artifact@v2
         with:
           name: km
           path: |
-            build/opt_kontain/bin/km
-            build/opt_kontain/bin/krun
-            build/opt_kontain/bin/shim
+            build/opt/kontain/bin/km
+            build/opt/kontain/bin/krun
+            build/opt/kontain/bin/shim
           retention-days: 7
 
       - uses: actions/upload-artifact@v2
@@ -184,12 +184,12 @@ jobs:
           name: km-build
           path: |
             build/cloud/k8s/deploy/shim
-            build/opt_kontain/bin
-            build/opt_kontain/lib
-            build/opt_kontain/include
+            build/opt/kontain/bin
+            build/opt/kontain/lib
+            build/opt/kontain/include
             tests/hello_test.km
             container-runtime/docker_config.sh
-            build/opt_kontain/runtime
+            build/opt/kontain/runtime
           retention-days: 7
 
   km-build-payloads:
@@ -328,8 +328,8 @@ jobs:
         run: |
           set -x
           # rename rkun.static to krun
-          mv build/container-runtime/krun.static build/opt_kontain/bin/krun
-          mv container-runtime/docker_config.sh build/opt_kontain/bin/docker_config.sh
+          mv build/container-runtime/krun.static build/opt/kontain/bin/krun
+          mv container-runtime/docker_config.sh build/opt/kontain/bin/docker_config.sh
 
       - run: make -C cloud/azure login-cli
 
@@ -348,14 +348,14 @@ jobs:
         run: |
           BLDTOP=$(realpath build)
 
-          chmod 755 ${BLDTOP}/opt_kontain/bin/km
-          chmod 755 ${BLDTOP}/opt_kontain/bin/krun
+          chmod 755 ${BLDTOP}/opt/kontain/bin/km
+          chmod 755 ${BLDTOP}/opt/kontain/bin/krun
           chmod 755 ${BLDTOP}/cloud/k8s/deploy/shim/containerd-shim-krun-v2
 
           tar -czvf ${BLDTOP}/kontain_bin.tar.gz \
               -C ${BLDTOP} km/km container-runtime/krun container-runtime/krun-label-trigger \
               cloud/k8s/deploy/shim/containerd-shim-krun-v2 kkm.run \
-              -C ${BLDTOP}/opt_kontain bin/docker_config.sh
+              -C ${BLDTOP}/opt/kontain bin/docker_config.sh
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -355,7 +355,42 @@ jobs:
           name: km-k8s-rel-artifact
           path: build/kontain_bin.tar.gz
 
-  km-test:
+  km-test-azure:
+    name: KM, tests, krun tests, KVM on Azure
+    runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
+    needs: [start-runners, km-build]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - run: make -C cloud/azure login-cli
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: km
+          path: /tmp/
+
+      - name: Configure KRUN
+        run: |
+          sudo mkdir -p /opt/kontain/bin
+          sudo mv -t /opt/kontain/bin /tmp/km /tmp/krun
+          sudo chmod +x /opt/kontain/bin/km /opt/kontain/bin/krun
+          sudo bash ./container-runtime/podman_config.sh
+          sudo bash ./container-runtime/docker_config.sh
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' > /tmp/rules
+          sudo mv /tmp/rules /etc/udev/rules.d/99-perm.rules
+          sudo udevadm control --reload-rules && sudo udevadm trigger
+
+      - name: Pull testenv images
+        run: |
+          make -C tests pull-testenv-image
+
+      - name: KM with KVM Test - Azure
+        run: make -C tests test-withdocker DOCKER_INTERACTIVE= DOCKER_RUN_CLEANUP=
+        timeout-minutes: 20
+
+  km-payloads-azure:
     name: KM, payloads, krun tests, KVM on Azure
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
     needs: [start-runners, km-build, km-build-payloads]
@@ -384,12 +419,7 @@ jobs:
 
       - name: Pull testenv images
         run: |
-          make -C tests pull-testenv-image
           make -C payloads -j pull-testenv-image
-
-      - name: KM with KVM Test - Azure
-        run: make -C tests test-withdocker DOCKER_INTERACTIVE= DOCKER_RUN_CLEANUP=
-        timeout-minutes: 20
 
       - name: KM with KVM Payloads Test - Azure
         if: ${{ ! (github.event_name == 'schedule' ||
@@ -435,10 +465,10 @@ jobs:
           retention-days: 7
 
   # TODO: Maybe not needed - review
-  kkm-test:
+  kkm-test-ubuntu:
     name: KM tests, KKM on CI VM
     runs-on: ubuntu-20.04
-    needs: [km-build, kkm-build, km-build-payloads]
+    needs: [km-build, kkm-build]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -465,8 +495,43 @@ jobs:
         if: always()
         run: sudo dmesg
 
-  kkm-test-vms:
+  kkm-test-aws:
     name: KM tests, KKM AWS
+    needs: [start-runners, km-build, kkm-build]
+    runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - run: make -C cloud/azure login-cli
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: km
+          path: /tmp/
+
+      - name: KKM and KKM tests
+        run: |
+          make -C kkm/kkm && make -C kkm/test_kkm
+          sudo insmod kkm/kkm/kkm.ko
+          ./kkm/test_kkm/test_kkm
+          sudo mkdir -p /opt/kontain/bin
+          sudo mv -t /opt/kontain/bin /tmp/km /tmp/krun
+          sudo chmod +x /opt/kontain/bin/km /opt/kontain/bin/krun
+          sudo bash ./container-runtime/podman_config.sh
+          sudo bash ./container-runtime/docker_config.sh
+
+      - name: Pull testenv image
+        run: |
+          make -C tests pull-testenv-image
+
+      - name: KM with KKM Test - AWS
+        run: make -C tests test-withdocker HYPERVISOR_DEVICE=/dev/kkm DOCKER_INTERACTIVE= DOCKER_RUN_CLEANUP=
+        timeout-minutes: 20
+
+  kkm-payloads-aws:
+    name: KM payloads test AWS
     needs: [start-runners, km-build, kkm-build, km-build-payloads]
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
     steps:
@@ -492,14 +557,9 @@ jobs:
           sudo bash ./container-runtime/podman_config.sh
           sudo bash ./container-runtime/docker_config.sh
 
-      - name: Pull testenv images
+      - name: Pull testenv image
         run: |
-          make -C tests pull-testenv-image
           make -C payloads -j pull-testenv-image
-
-      - name: KM with KKM Test - AWS
-        run: make -C tests test-withdocker HYPERVISOR_DEVICE=/dev/kkm DOCKER_INTERACTIVE= DOCKER_RUN_CLEANUP=
-        timeout-minutes: 20
 
       - name: KM with KKM Payloads Test - AWS
         if: ${{ ! (github.event_name == 'schedule' ||
@@ -700,9 +760,11 @@ jobs:
         km-build,
         krun-static-build,
         kkm-build,
-        km-test,
-        kkm-test,
-        kkm-test-vms,
+        km-test-azure,
+        km-payloads-azure,
+        kkm-test-ubuntu,
+        kkm-test-aws,
+        kkm-payloads-aws,
         minikube-testing,
         codeql-scan,
         ecs-hack-test,
@@ -723,7 +785,7 @@ jobs:
   stop-runner:
     if: always()
     name: Terminate self-hosted cloud runners
-    needs: [start-runners, km-test, kkm-test-vms]
+    needs: [start-runners, km-test-azure, km-payloads-azure, kkm-test-aws, kkm-payloads-aws]
     runs-on: ubuntu-latest
     steps:
       - name: Stop runners

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -357,7 +357,7 @@ jobs:
           path: build/kontain_bin.tar.gz
 
   km-test-azure:
-    name: KM, tests, krun tests, KVM on Azure
+    name: KM tests, KVM on Azure
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
     needs: [start-runners, km-build]
     steps:
@@ -397,9 +397,9 @@ jobs:
         timeout-minutes: 20
 
   km-payloads-azure:
-    name: KM, payloads, krun tests, KVM on Azure
+    name: Payloads on Azure
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
-    needs: [start-runners, km-build, km-build-payloads]
+    needs: [start-runners, km-build, km-build-payloads, km-test-azure]
     steps:
       # no need to checkout - just continue where tests left
       - name: Pull testenv images
@@ -481,7 +481,7 @@ jobs:
         run: sudo dmesg
 
   kkm-test-aws:
-    name: KM tests, KKM AWS
+    name: KM tests, KKM on AWS
     needs: [start-runners, km-build, kkm-build]
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
     steps:
@@ -521,8 +521,8 @@ jobs:
         timeout-minutes: 20
 
   kkm-payloads-aws:
-    name: KM payloads test AWS
-    needs: [start-runners, km-build, kkm-build, km-build-payloads]
+    name: Payloads on AWS
+    needs: [start-runners, km-build, kkm-build, km-build-payloads, kkm-test-aws]
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
     steps:
       # no need to checkout - just continue where stopped after tests

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -372,6 +372,11 @@ jobs:
           name: km
           path: /tmp/
 
+      - uses: actions/download-artifact@v2
+        with:
+          name: km-build
+          path: .
+
       - name: Configure KRUN
         run: |
           sudo mkdir -p /opt/kontain/bin
@@ -490,6 +495,11 @@ jobs:
         with:
           name: km
           path: /tmp/
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: km-build
+          path: .
 
       - name: KKM and KKM tests
         run: |

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -330,7 +330,6 @@ jobs:
         run: make withdocker TARGET=kkm-pkg
 
       # Note: need to have kkm.run ready for this step
-      # Note: we do no use
       #     make withdocker TARGET=kkm-pkg
       # because dependencies force it to re-build everything. We want to use pre-built km, krun (static) , kkm and so un
       #

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -754,7 +754,7 @@ jobs:
   stop-runner:
     if: always()
     name: Terminate self-hosted cloud runners
-    needs: [start-runners, km-test-azure, km-payloads-azure, kkm-test-aws, kkm-payloads-aws]
+    needs: [start-runners, km-payloads-azure, kkm-payloads-aws]
     runs-on: ubuntu-latest
     steps:
       - name: Stop runners

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -399,7 +399,7 @@ jobs:
   km-payloads-azure:
     name: Payloads on Azure
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
-    needs: [km-build-payloads, km-test-azure]
+    needs: [start-runners, km-build-payloads, km-test-azure]
     steps:
       # no need to checkout - just continue where tests left
       - name: Pull testenv images
@@ -522,7 +522,7 @@ jobs:
 
   kkm-payloads-aws:
     name: Payloads on AWS
-    needs: [km-build-payloads, kkm-test-aws]
+    needs: [start-runners, km-build-payloads, kkm-test-aws]
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
     steps:
       # no need to checkout - just continue where stopped after tests

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -99,7 +99,7 @@ jobs:
           az-vm-size: "Standard_D4s_v3"
 
   km-build:
-    name: Build KM, push test image
+    name: Build KM
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -141,6 +141,80 @@ jobs:
       - name: Build and push KM testenv image
         run: make -C tests testenv-image push-testenv-image
 
+      # - name: Build payloads and create test images
+      #   run: |
+      #     make -C payloads -j pull-buildenv-image
+      #     make -C payloads -j clean
+      #     make -C payloads -j all
+      #     make -C payloads -j testenv-image
+      #     make -C payloads -j push-testenv-image
+
+      # - name: Create payloads runenv and demo-runenv images
+      #   # Note: this builds both runenv and demo-runenv images
+      #   run: |
+      #     make -C payloads -j runenv-image
+      #     make -C payloads -j push-demo-runenv-image
+
+      # # Note: custom Python build needs to happen after python payload build
+      # - name: Python.km custom build
+      #   run: |
+      #     make -C payloads/python build-modules pack-modules CUSTOM_MODULES="markupsafe wrapt"
+      #     make -C payloads/python custom CUSTOM_MODULES="markupsafe wrapt"
+
+      - name: Build faktory
+        run: make -C tools/faktory all
+
+      - name: Build shim
+        run: |
+          make -C cloud/k8s/deploy/shim
+          mkdir build/opt_kontain/bin/shim
+          cp -r build/cloud/k8s/deploy/shim/* build/opt_kontain/bin/shim
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: km
+          path: |
+            build/opt_kontain/bin/km
+            build/opt_kontain/bin/krun
+            build/opt_kontain/bin/shim
+          retention-days: 7
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: km-build
+          path: |
+            build/cloud/k8s/deploy/shim
+            build/opt_kontain/bin
+            build/opt_kontain/lib
+            build/opt_kontain/include
+            tests/hello_test.km
+            container-runtime/docker_config.sh
+            build/opt_kontain/runtime
+          retention-days: 7
+
+  km-build-payloads:
+    name: Build payloads and create test images
+    runs-on: ubuntu-20.04
+    needs: km-build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: km-build
+          path: .
+
+      - name: Checking download and creating build directory
+        run: |
+          ls -R build
+
+      - run: make -C cloud/azure login-cli
+
+      - name: Prepare KM build env
+        run: make -C tests pull-buildenv-image .buildenv-local-lib
+
       - name: Build payloads and create test images
         run: |
           make -C payloads -j pull-buildenv-image
@@ -160,36 +234,6 @@ jobs:
         run: |
           make -C payloads/python build-modules pack-modules CUSTOM_MODULES="markupsafe wrapt"
           make -C payloads/python custom CUSTOM_MODULES="markupsafe wrapt"
-
-      - name: Build faktory
-        run: make -C tools/faktory all
-
-      - name: Build shim
-        run: |
-          make -C cloud/k8s/deploy/shim
-          mkdir /opt/kontain/bin/shim
-          cp -r build/cloud/k8s/deploy/shim/* /opt/kontain/bin/shim
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: km
-          path: |
-            /opt/kontain/bin/km
-            /opt/kontain/bin/krun
-            /opt/kontain/bin/shim
-          retention-days: 7
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: km-build
-          path: |
-            build/cloud/k8s/deploy/shim
-            build/km/km
-            tests/hello_test.km
-            build/container-runtime/krun-label-trigger
-            container-runtime/docker_config.sh
-
-          retention-days: 7
 
   # Builds a static linked, stripped binary for krun/crun
   # This uses the NIX virtual machine, just like the crun CI.
@@ -284,8 +328,7 @@ jobs:
         run: |
           set -x
           # rename rkun.static to krun
-          mv build/container-runtime/krun.static build/container-runtime/krun
-          mkdir -p build/opt_kontain/bin
+          mv build/container-runtime/krun.static build/opt_kontain/bin/krun
           mv container-runtime/docker_config.sh build/opt_kontain/bin/docker_config.sh
 
       - run: make -C cloud/azure login-cli
@@ -296,17 +339,17 @@ jobs:
       - name: Create kkm release artifact
         run: make withdocker TARGET=kkm-pkg
 
-      - name: Checking download and creating build directory
-        run: |
-          ls -R build
-
       # Note: need to have kkm.run ready for this step
+      # Note: we do no use
+      #     make withdocker TARGET=kkm-pkg
+      # because dependencies force it to re-build everything. We want to use pre-built km, krun (static) , kkm and so un
+      #
       - name: Create kontain bundles
         run: |
           BLDTOP=$(realpath build)
 
-          chmod 755 ${BLDTOP}/km/km
-          chmod 755 ${BLDTOP}/container-runtime/krun
+          chmod 755 ${BLDTOP}/opt_kontain/bin/km
+          chmod 755 ${BLDTOP}/opt_kontain/bin/krun
           chmod 755 ${BLDTOP}/cloud/k8s/deploy/shim/containerd-shim-krun-v2
 
           tar -czvf ${BLDTOP}/kontain_bin.tar.gz \
@@ -322,7 +365,7 @@ jobs:
   km-test:
     name: KM, payloads, krun tests, KVM on Azure
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['azure'] }}
-    needs: [start-runners, km-build]
+    needs: [start-runners, km-build, km-build-payloads]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -431,7 +474,7 @@ jobs:
 
   kkm-test-vms:
     name: KM tests, KKM AWS
-    needs: [start-runners, km-build, kkm-build]
+    needs: [start-runners, km-build, kkm-build, km-build-payloads]
     runs-on: ${{ fromJSON(needs.start-runners.outputs.run-ons)['ec2'] }}
     steps:
       - uses: actions/checkout@v2
@@ -662,6 +705,7 @@ jobs:
     needs:
       [
         km-build,
+        km-build-payloads,
         krun-static-build,
         kkm-build,
         km-test,

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -401,22 +401,6 @@ jobs:
 
       - run: make -C cloud/azure login-cli
 
-      - uses: actions/download-artifact@v2
-        with:
-          name: km
-          path: /tmp/
-
-      - name: Configure KRUN
-        run: |
-          sudo mkdir -p /opt/kontain/bin
-          sudo mv -t /opt/kontain/bin /tmp/km /tmp/krun
-          sudo chmod +x /opt/kontain/bin/km /opt/kontain/bin/krun
-          sudo bash ./container-runtime/podman_config.sh
-          sudo bash ./container-runtime/docker_config.sh
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' > /tmp/rules
-          sudo mv /tmp/rules /etc/udev/rules.d/99-perm.rules
-          sudo udevadm control --reload-rules && sudo udevadm trigger
-
       - name: Pull testenv images
         run: |
           make -C payloads -j pull-testenv-image
@@ -540,22 +524,6 @@ jobs:
           submodules: true
 
       - run: make -C cloud/azure login-cli
-
-      - uses: actions/download-artifact@v2
-        with:
-          name: km
-          path: /tmp/
-
-      - name: KKM and KKM tests
-        run: |
-          make -C kkm/kkm && make -C kkm/test_kkm
-          sudo insmod kkm/kkm/kkm.ko
-          ./kkm/test_kkm/test_kkm
-          sudo mkdir -p /opt/kontain/bin
-          sudo mv -t /opt/kontain/bin /tmp/km /tmp/krun
-          sudo chmod +x /opt/kontain/bin/km /opt/kontain/bin/krun
-          sudo bash ./container-runtime/podman_config.sh
-          sudo bash ./container-runtime/docker_config.sh
 
       - name: Pull testenv image
         run: |

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -142,26 +142,6 @@ jobs:
       - name: Build and push KM testenv image
         run: make -C tests testenv-image push-testenv-image
 
-      # - name: Build payloads and create test images
-      #   run: |
-      #     make -C payloads -j pull-buildenv-image
-      #     make -C payloads -j clean
-      #     make -C payloads -j all
-      #     make -C payloads -j testenv-image
-      #     make -C payloads -j push-testenv-image
-
-      # - name: Create payloads runenv and demo-runenv images
-      #   # Note: this builds both runenv and demo-runenv images
-      #   run: |
-      #     make -C payloads -j runenv-image
-      #     make -C payloads -j push-demo-runenv-image
-
-      # # Note: custom Python build needs to happen after python payload build
-      # - name: Python.km custom build
-      #   run: |
-      #     make -C payloads/python build-modules pack-modules CUSTOM_MODULES="markupsafe wrapt"
-      #     make -C payloads/python custom CUSTOM_MODULES="markupsafe wrapt"
-
       - name: Build faktory
         run: make -C tools/faktory all
 
@@ -180,6 +160,8 @@ jobs:
             build/opt/kontain/bin/shim
           retention-days: 7
 
+      # passing hello_test.c and libhelper.a
+      # because we will need to rebuid hello_test.kmd with correct RPATH for test and runtime environments
       - uses: actions/upload-artifact@v2
         with:
           name: km-build
@@ -188,10 +170,7 @@ jobs:
             build/opt/kontain/bin
             build/opt/kontain/lib
             build/opt/kontain/include
-            tests/hello_test.kmd
-            tests/hello_test
             tests/hello_test.c
-            tests/hello_test.o
             tests/libhelper.a
             container-runtime/docker_config.sh
             build/opt/kontain/runtime

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
       # Note the second make in this step is *not* run in our buildenv as there is no golang there
       - name: Build KM and tests
         run: |
-          make -j withdocker RUN_IN_CI=1
+          make -j withdocker RUN_IN_CI=1 RPATH=/opt/kontain
           make -C cloud/k8s/deploy/shim
 
       # get prebuilt static krun into its proper place

--- a/.vscode/km.code-workspace
+++ b/.vscode/km.code-workspace
@@ -38,7 +38,7 @@
          "**/.factorypath": true,
          "**/.project": true,
          "**/.settings": true,
-         "**/{*.o,*.d,*.so,*.km,*.class,*.gz,lib*,a}": true,
+         "**/{*.o,*.d,*.so,*.km,*.class,*.gz,a}": true,
          "build": true,
          "cpython/*": true,
          "payloads/java/{java,jtreg,jdk-11*}": true,

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ clang-format-check:
 clang-format:
 	clang-format -i km/*.h km/*.c tests/*.h tests/*.c tests/*.cpp
 
+withdocker runtime: | ${KM_OPT}/alpine-lib/gcc-libs-path.txt
+
+${KM_OPT}/alpine-lib/gcc-libs-path.txt:
+	make -C tests .buildenv-local-lib
+
 # On mac $(MAKE) evaluates to '/Applications/Xcode.app/Contents/Developer/usr/bin/make'
 ifeq ($(shell uname), Darwin)
 MAKE := make

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 include ${TOP}/make/actions.mk
 
 # build VMM and runtime library before trying to build tests
-tests: km runtime lib
+tests: km runtime lib tools/bin
 
 .PHONY: clang-format clang-format-check
 clang-format-check:
@@ -55,7 +55,7 @@ KM_KKM_RELEASE := ${BLDTOP}/kkm.run
 KM_BIN_RELEASE := ${BLDTOP}/kontain_bin.tar.gz
 KM_BINARIES := -C ${BLDTOP} km/km container-runtime/krun container-runtime/krun-label-trigger \
                cloud/k8s/deploy/shim/containerd-shim-krun-v2 kkm.run \
-               -C ${BLDTOP}/opt_kontain bin/docker_config.sh
+               -C ${BLDTOP}/opt/kontain bin/docker_config.sh
 # Show this on the release page
 RELEASE_MESSAGE ?= Kontain KM Beta Release. branch: ${SRC_BRANCH} sha: ${SRC_SHA}
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ clean-release: ## Clean the release tar files
 publish-release: ## Publish release with RELEASE_TAG to github
 	cd ${TOP}/tools/release; ./release_km.py ${KM_RELEASE} ${KM_BIN_RELEASE} ${KM_KKM_RELEASE} --version ${RELEASE_TAG} --message "${RELEASE_MESSAGE}"
 
-
 EDGE_RELEASE_MESSAGE ?= Kontain KM Edge - date: $(shell date) sha: $(shell git rev-parse HEAD)
 REPO_URL := https://${GITHUB_TOKEN}@github.com/kontainapp/km.git
 edge-release: ## Trigger edge-release building pipeline

--- a/Makefile
+++ b/Makefile
@@ -26,16 +26,16 @@ TOP := $(shell git rev-parse --show-toplevel)
 
 # scan all these and 'make' stuff there
 # do not build dynamic krun for ci
-ifneq ($RUN_IN_CI, )
-	SUBDIRS := lib km km_cli runtime tests container-runtime tools/bin include
-else
+ifneq (${RUN_IN_CI}, )
 	SUBDIRS := lib km km_cli runtime tests tools/bin include
+else
+	SUBDIRS := lib km km_cli runtime tests container-runtime tools/bin include
 endif
 
 include ${TOP}/make/actions.mk
 
 # build VMM and runtime library before trying to build tests
-tests: km runtime container-runtime lib
+tests: km runtime lib
 
 .PHONY: clang-format clang-format-check
 clang-format-check:
@@ -49,13 +49,39 @@ ifeq ($(shell uname), Darwin)
 MAKE := make
 endif
 
+# Package KM and libs+tools+docs for release
+KM_RELEASE := ${BLDTOP}/kontain.tar.gz
+KM_KKM_RELEASE := ${BLDTOP}/kkm.run
+KM_BIN_RELEASE := ${BLDTOP}/kontain_bin.tar.gz
+KM_BINARIES := -C ${BLDTOP} km/km container-runtime/krun container-runtime/krun-label-trigger \
+               cloud/k8s/deploy/shim/containerd-shim-krun-v2 kkm.run \
+               -C ${BLDTOP}/opt_kontain bin/docker_config.sh
+# Show this on the release page
+RELEASE_MESSAGE ?= Kontain KM Beta Release. branch: ${SRC_BRANCH} sha: ${SRC_SHA}
+
 kkm-pkg: ## Build KKM module self-extracting package.
 	@if ! type makeself >& /dev/null ; then echo Please install \"makeself\" first; false; fi
 	@# We only need source code, so running 'clean' first
 	-$(MAKE) MAKEFLAGS="$(MAKEFLAGS)" -C ${TOP}/kkm/kkm clean >& /dev/null
 	makeself -q kkm ${BLDTOP}/kkm.run "beta-release" ./installer/build-script.sh
 
-RELEASE_MESSAGE ?= Kontain KM Edge - date: $(shell date) sha: $(shell git rev-parse HEAD)
+release: ${KM_RELEASE} ${KM_BIN_RELEASE} ## Package kontain.tar.gz file for release
+	ls -lh ${KM_RELEASE} ${KM_BIN}
+
+${KM_RELEASE}: ${TOP}/tools/bin/create_release.sh ## Build a release tar.gz file for KM (called from release: target)
+	${TOP}/tools/bin/create_release.sh
+
+${KM_BIN_RELEASE}: ${KM_RELEASE} ## Build a release tar.gz file for KM runtime binaries
+	tar -czvf $@ ${KM_BINARIES}
+
+clean-release: ## Clean the release tar files
+	rm -f ${KM_RELEASE} ${KM_BIN_RELEASE}
+
+publish-release: ## Publish release with RELEASE_TAG to github
+	cd ${TOP}/tools/release; ./release_km.py ${KM_RELEASE} ${KM_BIN_RELEASE} ${KM_KKM_RELEASE} --version ${RELEASE_TAG} --message "${RELEASE_MESSAGE}"
+
+
+EDGE_RELEASE_MESSAGE ?= Kontain KM Edge - date: $(shell date) sha: $(shell git rev-parse HEAD)
 REPO_URL := https://${GITHUB_TOKEN}@github.com/kontainapp/km.git
 edge-release: ## Trigger edge-release building pipeline
 	git config user.email "release@kontain.app"
@@ -63,7 +89,7 @@ edge-release: ## Trigger edge-release building pipeline
 	@echo Delete the ${RELEASE_TAG} tag. Can fail if there is no such tag yet
 	-git tag -d ${RELEASE_TAG} && git push --delete ${REPO_URL} ${RELEASE_TAG}
 	@echo Now tag the source and push the tag to trigger the pipeline
-	git tag -a ${RELEASE_TAG} --message "${RELEASE_MESSAGE}"
+	git tag -a ${RELEASE_TAG} --message "${EDGE_RELEASE_MESSAGE}"
 	git push ${REPO_URL} ${RELEASE_TAG}
 
 ## Prepares release by
@@ -103,7 +129,3 @@ compile-commands: ## rebuild compile_commands.json. Assumes 'bear' is installed
 	make clean
 	bear make -j
 	sed -i 's-${CURDIR}-$${workspaceFolder}-' compile_commands.json
-
-# clean in subdirs will be done automatically. This is clean for stuff created from this makefile
-clean:
-	rm -f ${BLDTOP}/kkm.run

--- a/container-runtime/Makefile
+++ b/container-runtime/Makefile
@@ -37,7 +37,7 @@ include ${TOP}/make/actions.mk
 
 # Building crun shows errors indicating generated header files are not built yet,
 # so force single threading the make.
-all:	$(CRUNDIR)/Makefile .makefile_check
+all:	$(CRUNDIR)/Makefile .makefile_check | ${KM_OPT_BIN_PATH}
 	make -j1 -C $(CRUNDIR) all
 	cp $(CRUNDIR)/crun ${KM_OPT_BIN_PATH}
 	ln -f ${KM_OPT_BIN_PATH}/crun ${KM_OPT_BIN_PATH}/krun

--- a/full_test_local.sh
+++ b/full_test_local.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-make clean
-make -C container-runtime clobber
-make -j
-make -C tests testenv-image
-make -C tests test

--- a/full_test_local.sh
+++ b/full_test_local.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+make clean
+make -C container-runtime clobber
+make -j
+make -C tests testenv-image
+make -C tests test

--- a/full_test_widthdocker.sh
+++ b/full_test_widthdocker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+make clean
+make -C container-runtime clobber
+make -j withdocker
+make -C tests testenv-image
+make -C tests test-withdocker

--- a/full_test_widthdocker.sh
+++ b/full_test_widthdocker.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-make clean
-make -C container-runtime clobber
-make -j withdocker
-make -C tests testenv-image
-make -C tests test-withdocker

--- a/km-releases/kontain-install.sh
+++ b/km-releases/kontain-install.sh
@@ -29,7 +29,6 @@ set -e; [ "$TRACE" ] && set -x
 source /etc/os-release
 [ "$ID" != "fedora" -a "$ID" != "ubuntu" -a "$ID" != "amzn" ] && echo "Unsupported linux distribution: $ID" && exit 1
 
-
 readonly TAG=${1:-$(curl -L -s https://raw.githubusercontent.com/kontainapp/km/current/km-releases/current_release.txt)}
 if [[ $TAG == latest ]] ; then
    readonly URL="https://github.com/kontainapp/km/releases/${TAG}/download/kontain.tar.gz"

--- a/km-releases/kontain-install.sh
+++ b/km-releases/kontain-install.sh
@@ -16,8 +16,10 @@
 #
 # Install Kontain release on a Linux box. Assumes root.
 #
-# Usage: ./kontain-install.sh [TAG | -u]
+# Usage: ./kontain-install.sh [TAG | -u | file_path]
 # -u = uninstall changes made by install
+# file_path= path to local kontain.tar.gz in the format file:///full_path/to_file.tar.gz
+#
 #
 set -e; [ "$TRACE" ] && set -x
 
@@ -27,12 +29,16 @@ set -e; [ "$TRACE" ] && set -x
 source /etc/os-release
 [ "$ID" != "fedora" -a "$ID" != "ubuntu" -a "$ID" != "amzn" ] && echo "Unsupported linux distribution: $ID" && exit 1
 
+
 readonly TAG=${1:-$(curl -L -s https://raw.githubusercontent.com/kontainapp/km/current/km-releases/current_release.txt)}
-if [[ $TAG = latest ]] ; then
+if [[ $TAG == latest ]] ; then
    readonly URL="https://github.com/kontainapp/km/releases/${TAG}/download/kontain.tar.gz"
+elif [[ $TAG =~ ^file:* ]]; then
+   readonly URL=$TAG
 else
    readonly URL="https://github.com/kontainapp/km/releases/download/${TAG}/kontain.tar.gz"
 fi
+
 readonly PREFIX="/opt/kontain"
 
 # UNINSTALL
@@ -40,8 +46,8 @@ if [ $# -eq 1 -a "$1" = "-u" ]; then
    echo "Removing kontain"
 
    # Remove kontain config changes for docker and podman
-   bash /opt/kontain/bin/podman_config.sh -u
-   bash /opt/kontain/bin/docker_config.sh -u
+   bash $PREFIX/bin/podman_config.sh -u
+   bash $PREFIX/bin/docker_config.sh -u
 
    # Unload kernel modules?
 
@@ -78,11 +84,6 @@ validate=0
 function check_prereqs {
    if [ $(uname) != Linux ]; then
       error "Kontain requires a Linux distribution, e.g. Ubuntu 20 or Fedora 32. Current plaform: $(uname)"
-   fi
-
-   # check for PREFIX
-   if [[ ! -d $PREFIX || ! -w $PREFIX ]]; then
-      error "$PREFIX does not exist or not writeable. Use 'sudo mkdir -p $PREFIX ; sudo chown $(whoami) $PREFIX'"
    fi
 
    if ! command -v gcc; then
@@ -127,8 +128,8 @@ function get_bundle {
 }
 
 function config_container_runner {
-   bash /opt/kontain/bin/podman_config.sh
-   bash /opt/kontain/bin/docker_config.sh
+   bash $PREFIX/bin/podman_config.sh
+   bash $PREFIX/bin/docker_config.sh
 }
 
 # main

--- a/km/Makefile
+++ b/km/Makefile
@@ -39,27 +39,3 @@ include ${TOP}/make/actions.mk
 ${BLDDIR}/km_guest_asmcode.o: CFLAGS += -fpic
 CFLAGS += -fpic
 
-# Package KM and libs+tools+docs for release
-KM_RELEASE := ${BLDTOP}/kontain.tar.gz
-KM_KKM_RELEASE := ${BLDTOP}/kkm.run
-KM_BIN_RELEASE := ${BLDTOP}/kontain_bin.tar.gz
-KM_BINARIES := -C ${BLDTOP} km/km container-runtime/krun container-runtime/krun-label-trigger \
-               cloud/k8s/deploy/shim/containerd-shim-krun-v2 kkm.run \
-               -C ${BLDTOP}/opt_kontain bin/docker_config.sh
-# Show this on the release page
-RELEASE_MESSAGE ?= Kontain KM Beta Release. branch: ${SRC_BRANCH} sha: ${SRC_SHA}
-
-release: ${KM_RELEASE} ${KM_BIN_RELEASE} ## Package kontain.tar.gz file for release
-	ls -lh ${KM_RELEASE} ${KM_BIN}
-
-${KM_RELEASE}: ${KM_BIN} ${TOP}/tools/bin/create_release.sh ## Build a release tar.gz file for KM (called from release: target)
-	${TOP}/tools/bin/create_release.sh
-
-${KM_BIN_RELEASE}: ${KM_RELEASE} ## Build a release tar.gz file for KM runtime binaries
-	tar -czvf $@ ${KM_BINARIES}
-
-clean-release: ## Clean the release tar files
-	rm -f ${KM_RELEASE} ${KM_BIN_RELEASE}
-
-publish-release: ## Publish release with RELEASE_TAG to github
-	cd ${TOP}/tools/release; ./release_km.py ${KM_RELEASE} ${KM_BIN_RELEASE} ${KM_KKM_RELEASE} --version ${RELEASE_TAG} --message "${RELEASE_MESSAGE}"

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -151,6 +151,7 @@ static char* mgtpipe = NULL;
 static int log_to_fd = -1;
 extern int set_cpu_vendor_id;
 extern int kill_unimpl_hcall;
+extern char* km_interp;
 
 struct option km_cmd_long_options[] = {
     {"wait-for-signal", no_argument, &wait_for_signal, 1},
@@ -320,6 +321,7 @@ km_parse_args(int argc, char* argv[], int* argc_p, char** argv_p[], int* envc_p,
    if (getenv(KM_KILL_UNIMPL_SCALL) != NULL) {
       kill_unimpl_hcall = 1;
    }
+
    optind = 0;   // reinit getopt
    while ((opt = getopt_long(argc, argv, km_cmd_short_options, km_cmd_long_options, &longopt_index)) !=
           -1) {

--- a/lib/mimalloc/Makefile
+++ b/lib/mimalloc/Makefile
@@ -24,13 +24,13 @@ ME_MI_SRCDIR := ${ME_SRCDIR}/mimalloc
 ME_MI_BLDDIR := ${ME_BLDDIR}/mimalloc
 
 all:
-	cmake -S ${ME_MI_SRCDIR} -B ${ME_MI_BLDDIR} -D MI_BUILD_TESTS:BOOL=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_SHARED_LINKER_FLAGS="-L/opt/kontain/alpine-lib/usr/lib -L/opt/kontain/alpine-lib/lib -Wl,-rpath,/opt/kontain/alpine-lib/usr/lib:/opt/kontain/alpine-lib/lib:"
+	cmake -S ${ME_MI_SRCDIR} -B ${ME_MI_BLDDIR} -D MI_BUILD_TESTS:BOOL=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_SHARED_LINKER_FLAGS="-L${KM_OPT_ALPINELIB}/usr/lib -L${KM_OPT_ALPINELIB}lib -Wl,-rpath,${KM_OPT_ALPINELIB}/usr/lib:${KM_OPT_ALPINELIB}/lib:"
 	make -C ${ME_MI_BLDDIR}
 	mkdir -p ${KM_OPT_LIB}
 	cp ${ME_MI_BLDDIR}/libmimalloc.a ${KM_OPT_LIB}/libmimalloc.a
 	chmod 0644 ${KM_OPT_LIB}/libmimalloc.a
 	cp ${ME_MI_BLDDIR}/libmimalloc.so.1.7 ${KM_OPT_LIB}/libmimalloc.so.1.7
 	chmod 0755 ${KM_OPT_LIB}/libmimalloc.so.1.7
-	ln -f -s ${KM_OPT_LIB}/libmimalloc.so.1.7  ${KM_OPT_LIB}/libmimalloc.so
+	ln -sf libmimalloc.so.1.7 ${KM_OPT_LIB}/libmimalloc.so
 	ldd ${ME_MI_BLDDIR}/libmimalloc.so.1.7
 

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -85,6 +85,9 @@ else # not SUBDIRS, i.e. EXEC or LIB
 ifneq (${EXEC},)
 
 all: ${BLDEXEC}
+${KM_OPT_BIN_PATH}:
+	mkdir -p $@
+
 ${BLDEXEC}: $(OBJS) | ${KM_OPT_BIN_PATH}
 	$(CC) $(CFLAGS) $(OBJS) $(LDOPTS) $(LOCAL_LDOPTS) $(addprefix -l ,${LLIBS}) -o $@
 	if [ "${EXEC_SELINUX_CONTEXT}" != "" -a -e ${GETENFORCE} ]; then if [ `${GETENFORCE}` != "Disabled" ]; then chcon ${EXEC_SELINUX_CONTEXT} $@; fi; fi
@@ -202,7 +205,6 @@ withdocker: ## Build using Docker container for build environment. 'make withdoc
 		Use 'make buildenv-image' to build$(NOCOLOR)" ; fi
 	${_CMD} \
 		-v ${TOP}:${DOCKER_KM_TOP}:z \
-		-v ${KM_OPT}:${KM_OPT}:z \
 		-w ${DOCKER_KM_TOP}/${FROMTOP} \
 		$(BUILDENV_IMG):$(BUILDENV_IMAGE_VERSION) \
 		$(MAKE) MAKEFLAGS="$(MAKEFLAGS)" $(TARGET)

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -85,8 +85,6 @@ else # not SUBDIRS, i.e. EXEC or LIB
 ifneq (${EXEC},)
 
 all: ${BLDEXEC}
-${KM_OPT_BIN_PATH}:
-	mkdir -p $@
 
 ${BLDEXEC}: $(OBJS) | ${KM_OPT_BIN_PATH}
 	$(CC) $(CFLAGS) $(OBJS) $(LDOPTS) $(LOCAL_LDOPTS) $(addprefix -l ,${LLIBS}) -o $@
@@ -133,6 +131,9 @@ OBJDIRS = $(sort $(dir ${OBJS}))
 ${OBJS} ${DEPS}: | ${OBJDIRS}	# order only prerequisite - just make sure it exists
 
 ${OBJDIRS}:
+	mkdir -p $@
+
+${KM_OPT_BIN_PATH}:
 	mkdir -p $@
 
 # The sed regexp below is the same as in Visual Studion Code problemWatcher in tasks.json.

--- a/make/actions.mk
+++ b/make/actions.mk
@@ -164,7 +164,7 @@ clean::
 #
 # do not generate .d file for some targets
 #
-no_deps := $(shell [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${MAKEFLAGS}" =~ "n" ]] && echo -n match)
+no_deps := $(shell tmp=(${MAKEFLAGS}) && [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${tmp[0]}" =~ "n" ]] && echo -n match)
 ifneq ($(no_deps),match)
 -include ${DEPS}
 endif

--- a/make/images.mk
+++ b/make/images.mk
@@ -74,12 +74,35 @@ RUNENV_PATH ?= ${BLDDIR}
 RUNENV_DEMO_PATH ?= .
 
 
-# TESTENV_EXTRA_FILES
-TESTENV_EXTRA_FILES += ${KM_BIN} ${KM_LDSO}
-testenv_prep = cp --preserve=links ${TESTENV_EXTRA_FILES} ${TESTENV_PATH}
-testenv_cleanup = rm $(addprefix ${TESTENV_PATH}/,${notdir ${TESTENV_EXTRA_FILES}})
+define testenv_prep =
+	$(call testenv_preprocess)
+	tar -czvf ${TESTENV_PATH}/extras.tar.gz \
+		-C ${BLDTOP} \
+						opt/kontain/runtime/libc.so \
+						opt/kontain/runtime/ld-linux-x86-64.so.2 \
+						opt/kontain/runtime/libstdc++.so \
+						opt/kontain/alpine-lib/usr/lib/libstdc++.so.6 \
+						opt/kontain/alpine-lib/usr/lib/libstdc++.so.6.0.28 \
+						opt/kontain/alpine-lib/usr/lib/libgcc_s.so.1 \
+						opt/kontain/bin/km \
+						opt/kontain/lib/libmimalloc.so \
+						opt/kontain/lib/libmimalloc.so.1.7 \
+						opt/kontain/alpine-lib/usr/lib/libffi.so \
+						opt/kontain/alpine-lib/usr/lib/libffi.so.6 \
+						opt/kontain/alpine-lib/usr/lib/libffi.so.7 \
+						opt/kontain/alpine-lib/usr/lib/libffi.so.7.1.0 \
+						opt/kontain/alpine-lib/usr/lib/libgcc_s.so \
+						opt/kontain/runtime/libpthread.so
+	$(if ${TESTENV_EXTRA_FILES},cp -r --preserve=links ${TESTENV_EXTRA_FILES} ${TESTENV_PATH})
+endef
 
-testenv-image: ## build test image with test tools and code
+
+testenv_cleanup = rm ${TESTENV_PATH}/extras.tar.gz
+testenv_cleanup_extras=$(if ${TESTENV_EXTRA_FILES},rm  ${TESTENV_PATH}/${TESTENV_EXTRA_FILES} )
+
+## build test image with test tools and code
+## requires building
+testenv-image:
 	$(call clean_container_image,${TEST_IMG_TAGGED})
 	$(call testenv_prep)
 	${DOCKER_BUILD} --no-cache \

--- a/make/images.mk
+++ b/make/images.mk
@@ -75,9 +75,9 @@ RUNENV_DEMO_PATH ?= .
 
 
 # TESTENV_EXTRA_FILES
-TEST_BUILD_ENV = -C ${TOP} build/opt_kontain
-testenv_prep = tar -czf ${TESTENV_PATH}/bldenv.tgz ${TEST_BUILD_ENV}
-testenv_cleanup = rm -f $(addprefix ${TESTENV_PATH}/,${notdir ${TESTENV_EXTRA_FILES}}) ${TESTENV_PATH}/bldenv.tgz
+TESTENV_EXTRA_FILES += ${KM_BIN} ${KM_LDSO}
+testenv_prep = cp --preserve=links ${TESTENV_EXTRA_FILES} ${TESTENV_PATH}
+testenv_cleanup = rm $(addprefix ${TESTENV_PATH}/,${notdir ${TESTENV_EXTRA_FILES}})
 
 testenv-image: ## build test image with test tools and code
 	$(call clean_container_image,${TEST_IMG_TAGGED})

--- a/make/images.mk
+++ b/make/images.mk
@@ -96,12 +96,10 @@ define testenv_prep =
 	$(if ${TESTENV_EXTRA_FILES},cp -r --preserve=links ${TESTENV_EXTRA_FILES} ${TESTENV_PATH})
 endef
 
-
 testenv_cleanup = rm ${TESTENV_PATH}/extras.tar.gz
 testenv_cleanup_extras=$(if ${TESTENV_EXTRA_FILES},rm  ${TESTENV_PATH}/${TESTENV_EXTRA_FILES} )
 
 ## build test image with test tools and code
-## requires building
 testenv-image:
 	$(call clean_container_image,${TEST_IMG_TAGGED})
 	$(call testenv_prep)

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -41,8 +41,6 @@ endif
 # current SHA, to be saved for 'km -v' uniquiness
 SRC_SHA ?= $(shell git rev-parse HEAD)
 
-PATH := $(abspath ${TOP}/tools/bin):${PATH}
-
 # sha and build time for further reporting
 SRC_VERSION := $(shell git rev-parse HEAD)
 BUILD_TIME := $(shell date -Iminutes)
@@ -56,16 +54,23 @@ BLDDIR := $(abspath ${BLDTOP}/${FROMTOP}/${BLDTYPE})
 
 # km location needs to be fixed no matter what is the FROMTOP,
 # so we can use KM from different places
+KM_INSTALL := /opt/kontain
+KM_INSTALL_BIN := ${KM_INSTALL}/bin
+KM_INSTALL_COVERAGE := ${KM_INSTALL}/${COV_BLDTYPE}
+KM_INSTALL_COVERAGE_BIN := ${KM_INSTALL_COVERAGE}/bin
+
 KM_BLDDIR := $(abspath ${BLDTOP}/km/${BLDTYPE})
 KM_BIN := ${KM_BLDDIR}/km
 KM_RT := ${BLDTOP}/runtime
-KM_OPT := ${BLDTOP}/opt_kontain
+KM_OPT := ${BLDTOP}/opt/kontain
 KM_OPT_BIN := ${KM_OPT}/bin
 KM_OPT_INC := ${KM_OPT}/include
 KM_OPT_LIB := ${KM_OPT}/lib
 KM_OPT_RT := ${KM_OPT}/runtime
 KM_OPT_ALPINELIB := ${KM_OPT}/alpine-lib
-KM_LDSO := ${BLDTOP}/runtime/libc.so
+KM_LDSO := ${KM_OPT_RT}/libc.so
+
+PATH := $(abspath ${KM_OPT_BIN}):${PATH}
 
 GETENFORCE := /usr/sbin/getenforce
 
@@ -127,7 +132,6 @@ PODMAN_RUN_TEST := ${PODMAN_RUN} ${DOCKER_INTERACTIVE} --init
 DOCKER_HOME_PATH := /home/appuser
 DOCKER_KM_TOP := ${DOCKER_HOME_PATH}/km
 DOCKER_BLDTOP := ${DOCKER_KM_TOP}/build
-DOCKER_OPT_KONTAIN := ${DOCKER_BLDTOP}/opt_kontain
 DOCKER_COVERAGE_KM_BLDDIR := ${DOCKER_BLDTOP}/km/coverage
 
 # These volumes needs to be mapped into runenv images. At the moment, they

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -60,7 +60,6 @@ KM_INSTALL_COVERAGE := ${KM_INSTALL}/${COV_BLDTYPE}
 KM_INSTALL_COVERAGE_BIN := ${KM_INSTALL_COVERAGE}/bin
 
 KM_BLDDIR := $(abspath ${BLDTOP}/km/${BLDTYPE})
-KM_BIN := ${KM_BLDDIR}/km
 KM_RT := ${BLDTOP}/runtime
 KM_OPT := ${BLDTOP}/opt/kontain
 KM_OPT_BIN := ${KM_OPT}/bin
@@ -69,6 +68,8 @@ KM_OPT_LIB := ${KM_OPT}/lib
 KM_OPT_RT := ${KM_OPT}/runtime
 KM_OPT_ALPINELIB := ${KM_OPT}/alpine-lib
 KM_LDSO := ${KM_OPT_RT}/libc.so
+KM_BIN := ${KM_OPT_BIN}/km
+
 
 PATH := $(abspath ${KM_OPT_BIN}):${PATH}
 

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -59,7 +59,7 @@ BLDDIR := $(abspath ${BLDTOP}/${FROMTOP}/${BLDTYPE})
 KM_BLDDIR := $(abspath ${BLDTOP}/km/${BLDTYPE})
 KM_BIN := ${KM_BLDDIR}/km
 KM_RT := ${BLDTOP}/runtime
-KM_OPT := /opt/kontain
+KM_OPT := ${BLDTOP}/opt_kontain
 KM_OPT_BIN := ${KM_OPT}/bin
 KM_OPT_INC := ${KM_OPT}/include
 KM_OPT_LIB := ${KM_OPT}/lib
@@ -127,6 +127,7 @@ PODMAN_RUN_TEST := ${PODMAN_RUN} ${DOCKER_INTERACTIVE} --init
 DOCKER_HOME_PATH := /home/appuser
 DOCKER_KM_TOP := ${DOCKER_HOME_PATH}/km
 DOCKER_BLDTOP := ${DOCKER_KM_TOP}/build
+DOCKER_OPT_KONTAIN := ${DOCKER_BLDTOP}/opt_kontain
 DOCKER_COVERAGE_KM_BLDDIR := ${DOCKER_BLDTOP}/km/coverage
 
 # These volumes needs to be mapped into runenv images. At the moment, they

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -70,7 +70,6 @@ KM_OPT_ALPINELIB := ${KM_OPT}/alpine-lib
 KM_LDSO := ${KM_OPT_RT}/libc.so
 KM_BIN := ${KM_OPT_BIN}/km
 
-
 PATH := $(abspath ${KM_OPT_BIN}):${PATH}
 
 GETENFORCE := /usr/sbin/getenforce

--- a/payloads/Makefile
+++ b/payloads/Makefile
@@ -23,6 +23,11 @@
 SUBDIRS := busybox dynamic-base dynamic-base-scratch dynamic-base-large demo-dweb python node java java-shell dynamic-python
 
 TOP := $(shell git rev-parse --show-toplevel)
+
+BLDTOP := ${TOP}/build
+KM_OPT := ${BLDTOP}/opt/kontain
+KM_OPT_BIN := ${KM_OPT}/bin
+
 include ${TOP}/make/actions.mk
 
 demo-dweb python node dynamic-base dynamic-base-large: busybox

--- a/payloads/Makefile
+++ b/payloads/Makefile
@@ -30,6 +30,8 @@ KM_OPT_BIN := ${KM_OPT}/bin
 
 include ${TOP}/make/actions.mk
 
+dynamic-base dynamic-base-large dynamic-base-scratch: test-rebuild
+
 demo-dweb python node dynamic-base dynamic-base-large: busybox
 
 java-shell: dynamic-base java
@@ -37,6 +39,16 @@ java-shell: dynamic-base java
 java: dynamic-base-scratch
 
 dynamic-python: dynamic-base-large python
+
+test-rebuild:
+ifeq ($(findstring runenv,$(MAKECMDGOALS)),runenv)
+	rm -f $(TOP)/tests/hello_test.kmd
+	make -C $(TOP)/tests hello_test.kmd RPATH=/opt/kontain
+endif
+ifeq ($(findstring testenv,$(MAKECMDGOALS)),testenv)
+	rm -f $(TOP)/tests/hello_test.kmd
+	make -C $(TOP)/tests hello_test.kmd RPATH=/home/appuser/km/build/opt/kontain
+endif
 
 # Also, just 'make' will not cause building payloads , so it is reserved for building KM only.
 # Use 'make all' or 'make build' to request payloads build

--- a/payloads/Makefile
+++ b/payloads/Makefile
@@ -41,9 +41,9 @@ java: dynamic-base-scratch
 dynamic-python: dynamic-base-large python
 
 test-rebuild:
-ifeq ($(findstring runenv,$(MAKECMDGOALS)),runenv)
+ifneq (, $(or $(filter runenv-image,$(MAKECMDGOALS)), $(filter demo-runenv-image,$(MAKECMDGOALS))))
 	rm -f $(TOP)/tests/hello_test.kmd
-	make -C $(TOP)/tests RPATH=/opt/kontain hello_test.kmd
+	PATH=${KM_OPT_BIN}:${PATH} make -C $(TOP)/tests RPATH=/opt/kontain hello_test.kmd
 endif
 
 # Also, just 'make' will not cause building payloads , so it is reserved for building KM only.

--- a/payloads/Makefile
+++ b/payloads/Makefile
@@ -43,11 +43,7 @@ dynamic-python: dynamic-base-large python
 test-rebuild:
 ifeq ($(findstring runenv,$(MAKECMDGOALS)),runenv)
 	rm -f $(TOP)/tests/hello_test.kmd
-	make -C $(TOP)/tests hello_test.kmd RPATH=/opt/kontain
-endif
-ifeq ($(findstring testenv,$(MAKECMDGOALS)),testenv)
-	rm -f $(TOP)/tests/hello_test.kmd
-	make -C $(TOP)/tests hello_test.kmd RPATH=/home/appuser/km/build/opt/kontain
+	make -C $(TOP)/tests RPATH=/opt/kontain hello_test.kmd
 endif
 
 # Also, just 'make' will not cause building payloads , so it is reserved for building KM only.

--- a/payloads/busybox/run-all-tests.sh
+++ b/payloads/busybox/run-all-tests.sh
@@ -16,4 +16,4 @@
 #
 #
 
-./km ./bin/sh -c 'echo "Hello, World!" && ./bin/ls -l'
+km ./bin/sh -c 'echo "Hello, World!" && ./bin/ls -l'

--- a/payloads/busybox/run-test.sh
+++ b/payloads/busybox/run-test.sh
@@ -16,4 +16,4 @@
 #
 #
 
-./km ./bin/sh -c 'echo Hello, World!'
+km ./bin/sh -c 'echo Hello, World!'

--- a/payloads/busybox/test-fedora.dockerfile
+++ b/payloads/busybox/test-fedora.dockerfile
@@ -20,4 +20,6 @@ FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 
 # turn off km symlink trick and minimal shell interpretation
 ADD --chown=0:0 busybox/_install run-test.sh run-all-tests.sh ./
-ADD km .
+ADD --chown=appuser:appuser extras.tar.gz /home/appuser/km/build
+ENV PATH "$PATH:/home/appuser/km/build/opt/kontain/bin"
+

--- a/payloads/demo-dweb/dweb/Makefile
+++ b/payloads/demo-dweb/dweb/Makefile
@@ -27,7 +27,7 @@ dweb: $(OBJS)
 	$(CC) -static $(CLFAGS) -pthread  -o $@ $^
 
 dweb.km: $(OBJS)
-	${TOP}/tools/bin/kontain-gcc -static -no-pie $(CLFAGS) -pthread  -o $@ $^
+	${TOP}/build/opt/kontain/bin/kontain-gcc -static -no-pie $(CLFAGS) -pthread  -o $@ $^
 
 .PHONY: clean
 clean:

--- a/payloads/demo-dweb/test-fedora.dockerfile
+++ b/payloads/demo-dweb/test-fedora.dockerfile
@@ -26,8 +26,9 @@ ENV DHOME /home/$USER/demo-dweb/dweb
 RUN mkdir -p ${DHOME}
 WORKDIR ${DHOME}
 
-COPY --chown=appuser:appuser km dweb/dweb dweb/js/  dweb/css/ dweb/fonts/ dweb/*.htm* dweb/*.png dweb/*.ico ${DHOME}/
+COPY --chown=appuser:appuser dweb/dweb dweb/js/  dweb/css/ dweb/fonts/ dweb/*.htm* dweb/*.png dweb/*.ico ${DHOME}/
 RUN ln -s km demo-dweb && ln -s dweb demo-dweb.km
+ADD --chown=appuser:appuser extras.tar.gz ${KM_TOP}/build/
 
 EXPOSE 8080/tcp
 ENV KM_VERBOSE="GENERIC"

--- a/payloads/dynamic-base-large/Makefile
+++ b/payloads/dynamic-base-large/Makefile
@@ -20,13 +20,15 @@ COMPONENT := dynamic-base-large
 
 # name to be added to label(s)
 PAYLOAD_NAME := Dynamic-base-large
-PAYLOAD_FILES := -C /opt/kontain/ --exclude '*.a' runtime lib alpine-lib
+PAYLOAD_FILES := -C ${TOP}/build/opt/kontain/ --exclude '*.a' runtime lib alpine-lib
 # Command to run tests in testenv-image container:
-CONTAINER_TEST_CMD := ./km hello_test.kmd Hello 'The One'
+CONTAINER_TEST_CMD := km hello_test.kmd Hello 'The One'
 CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 
 export define runenv_prep
+	rm -f ${TOP}/tests/hello_test.kmd
+	make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd
 	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}
 endef

--- a/payloads/dynamic-base-large/Makefile
+++ b/payloads/dynamic-base-large/Makefile
@@ -27,6 +27,10 @@ CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 
 export define runenv_prep
+# hello_test.kmd rpath for runenv-image and demo-runenv-image must point to /opt/kontain.
+# This file is used by multiple payloads so we check wheteher it already has correct rpath and if not, we re-build it
+# Note: it will be already correct when runenv/demo-runenv done from payloads level because we pre-buid it there to avoid
+# race condition when using -j
 	[ ! -f ${TOP}/tests/hello_test.kmd ] || ! (readelf -l ${TOP}/tests/hello_test.kmd | grep -q ": /opt/kontain/") && (rm -f ${TOP}/tests/hello_test.kmd && make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd) || echo -n ""
 	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}

--- a/payloads/dynamic-base-large/Makefile
+++ b/payloads/dynamic-base-large/Makefile
@@ -27,8 +27,7 @@ CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 
 export define runenv_prep
-	rm -f ${TOP}/tests/hello_test.kmd
-	make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd
+	[ ! -f ${TOP}/tests/hello_test.kmd ] || ! (readelf -l ${TOP}/tests/hello_test.kmd | grep -q ": /opt/kontain/") && (rm -f ${TOP}/tests/hello_test.kmd && make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd) || echo -n ""
 	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}
 endef

--- a/payloads/dynamic-base-large/test-fedora.dockerfile
+++ b/payloads/dynamic-base-large/test-fedora.dockerfile
@@ -17,5 +17,6 @@ ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
 
 FROM kontainapp/buildenv-dynamic-base-${DTYPE}:${BUILDENV_IMAGE_VERSION}
-ADD libc.so /opt/kontain/runtime/
-ADD km hello_test.kmd ./
+ADD --chown=appuser:appuser extras.tar.gz /home/appuser/km/build
+ADD hello_test.kmd ./
+ENV PATH "$PATH:/home/appuser/km/build/opt/kontain/bin"

--- a/payloads/dynamic-base-scratch/Makefile
+++ b/payloads/dynamic-base-scratch/Makefile
@@ -39,6 +39,10 @@ RUNENV_TAG := ${COMPONENT}
 
 export define runenv_prep
 	mkdir -p tmp && rm -rf tmp/* && chmod a+rwx tmp
+# hello_test.kmd rpath for runenv-image and demo-runenv-image must point to /opt/kontain.
+# This file is used by multiple payloads so we check wheteher it already has correct rpath and if not, we re-build it
+# Note: it will be already correct when runenv/demo-runenv done from payloads level because we pre-buid it there to avoid
+# race condition when using -j
 	[ ! -f ${TOP}/tests/hello_test.kmd ] || ! (readelf -l ${TOP}/tests/hello_test.kmd | grep -q ": /opt/kontain/") && (rm -f ${TOP}/tests/hello_test.kmd && make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd) || echo -n ""
 	tar -czf ${RUNENV_PATH}/libs.tar ${PAYLOAD_FILES}
 	cp ${TESTENV_EXTRA_FILES} ${RUNENV_DEMO_PATH}

--- a/payloads/dynamic-base-scratch/Makefile
+++ b/payloads/dynamic-base-scratch/Makefile
@@ -39,8 +39,7 @@ RUNENV_TAG := ${COMPONENT}
 
 export define runenv_prep
 	mkdir -p tmp && rm -rf tmp/* && chmod a+rwx tmp
-	rm -f ${TOP}/tests/hello_test
-	make -C ${TOP}/tests RPATH=/opt/kontain hello_test
+	[ ! -f ${TOP}/tests/hello_test.kmd ] || ! (readelf -l ${TOP}/tests/hello_test.kmd | grep -q ": /opt/kontain/") && (rm -f ${TOP}/tests/hello_test.kmd && make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd) || echo -n ""
 	tar -czf ${RUNENV_PATH}/libs.tar ${PAYLOAD_FILES}
 	cp ${TESTENV_EXTRA_FILES} ${RUNENV_DEMO_PATH}
 	mkdir -p ${RUNENV_PATH}/.kontain

--- a/payloads/dynamic-base-scratch/Makefile
+++ b/payloads/dynamic-base-scratch/Makefile
@@ -20,9 +20,9 @@ COMPONENT := dynamic-base-scratch
 
 # name to be added to label(s)
 PAYLOAD_NAME := Dynamic-base-scratch
-PAYLOAD_FILES := tmp -C /opt/kontain/ --exclude '*.a' --exclude '*c++*' runtime lib
+PAYLOAD_FILES := tmp -C ${TOP}/build/opt/kontain/ --exclude '*.a' --exclude '*c++*' runtime lib
 # Command to run tests in testenv-image container:
-CONTAINER_TEST_CMD := ./km hello_test.kmd Hello 'The One'
+CONTAINER_TEST_CMD := km hello_test.kmd Hello 'The One'
 CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 
@@ -39,6 +39,8 @@ RUNENV_TAG := ${COMPONENT}
 
 export define runenv_prep
 	mkdir -p tmp && rm -rf tmp/* && chmod a+rwx tmp
+	rm -f ${TOP}/tests/hello_test
+	make -C ${TOP}/tests RPATH=/opt/kontain hello_test
 	tar -czf ${RUNENV_PATH}/libs.tar ${PAYLOAD_FILES}
 	cp ${TESTENV_EXTRA_FILES} ${RUNENV_DEMO_PATH}
 	mkdir -p ${RUNENV_PATH}/.kontain

--- a/payloads/dynamic-base-scratch/test-fedora.dockerfile
+++ b/payloads/dynamic-base-scratch/test-fedora.dockerfile
@@ -17,5 +17,6 @@ ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
 
 FROM kontainapp/buildenv-dynamic-base-${DTYPE}:${BUILDENV_IMAGE_VERSION}
-ADD libc.so /opt/kontain/runtime/
-ADD km hello_test.kmd ./
+ADD hello_test.kmd ./
+ADD --chown=appuser:appuser extras.tar.gz /home/appuser/km/build/
+ENV PATH "$PATH:/home/appuser/km/build/opt/kontain/bin"

--- a/payloads/dynamic-base/Makefile
+++ b/payloads/dynamic-base/Makefile
@@ -27,9 +27,8 @@ CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 
 export define runenv_prep
-	rm -f ${TOP}/tests/hello_test.kmd
-	make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd
-	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
+	[ ! -f ${TOP}/tests/hello_test.kmd ] || ! (readelf -l ${TOP}/tests/hello_test.kmd | grep -q ": /opt/kontain/") && (rm -f ${TOP}/tests/hello_test.kmd && make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd) || echo -n ""
+ 	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}
 endef
 

--- a/payloads/dynamic-base/Makefile
+++ b/payloads/dynamic-base/Makefile
@@ -27,6 +27,10 @@ CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 
 export define runenv_prep
+# hello_test.kmd rpath for runenv-image and demo-runenv-image must point to /opt/kontain.
+# This file is used by multiple payloads so we check wheteher it already has correct rpath and if not, we re-build it
+# Note: it will be already correct when runenv/demo-runenv done from payloads level because we pre-buid it there to avoid
+# race condition when using -j
 	[ ! -f ${TOP}/tests/hello_test.kmd ] || ! (readelf -l ${TOP}/tests/hello_test.kmd | grep -q ": /opt/kontain/") && (rm -f ${TOP}/tests/hello_test.kmd && make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd) || echo -n ""
  	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}

--- a/payloads/dynamic-base/Makefile
+++ b/payloads/dynamic-base/Makefile
@@ -20,13 +20,15 @@ COMPONENT := dynamic-base
 
 # name to be added to label(s)
 PAYLOAD_NAME := Dynamic-base
-PAYLOAD_FILES := -C /opt/kontain/ --exclude '*.a' --exclude '*c++*' runtime lib
+PAYLOAD_FILES := -C ${TOP}/build/opt/kontain/ --exclude '*.a' --exclude '*c++*' runtime lib
 # Command to run tests in testenv-image container:
-CONTAINER_TEST_CMD := ./km hello_test.kmd Hello 'The One'
+CONTAINER_TEST_CMD := km hello_test.kmd Hello 'The One'
 CONTAINER_TEST_ALL_CMD := ${CONTAINER_TEST_CMD}
 TESTENV_EXTRA_FILES := ${TOP}/tests/hello_test.kmd
 
 export define runenv_prep
+	rm -f ${TOP}/tests/hello_test.kmd
+	make -C ${TOP}/tests RPATH=/opt/kontain hello_test.kmd
 	tar ${PAYLOAD_FILES} -czf ${RUNENV_PATH}/libs.tar
 	cp ${TOP}/tests/hello_test.kmd ${RUNENV_DEMO_PATH}
 endef

--- a/payloads/dynamic-base/test-fedora.dockerfile
+++ b/payloads/dynamic-base/test-fedora.dockerfile
@@ -17,5 +17,6 @@ ARG DTYPE=fedora
 ARG BUILDENV_IMAGE_VERSION=latest
 
 FROM kontainapp/buildenv-dynamic-base-${DTYPE}:${BUILDENV_IMAGE_VERSION}
-ADD libc.so /opt/kontain/runtime/
-ADD km hello_test.kmd ./
+ADD  hello_test.kmd ./
+ADD --chown=appuser:appuser extras.tar.gz /home/appuser/km/build/
+ENV PATH "$PATH:/home/appuser/km/build/opt/kontain/bin"

--- a/payloads/dynamic-python/Makefile
+++ b/payloads/dynamic-python/Makefile
@@ -29,13 +29,13 @@ ABI = $(shell if [ $$(echo ${VERS} | sed 's/^[0-9]*.//') -le 7 ] ; then echo m; 
 BUILDENV_IMAGE_EXTRA_ARGS = --label "VERS=${VERS}" --build-arg=VERS=${VERS} --build-arg=ABI=${ABI} --build-arg=TAG=${TAG}
 TESTENV_IMAGE_EXTRA_ARGS  = --label "VERS=${VERS}" --build-arg=VERS=${VERS} --build-arg=ABI=${ABI}
 RUNENV_IMAGE_EXTRA_ARGS   = --label "VERS=${VERS}" --build-arg=VERS=${VERS}
-TESTENV_EXTRA_FILES := $(wildcard /opt/kontain/lib/libmimalloc.so*)
+TESTENV_EXTRA_FILES := $(wildcard ${TOP}/build/opt/kontain/lib/libmimalloc.so*)
 
 # Location of cpython sources. When building in container, it is set in buildenv dockerfile.
 PYTHONTOP ?= ${TOP}/payloads/python/cpython
 
 # this is how we run python.km tests in container
-CONTAINER_TEST_CMD := ./scripts/test-run.sh ./km ./python.km
+CONTAINER_TEST_CMD := ./scripts/test-run.sh km ./python.km
 
 # Component id for docker images.
 # Note that for now it is version-independent (i.e. not python${VERS})
@@ -58,9 +58,15 @@ RUNENV_DEMO_PATH := ${TOP}/payloads/python
 RUNENV_VALIDATE_CMD := ("/usr/local/bin/python3" "scripts/sanity_test.py")
 
 export define runenv_prep
+	make -C ../python RPATH=/opt/kontain
 	${RUNENV_ROOTFS_SCRIPT} ${PYTHONTOP} ${RUNENV_PATH} ${VERS} $(notdir ${PAYLOAD_KM}) dynamic
 endef
 
 RUNENV_TAG := dynamic-python dynamic-python-${VERS}
+
+TESTENV_EXTRA_FILES=../python/cpython/python.kmd.mimalloc
+define testenv_preprocess
+	make -C ../python RPATH=/home/appuser/km/build/opt/kontain
+endef
 
 include ${TOP}/make/images.mk

--- a/payloads/dynamic-python/test-fedora.dockerfile
+++ b/payloads/dynamic-python/test-fedora.dockerfile
@@ -20,6 +20,6 @@ ARG DTYPE=fedora
 ARG IMAGE_VERSION=latest
 
 FROM kontainapp/test-python-${DTYPE}:${IMAGE_VERSION}
-RUN mv python.kmd.mimalloc python.km
-ADD libc.so /opt/kontain/runtime/
-ADD libmimalloc.so* /opt/kontain/lib/
+COPY --chown=appuser:appuser python.kmd.mimalloc python.km
+ADD --chown=appuser:appuser extras.tar.gz /home/appuser/km/build/
+ENV PATH "$PATH:/home/appuser/km/build/opt/kontain/bin"

--- a/payloads/java/Makefile
+++ b/payloads/java/Makefile
@@ -23,9 +23,15 @@ JDK_VERSION := jdk-11.0.8+10
 COMPONENT := jdk-11.0.8
 PAYLOAD_NAME := ${COMPONENT}
 
-CONTAINER_TEST_CMD := ./scripts/test-run.sh
-
 JDK_BUILD_DIR = ${JDK_VERSION}/build/linux-x86_64-normal-server-release
+
+define testenv_preprocess
+	./link-km.sh ${JDK_BUILD_DIR} /home/appuser/km/build/opt/kontain
+endef
+
+TESTENV_EXTRA_FILES := ${JDK_BUILD_DIR}/images/jdk/* ${JDK_BUILD_DIR}/images/jdk/bin/java.kmd
+# this is how we are running tests in the container
+CONTAINER_TEST_CMD := ./scripts/test-run.sh
 
 # Needed to build Java from source - the same list as in buildenv-fedora.dockerfile
 DEP_PACKAGES := java-11-openjdk \
@@ -55,6 +61,7 @@ RUNENV_VALIDATE_DEPENDENCIES := scripts/Hello.class \
 
 # runenv-image configs
 export define runenv_prep
+	./link-km.sh ${JDK_BUILD_DIR} /opt/kontain
 	mkdir -p ${RUNENV_PATH} && cp --recursive --preserve=all ${JDK_BUILD_DIR}/images/jdk/* ${RUNENV_PATH}
 	mv ${RUNENV_PATH}/bin/java.kmd ${RUNENV_PATH}/bin/java
 endef
@@ -151,8 +158,7 @@ in-blank-container: ## invoked in blank container by ``make all''. DO NOT invoke
 	tar -C /home/appuser/java -cf - . | tar -C ${JDK_BUILD_DIR} -xf -
 	./link-km.sh ${JDK_BUILD_DIR}
 
-
-JAVA_LD_PATH := ${CURDIR}/${JAVA_DIR}/lib/server:${CURDIR}/${JAVA_DIR}/lib/jli:${CURDIR}/${JAVA_DIR}/lib:/opt/kontain/runtime
+JAVA_LD_PATH := ${CURDIR}/${JAVA_DIR}/lib/server:${CURDIR}/${JAVA_DIR}/lib/jli:${CURDIR}/${JAVA_DIR}/lib
 test: ${RUNENV_VALIDATE_DEPENDENCIES} api test_java.bats ## Basic test run
 	JAVA_DIR=${CURDIR}/${JAVA_DIR} JAVA_LD_PATH=${JAVA_LD_PATH} BLDDIR=${BLDDIR} \
 		${TOP}/tests/run_bats_tests.sh --km=${KM_BIN} \

--- a/payloads/java/link-km.sh
+++ b/payloads/java/link-km.sh
@@ -34,6 +34,6 @@ ${KM_TOP}/tools/bin/kontain-gcc -dynamic -rdynamic \
     -Wl,-O1 -m64 -Wl,--allow-shlib-undefined -Wl,--exclude-libs,ALL \
     ${JDK_DIR}/support/native/java.base/java/main.o \
     -L${JDK_DIR}/images/jdk/lib/jli -ljli \
-    -L /opt/kontain/lib -lmimalloc \
+    -L ${KM_TOP}/build/opt_kontain/lib -lmimalloc \
     -o ${OUT_DIR}/java.kmd
 

--- a/payloads/java/link-km.sh
+++ b/payloads/java/link-km.sh
@@ -34,6 +34,6 @@ ${KM_TOP}/tools/bin/kontain-gcc -dynamic -rdynamic \
     -Wl,-O1 -m64 -Wl,--allow-shlib-undefined -Wl,--exclude-libs,ALL \
     ${JDK_DIR}/support/native/java.base/java/main.o \
     -L${JDK_DIR}/images/jdk/lib/jli -ljli \
-    -L ${KM_TOP}/build/opt_kontain/lib -lmimalloc \
+    -L ${KM_TOP}/build/opt/kontain/lib -lmimalloc \
     -o ${OUT_DIR}/java.kmd
 

--- a/payloads/java/link-km.sh
+++ b/payloads/java/link-km.sh
@@ -34,7 +34,6 @@ if [[ ! -z ${PREFIX} ]]; then
    PREFIX="--prefix=${PREFIX}"
 fi
 
-
 OUT_DIR=${JDK_DIR}/images/jdk/bin
 
 mkdir -p ${OUT_DIR}

--- a/payloads/java/link-km.sh
+++ b/payloads/java/link-km.sh
@@ -17,19 +17,28 @@
 #
 # Link java.kmd
 #
-set -e ; [ "$TRACE" ] && set -x
+set -ex ; [ "$TRACE" ] && set -x
 
 KM_TOP=$(git rev-parse --show-toplevel)
+
 if [[ -z "$1" ]] ; then
    echo Usage: link-km.sh jdk_dir
    exit 1
 fi
 
 JDK_DIR=$1
+
+PREFIX=${2:-}
+
+if [[ ! -z ${PREFIX} ]]; then
+   PREFIX="--prefix=${PREFIX}"
+fi
+
+
 OUT_DIR=${JDK_DIR}/images/jdk/bin
 
 mkdir -p ${OUT_DIR}
-${KM_TOP}/tools/bin/kontain-gcc -dynamic -rdynamic \
+${KM_TOP}/build/opt/kontain/bin/kontain-gcc ${PREFIX} -dynamic -rdynamic \
     -Wl,--hash-style=both -Wl,-z,defs -Wl,-z,noexecstack \
     -Wl,-O1 -m64 -Wl,--allow-shlib-undefined -Wl,--exclude-libs,ALL \
     ${JDK_DIR}/support/native/java.base/java/main.o \

--- a/payloads/java/scripts/test-run.sh
+++ b/payloads/java/scripts/test-run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -ex
+#!/bin/bash
 #
 # Copyright 2021 Kontain Inc
 #
@@ -18,5 +18,7 @@
 #
 # wrapper/entrypoint for running tests
 
-echo "TODO: Tests will be implemented"
-true
+#echo "Test will go here"
+
+km --putenv=LD_LIBRARY_PATH=${JAVA_LD_PATH} \
+		${JAVA_DIR}/bin/java.kmd -version

--- a/payloads/java/test-fedora.dockerfile
+++ b/payloads/java/test-fedora.dockerfile
@@ -16,6 +16,15 @@
 FROM fedora:31
 
 # Contains the scripts needs to run tests.
-COPY scripts ./scripts
-COPY km /opt/kontain/bin/km
-COPY libc.so /opt/kontain/runtime/
+ADD extras.tar.gz /home/appuser/km/build/
+ARG JAVA_DIR=/home/appuser/km/build/opt/kontain
+ENV PATH=${JAVA_DIR}/bin:${PATH}
+COPY . ${JAVA_DIR}
+RUN mkdir -p /home/appuser/km/payloads/java
+COPY ./scripts/* /home/appuser/km/payloads/java/scripts/
+
+ENV JAVA_DIR=${JAVA_DIR}
+ENV JAVA_LD_PATH=${JAVA_DIR}/lib/server:${JAVA_DIR}/lib/jli:${JAVA_DIR}/lib:/opt/kontain/runtime
+ENV PATH=${JAVA_DIR}/bin:${PATH}
+
+WORKDIR /home/appuser/km/payloads/java

--- a/payloads/nginx/Makefile
+++ b/payloads/nginx/Makefile
@@ -39,7 +39,7 @@ fromsrc: ${NGINX_KM}  ## Clone the repo if needed, and build nginx (default)
 
 ${NGINX_KM}: ${NGINX_EXECUTABLE} .check link-km.sh
 	@mkdir -p ${BLDDIR}
-	./link-km.sh ${NGINX_OBJ_LOC} ${TOP}/tools/bin ${BLDDIR}
+	./link-km.sh ${NGINX_OBJ_LOC} ${KM_OPT_BIN} ${BLDDIR}
 
 ${NGINX_EXECUTABLE}: ${NGINX_TOP}
 	./build.sh

--- a/payloads/node/.dockerignore
+++ b/payloads/node/.dockerignore
@@ -12,4 +12,5 @@
 !node/test
 !node/doc
 !payload.tar
+!extras.tar.gz
 

--- a/payloads/node/Makefile
+++ b/payloads/node/Makefile
@@ -93,13 +93,13 @@ test test-all: ${PAYLOAD_KM} ${TEST_KM}
 	scripts/test-run.sh $@ ${KM_BIN} ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
 
 # Command to run tests in testenv-image container:
-CONTAINER_TEST_CMD := scripts/test-run.sh test ./km ${PAYLOAD_KM} ${TEST_KM}
+CONTAINER_TEST_CMD := scripts/test-run.sh test km ${PAYLOAD_KM} ${TEST_KM}
 
 # TODO: revert when kkm is fixed
 ifeq (${HYPERVISOR_DEVICE},/dev/kkm)
-CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test ./km ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
+CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test km ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
 else
-CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test-all ./km ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
+CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test-all km ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
 endif
 
 # Use existing small dir for buildenv image builds (saves on sending data to docker svc)

--- a/payloads/node/link-km.sh
+++ b/payloads/node/link-km.sh
@@ -24,7 +24,12 @@ KM_TOP=$(git rev-parse --show-toplevel)
 
 if [[ $# -ne 0 ]] ; then NODE=$1 ; else exit 1 ; fi
 OUT=${2:-$NODE}
-PATH=../../tools:$PATH
+
+PATH=$PATH
+echo PWD: `pwd`
+echo "PATH : ${PATH}"
+echo "ls /src/build/opt/kontain/bin : " `ls -l /src/build/opt/kontain/bin`
+echo `which kontain-g++`
 
 link_node() {
    kontain-g++ -ggdb -o $OUT/node.km \

--- a/payloads/node/link-km.sh
+++ b/payloads/node/link-km.sh
@@ -62,7 +62,7 @@ link_node() {
       $NODE/obj.target/tools/v8_gypfiles/libv8_zlib.a \
       $NODE/obj.target/tools/v8_gypfiles/libv8_compiler.a \
       $NODE/obj.target/tools/v8_gypfiles/libv8_initializers.a \
-      -L ${KM_TOP}/build/opt_kontain/lib -lmimalloc \
+      -L ${KM_TOP}/build/opt/kontain/lib -lmimalloc \
    -Wl,--end-group -pthread
 }
 

--- a/payloads/node/link-km.sh
+++ b/payloads/node/link-km.sh
@@ -20,6 +20,8 @@
 # and put the result into location at $2
 set -e ; [ "$TRACE" ] && set -x
 
+KM_TOP=$(git rev-parse --show-toplevel)
+
 if [[ $# -ne 0 ]] ; then NODE=$1 ; else exit 1 ; fi
 OUT=${2:-$NODE}
 PATH=../../tools:$PATH
@@ -60,7 +62,7 @@ link_node() {
       $NODE/obj.target/tools/v8_gypfiles/libv8_zlib.a \
       $NODE/obj.target/tools/v8_gypfiles/libv8_compiler.a \
       $NODE/obj.target/tools/v8_gypfiles/libv8_initializers.a \
-      -L /opt/kontain/lib -lmimalloc \
+      -L ${KM_TOP}/build/opt_kontain/lib -lmimalloc \
    -Wl,--end-group -pthread
 }
 

--- a/payloads/node/test-fedora.dockerfile
+++ b/payloads/node/test-fedora.dockerfile
@@ -25,7 +25,9 @@ ARG MODE=Release
 ENV MODE=$MODE VERS=$VERS NODETOP=/home/appuser/node
 
 COPY --chown=appuser:appuser node /home/$USER/node
-COPY --chown=appuser:appuser skip_* km /home/$USER/
+ADD --chown=appuser:appuser ./extras.tar.gz /home/$USER/km/build
 COPY --chown=appuser:appuser scripts /home/$USER/scripts
-RUN ln -s /home/$USER/km /home/$USER/node/out/${MODE}/node
+
+ENV PATH "$PATH:/home/appuser/km/build/opt/kontain/bin"
+
 WORKDIR /home/$USER/

--- a/payloads/python/Makefile
+++ b/payloads/python/Makefile
@@ -39,7 +39,7 @@ PYTHONTOP ?= cpython
 COMPONENT := python
 
 # this is how we run python.km tests in container
-CONTAINER_TEST_CMD := ./scripts/test-run.sh ./km ./python.km
+CONTAINER_TEST_CMD := ./scripts/test-run.sh km ./python.km
 
 # KM file name, relative to currentdir. Note that the same will be absolute in the container
 PAYLOAD_KM := cpython/python.km
@@ -72,7 +72,7 @@ export define link_cpython_km
 	for mod in $(foreach m,${CUSTOM_MODULES},cpython/Modules/$m/dlstatic_km.mk.json) ; do \
 		./extensions/linkline.py $${mod} $$(test -f ./${CUSTOM_TAKE} && echo -n --take ${CUSTOM_TAKE}) ; \
 	done
-	./link-km.sh ${PYTHONTOP} cpython "$(foreach m,${CUSTOM_MODULES},@Modules/$m/linkline_km.txt)" "${CUSTOM_KM}"
+	./link-km.sh ${PYTHONTOP} cpython "$(foreach m,${CUSTOM_MODULES},@Modules/$m/linkline_km.txt)" "${CUSTOM_KM}" "${RPATH}"
 endef
 
 # Set info for runenv-image build
@@ -91,9 +91,9 @@ ifneq ($(FROMSRC),yes)
 	${DOCKER_RUN_BUILD} \
 		-v ${TOP}:${TOP}:z \
 		${KM_OPT_VOLUME} \
-		-w ${TOP}/payloads/python \
+		-w ${TOP}/${FROMTOP} \
 		${BUILDENV_IMG_TAGGED} \
-		make in-blank-container CUSTOM_MODULES="${CUSTOM_MODULES}" CUSTOM_KM="${CUSTOM_KM}"
+		make in-blank-container CUSTOM_MODULES="${CUSTOM_MODULES}" CUSTOM_KM="${CUSTOM_KM}" RPATH="${RPATH}"
 else
 	eval $(link_cpython_km)
 endif

--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -17,7 +17,7 @@
 #
 # Links Python.km from python libs and km 'dlstatic' builtins mentioned in $target/linkline_km.txt
 #
-set -e
+set -ex
 [ "$TRACE" ] && set -x
 
 if [ "$1" == "--help" ]; then
@@ -42,7 +42,7 @@ NAME=${4:-python.km}
 KM_TOP=$(git rev-parse --show-toplevel)
 PATH=$(realpath ${KM_TOP}/tools/bin):$PATH
 
-KM_OPT_BIN=/opt/kontain/bin
+KM_OPT_BIN=${KM_TOP}/build/opt_kontain/bin
 
 cd $OUT
 echo kontain-gcc -pthread -ggdb ${BUILD}/Programs/python.o \
@@ -62,7 +62,7 @@ kontain-gcc -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/p
 kontain-gcc -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/python.o \
    -Xlinker --undefined=strtoull_l \
    ${BUILD}/libpython3*.a -lsqlite3 $LDLIBS \
-   -L/opt/kontain/lib -lmimalloc \
+   -L ${KM_TOP}/build/opt_kontain/lib -lmimalloc \
    -o ${NAME}d.mimalloc
 
 # Add python->km symlink and make python to looking for libs in correct place

--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -42,7 +42,7 @@ NAME=${4:-python.km}
 KM_TOP=$(git rev-parse --show-toplevel)
 PATH=$(realpath ${KM_TOP}/tools/bin):$PATH
 
-KM_OPT_BIN=${KM_TOP}/build/opt_kontain/bin
+KM_OPT_BIN=${KM_TOP}/build/opt/kontain/bin
 
 cd $OUT
 echo kontain-gcc -pthread -ggdb ${BUILD}/Programs/python.o \
@@ -62,7 +62,7 @@ kontain-gcc -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/p
 kontain-gcc -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/python.o \
    -Xlinker --undefined=strtoull_l \
    ${BUILD}/libpython3*.a -lsqlite3 $LDLIBS \
-   -L ${KM_TOP}/build/opt_kontain/lib -lmimalloc \
+   -L ${KM_TOP}/build/opt/kontain/lib -lmimalloc \
    -o ${NAME}d.mimalloc
 
 # Add python->km symlink and make python to looking for libs in correct place

--- a/payloads/python/link-km.sh
+++ b/payloads/python/link-km.sh
@@ -17,8 +17,7 @@
 #
 # Links Python.km from python libs and km 'dlstatic' builtins mentioned in $target/linkline_km.txt
 #
-set -ex
-[ "$TRACE" ] && set -x
+set -e && [ "$TRACE" ] && set -x
 
 if [ "$1" == "--help" ]; then
    cat <<EOF
@@ -30,6 +29,8 @@ location - where cpython artifacts are. Default: $(dirname ${BASH_SOURCE[0]})/cp
 target   - where to put the results.    Default: $(dirname ${BASH_SOURCE[0]})/cpython
 extra    - optional list of files to add (e.g. @f1 @f2...). Default: none
 name     - optional km name. Defaul: python.km
+prefix   - optional RPATH prefix for kontain-gcc
+
 EOF
    exit 0
 fi
@@ -38,11 +39,17 @@ BUILD=$(realpath ${1:-cpython})
 OUT=$(realpath ${2:-cpython})
 EXTRA_FILES="$3"
 NAME=${4:-python.km}
+PREFIX=${5:-}
+
+if [[ ! -z ${PREFIX} ]]; then
+   PREFIX="--prefix=${PREFIX}"
+fi
 
 KM_TOP=$(git rev-parse --show-toplevel)
-PATH=$(realpath ${KM_TOP}/tools/bin):$PATH
-
 KM_OPT_BIN=${KM_TOP}/build/opt/kontain/bin
+
+
+PATH=$(realpath ${KM_OPT_BIN}):$PATH
 
 cd $OUT
 echo kontain-gcc -pthread -ggdb ${BUILD}/Programs/python.o \
@@ -54,12 +61,12 @@ kontain-gcc -pthread -ggdb ${BUILD}/Programs/python.o \
    ${BUILD}/libpython3*.a -lz -lssl -lcrypto -lsqlite3 $LDLIBS \
    -o ${NAME} && echo Linked: ${OUT}/${NAME}
 
-kontain-gcc -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/python.o \
+kontain-gcc ${PREFIX} -dynamic  -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/python.o \
    -Xlinker --undefined=strtoull_l \
    ${BUILD}/libpython3*.a -lsqlite3 $LDLIBS \
    -o ${NAME}d
 
-kontain-gcc -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/python.o \
+kontain-gcc ${PREFIX} -dynamic -Xlinker -export-dynamic -pthread -ggdb ${BUILD}/Programs/python.o \
    -Xlinker --undefined=strtoull_l \
    ${BUILD}/libpython3*.a -lsqlite3 $LDLIBS \
    -L ${KM_TOP}/build/opt/kontain/lib -lmimalloc \

--- a/payloads/python/runenv/rootfs.sh
+++ b/payloads/python/runenv/rootfs.sh
@@ -29,7 +29,6 @@
 
 set -e ; [ "$TRACE" ] && set -x
 
-set -x
 readonly PROGNAME=$(basename $0)
 readonly CURRENT=$(readlink -m $(dirname $0))
 

--- a/payloads/python/runenv/rootfs.sh
+++ b/payloads/python/runenv/rootfs.sh
@@ -29,6 +29,7 @@
 
 set -e ; [ "$TRACE" ] && set -x
 
+set -x
 readonly PROGNAME=$(basename $0)
 readonly CURRENT=$(readlink -m $(dirname $0))
 
@@ -88,7 +89,7 @@ function main() {
       # Install platform specific libs to /usr/lib/python{X,Y}/lib-dynload
       cp ${PYTHON_SRC_LIB_STUBS} ${RUNENV_PATH}/${RUNENV_PYTHON_LIB_DYNLOAD}
       mkdir -p ${RUNENV_PATH}/opt/kontain
-      tar -C /opt/kontain --exclude '*.a' --exclude '*.o' -cf - alpine-lib | tar -C ${RUNENV_PATH}/opt/kontain -xf -
+      tar -C ${RUNENV_PATH}/../../opt/kontain --exclude '*.a' --exclude '*.o' -cf - alpine-lib | tar -C ${RUNENV_PATH}/opt/kontain -xf -
     else
       echo "Installing platform libs as thumbstones..."
       # Install platform specific libs to /usr/lib/python{X,Y}/lib-dynload. The files are thumbstones.

--- a/payloads/python/scripts/test-run.sh
+++ b/payloads/python/scripts/test-run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -ex
+#!/usr/bin/bash -e
 #
 # Copyright 2021 Kontain Inc
 #

--- a/payloads/python/test-fedora.dockerfile
+++ b/payloads/python/test-fedora.dockerfile
@@ -32,12 +32,13 @@ WORKDIR ${PHOME}
 COPY --chown=appuser:appuser scripts scripts/
 COPY --chown=appuser:appuser test_snapshot.py test_snapshot.py
 COPY --chown=appuser:appuser cpython/pybuilddir.txt cpython/
-COPY --chown=appuser:appuser km cpython/python.km cpython/python.kmd.mimalloc test_unittest.py ./
+COPY --chown=appuser:appuser cpython/python.km test_unittest.py ./
+ADD --chown=appuser:appuser extras.tar.gz /home/appuser/km/build/
 COPY --chown=appuser:appuser cpython/Modules cpython/Modules/
 COPY --chown=appuser:appuser cpython/Lib cpython/Lib/
 # TODO: construct path names once, instread of hardcoding them here
 COPY --chown=appuser:appuser cpython/build/lib.linux-x86_64-${VERS} cpython/build/lib.linux-x86_64-${VERS}
 COPY --chown=appuser:appuser cpython/build/lib.linux-x86_64-${VERS}/_sysconfigdata_${ABI}_linux_x86_64-linux-gnu.py cpython/Lib/
-RUN ln -s km python && echo -e "home = ${PHOME}/cpython\ninclude-system-site-packages = false\nruntime = kontain" > pyvenv.cfg
+RUN echo -e "home = ${PHOME}/cpython\ninclude-system-site-packages = false\nruntime = kontain" > pyvenv.cfg
 ENV KM_VERBOSE="GENERIC"
-
+ENV PATH "$PATH:/home/appuser/km/build/opt/kontain/bin"

--- a/payloads/redis/link-km.sh
+++ b/payloads/redis/link-km.sh
@@ -20,7 +20,7 @@
 set -e ; [ "$TRACE" ] && set -x
 
 TOP=$(git rev-parse --show-toplevel)
-KONTAIN_GCC=${TOP}/tools/bin/kontain-gcc
+KONTAIN_GCC=${KM_OPT_BIN}/kontain-gcc
 CURRENT=${TOP}/payloads/redis
 REDIS_TOP=${CURRENT}/redis
 REDIS_SRC=${REDIS_TOP}/src

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -58,7 +58,7 @@ BATS_CMD := run_bats_tests.sh --match="${MATCH}" --usevirt="${USEVIRT}" ${IGNORE
 TEST_CMD := time ./${BATS_CMD} --km=${KM_OPT_BIN}/km --pretty
 COVERAGE_TEST_CMD := time ./${BATS_CMD} --km=${COVERAGE_KM_BIN} --pretty
 # this is how we run tests in containers:
-CONTAINER_TEST_CMD          := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${KM_INSTALL_BIN}/km
+CONTAINER_TEST_CMD          := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${DOCKER_KM_TOP}/build/opt/kontain/bin/km
 CONTAINER_COVERAGE_TEST_CMD := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${KM_INSTALL_COVERAGE_BIN}/km
 
 # Build from these sources. Note that test may be skipped using "skip" support in out bats files
@@ -91,9 +91,7 @@ SEXECS := ${SRC_SHR:%.c=%.so}
 # Only tests matching this regexp will be run
 MATCH ?= .*
 
-all: check-indocker ${EXECS} ${SEXECS} ## Build all test, for Linux and KM
-
-check-indocker:
+all: ${EXECS} ${SEXECS} ## Build all test, for Linux and KM
 
 ${EXECS} ${SEXECS}: libhelper.a
 
@@ -112,6 +110,10 @@ test-all: test ## alias for test
 
 KCC := kontain-gcc
 KCXX := kontain-g++
+
+ifneq (${RPATH}, )
+   KCC_PREFIX="--prefix=${RPATH}"
+endif
 
 # use g++ link libs when sources were C++
 # ${SRC_CPP:%.cpp=%}: CC=${CXX}
@@ -137,16 +139,16 @@ ${SRC_CPP:%.cpp=%.km.so}: KCC=${KCXX}
 	${KCC} -static ${LDFLAGS} $< ${LDLIBS} -o $@
 
 %.kmd: %.o
-	${KCC} -dynamic ${LDFLAGS} $< ${LDLIBS} -o $@
+	${KCC} ${KCC_PREFIX} -dynamic ${LDFLAGS} $< ${LDLIBS} -o $@
 
 %.alpine.km: %.o
 	${KCC} -static -alpine ${LDFLAGS} $< ${LDLIBS} -o $@
 
 %.alpine.kmd: %.o
-	${KCC} -dynamic -alpine ${LDFLAGS} $< ${LDLIBS} -o $@
+	${KCC} ${KCC_PREFIX} -dynamic -alpine ${LDFLAGS} $< ${LDLIBS} -o $@
 
 %.km.so: %.o
-	${KCC} -shared ${LDFLAGS} $< -o $@ ${LDLIBS}
+	${KCC} ${KCC_PREFIX} -shared ${LDFLAGS} $< -o $@ ${LDLIBS}
 
 .PHONY: load_expected_size
 load_expected_size: load_test.km # load_test.so

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,11 +55,11 @@ endif
 # Base command to run BATS, and derivatives - how to run outside of container, in container, etc..
 BATS_CMD := run_bats_tests.sh --match="${MATCH}" --usevirt="${USEVIRT}" ${IGNORE_FAILURE} ${__BATS_JOBS}
 # this is how we run in outside of container
-TEST_CMD := time ./${BATS_CMD} --km=${KM_BIN} --pretty
+TEST_CMD := time ./${BATS_CMD} --km=${KM_OPT_BIN}/km --pretty
 COVERAGE_TEST_CMD := time ./${BATS_CMD} --km=${COVERAGE_KM_BIN} --pretty
 # this is how we run tests in containers:
-CONTAINER_TEST_CMD          := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${DOCKER_OPT_KONTAIN}/bin/km
-CONTAINER_COVERAGE_TEST_CMD := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${KM_OPT_COVERAGE_BIN}/km
+CONTAINER_TEST_CMD          := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${KM_INSTALL_BIN}/km
+CONTAINER_COVERAGE_TEST_CMD := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${KM_INSTALL_COVERAGE_BIN}/km
 
 # Build from these sources. Note that test may be skipped using "skip" support in out bats files
 SRC_C := $(abspath $(wildcard *_test.c))
@@ -91,7 +91,9 @@ SEXECS := ${SRC_SHR:%.c=%.so}
 # Only tests matching this regexp will be run
 MATCH ?= .*
 
-all: ${EXECS} ${SEXECS} ## Build all test, for Linux and KM
+all: check-indocker ${EXECS} ${SEXECS} ## Build all test, for Linux and KM
+
+check-indocker:
 
 ${EXECS} ${SEXECS}: libhelper.a
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -160,13 +160,15 @@ load_expected_size: load_test.km # load_test.so
 %.d: %.cpp
 	$(CXX) -MT $*.o -MT $@ -MM ${CXXFLAGS} ${CPPFLAGS} $< -o $@
 
+.PRECIOUS: %.o
+
 clean:
 	rm -f *.o *.d ${EXECS} ${SEXECS} kmcore km km.coverage *.a *.so *.km *.kmd *_test *.${DTYPE}
 
 #
 # do not generate .d file for some targets
 #
-no_deps := $(shell [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${MAKEFLAGS}" =~ "n" ]] && echo -n match)
+no_deps := $(shell tmp=(${MAKEFLAGS}) && [[ "${MAKECMDGOALS}" =~ ^${NO_DEPS_TARGETS}$$ || "${tmp[0]}" =~ "n" ]] && echo -n match)
 ifneq ($(no_deps),match)
 -include ${DEPS}
 endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -58,7 +58,7 @@ BATS_CMD := run_bats_tests.sh --match="${MATCH}" --usevirt="${USEVIRT}" ${IGNORE
 TEST_CMD := time ./${BATS_CMD} --km=${KM_BIN} --pretty
 COVERAGE_TEST_CMD := time ./${BATS_CMD} --km=${COVERAGE_KM_BIN} --pretty
 # this is how we run tests in containers:
-CONTAINER_TEST_CMD          := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${KM_OPT_BIN}/km
+CONTAINER_TEST_CMD          := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${DOCKER_OPT_KONTAIN}/bin/km
 CONTAINER_COVERAGE_TEST_CMD := ${DOCKER_KM_TOP}/tests/${BATS_CMD} --km=${KM_OPT_COVERAGE_BIN}/km
 
 # Build from these sources. Note that test may be skipped using "skip" support in out bats files

--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -55,7 +55,7 @@ RUN tar cf - -C / lib usr/lib \
    --exclude firmware --exclude mdev --exclude bash \
    --exclude engines-\* | tar xf - -C $PREFIX/alpine-lib
 # Alpine 3.12+ bumped libffi version, Fedora 33 hasn't yet. Hack to support that
-RUN ln -sf ${PREFIX}/alpine-lib/usr/lib/libffi.so.7 ${PREFIX}/alpine-lib/usr/lib/libffi.so.6
+RUN ln -sf libffi.so.7 ${PREFIX}/alpine-lib/usr/lib/libffi.so.6
 RUN tar -cf - -C /usr/local/lib64 . | tar xf - -C $PREFIX/runtime
 
 # Save the path to gcc versioned libs for the future

--- a/tests/gdb_forker_test.c
+++ b/tests/gdb_forker_test.c
@@ -35,6 +35,7 @@
 
 int main(int argc, char* argv[])
 {
+   extern char** environ;
    //   char payload[] = "tests/hello_test";
    char payload[] = "hello_test.km";
    pid_t pid;
@@ -47,10 +48,10 @@ int main(int argc, char* argv[])
       char* new_argv[2];
       new_argv[0] = payload;
       new_argv[1] = NULL;
-      char* new_envp[1];
-      new_envp[0] = NULL;
+      // char* new_envp[1];
+      // new_envp[0] = NULL;
       fprintf(stderr, "Child pid %d exec()'ing to %s\n", getpid(), payload);
-      execve(payload, new_argv, new_envp);
+      execve(payload, new_argv, environ);
       fprintf(stderr, "execve() to %s, pid %d, failed %s\n", payload, getpid(), strerror(errno));
       return 1;
    } else {   // parent

--- a/tests/gdb_forker_test.c
+++ b/tests/gdb_forker_test.c
@@ -48,8 +48,6 @@ int main(int argc, char* argv[])
       char* new_argv[2];
       new_argv[0] = payload;
       new_argv[1] = NULL;
-      // char* new_envp[1];
-      // new_envp[0] = NULL;
       fprintf(stderr, "Child pid %d exec()'ing to %s\n", getpid(), payload);
       execve(payload, new_argv, environ);
       fprintf(stderr, "execve() to %s, pid %d, failed %s\n", payload, getpid(), strerror(errno));

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -27,7 +27,7 @@ load test_helper
 
 # not_needed_{generic,static,dynamic,shared} - skip since it's not needed
 # todo_{generic,static,dynamic,shared} - skip since it's a TODO
-not_needed_generic=
+not_needed_generic=perf
 # TODO: gdb_delete_breakpoint and gdb_server_race are caused by race described in https://github.com/kontainapp/km/issues/821.
 # Disable them for now to improve signal/noise ratio
 todo_generic='gdb_delete_breakpoint gdb_server_race clock_gettime'

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -27,7 +27,7 @@ load test_helper
 
 # not_needed_{generic,static,dynamic,shared} - skip since it's not needed
 # todo_{generic,static,dynamic,shared} - skip since it's a TODO
-not_needed_generic=perf
+not_needed_generic=
 # TODO: gdb_delete_breakpoint and gdb_server_race are caused by race described in https://github.com/kontainapp/km/issues/821.
 # Disable them for now to improve signal/noise ratio
 todo_generic='gdb_delete_breakpoint gdb_server_race clock_gettime'

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -501,7 +501,7 @@ fi
    # Check for some output from "info auxv"
    assert_line --regexp "31   AT_EXECFN            File name of executable *0x[0-9a-f]*.*stray_test.kmd"
    # Check for some output from "info sharedlibrary"
-   assert_line --regexp "0x[0-9a-f]*  0x[0-9a-f]*  Yes         target:.*libc.so"
+   assert_line --regexp "0x[0-9a-f]*  0x[0-9a-f]*  Yes         .*/libc.so"
    wait_and_check $pid $(( $signal_flag + 11)) # expect KM to exit with SIGSEGV
 
    # There is no explicit test for vFile remote commands.  gdb uses vFile as part of
@@ -520,7 +520,7 @@ fi
    run gdb_with_timeout -q -nx --ex="target remote :$km_gdb_port" \
       --ex="source cmd_for_sharedlib2_test.gdb" --ex=q
    assert_success
-   assert_line --regexp "Yes         target:.*/dlopen_test_lib.so"
+   assert_line --regexp "Yes         .*/dlopen_test_lib.so"
    assert_line --partial "Dump of assembler code for function do_function"
    assert_line --partial "Hit the breakpoint at do_function"
    wait_and_check $pid 0

--- a/tests/run_bats_tests.sh
+++ b/tests/run_bats_tests.sh
@@ -42,6 +42,7 @@ Usage:  ${BASH_SOURCE[0]} [options]
   --dry-run               print commands instead of executing them
   --usevirt=virtmanager   optional argument to override virtualization platform kvm or kkm
   --jobs=count            optional argument to override parallel runs. Default is the result of nproc command (`nproc`)
+  --rt_ld_path=path       optional argument to specify runtime libraries to use intead of /opt/kontain/*** in standard LD_LIBRARY_PATH format
 EOF
 }
 
@@ -169,12 +170,6 @@ for t in $test_type ; do
    sed 2d $tests >> $tmp_file
    test_list="$test_list $tmp_file"
 done
-
-# If running on development machine, i.e  /opt/kontain is not used
-# set up LD_LIBRARY_PATH so dynamically linked libraries can be picked up from build/opt_kontain
-
-OPT_KONTAIN=${TESTS_BASE}/../build/opt_kontain
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OPT_KONTAIN}/alpine-lib:${OPT_KONTAIN}/lib:${OPT_KONTAIN}/runtime
 
 $DEBUG ${TESTS_BASE}/bats/bin/bats $jobs $pretty -f "$match" $test_list
 exit_code=$?

--- a/tests/run_bats_tests.sh
+++ b/tests/run_bats_tests.sh
@@ -170,6 +170,12 @@ for t in $test_type ; do
    test_list="$test_list $tmp_file"
 done
 
+# If running on development machine, i.e  /opt/kontain is not used
+# set up LD_LIBRARY_PATH so dynamically linked libraries can be picked up from build/opt_kontain
+
+OPT_KONTAIN=${TESTS_BASE}/../build/opt_kontain
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OPT_KONTAIN}/alpine-lib:${OPT_KONTAIN}/lib:${OPT_KONTAIN}/runtime
+
 $DEBUG ${TESTS_BASE}/bats/bin/bats $jobs $pretty -f "$match" $test_list
 exit_code=$?
 if [ $exit_code == 0 ] ; then

--- a/tests/test-fedora.dockerfile
+++ b/tests/test-fedora.dockerfile
@@ -23,18 +23,23 @@ FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 ARG branch
 ENV BRANCH=${branch}
 
+ENV KM_TOP=/home/appuser/km
+ENV KM_TEST_TOP=${KM_TOP}/tests
+
 USER root
 
-COPY libc.so /opt/kontain/runtime/libc.so
-COPY km /opt/kontain/bin/km
+# COPY libc.so /opt/kontain/runtime/libc.so
+# COPY km /opt/kontain/bin/km
 
 RUN test -f km.coverage && cp km.coverage /opt/kontain/coverage/bin/km || true
 
-ENV KM_TOP=/home/appuser/km
-ENV KM_TEST_TOP=${KM_TOP}/tests
 RUN mkdir -p ${KM_TOP}
-RUN chown appuser ${KM_TOP}
+RUN mkdir ${KM_TOP}/build
+RUN chown -R appuser:appuser ${KM_TOP}
+
+
 COPY --chown=appuser:appuser . ${KM_TEST_TOP}
+ADD --chown=appuser:appuser extras.tar.gz ${KM_TOP}/build/
 
 WORKDIR /home/appuser/km/tests
 

--- a/tests/test-fedora.dockerfile
+++ b/tests/test-fedora.dockerfile
@@ -25,6 +25,9 @@ ENV BRANCH=${branch}
 
 USER root
 
+COPY libc.so /opt/kontain/runtime/libc.so
+COPY km /opt/kontain/bin/km
+
 RUN test -f km.coverage && cp km.coverage /opt/kontain/coverage/bin/km || true
 
 ENV KM_TOP=/home/appuser/km
@@ -32,13 +35,8 @@ ENV KM_TEST_TOP=${KM_TOP}/tests
 RUN mkdir -p ${KM_TOP}
 RUN chown appuser ${KM_TOP}
 COPY --chown=appuser:appuser . ${KM_TEST_TOP}
-ADD --chown=appuser:appuser ./bldenv.tgz ${KM_TOP}
-# Due to Docker issue https://github.com/docker/for-linux/issues/360
-RUN chown -R appuser:appuser ${KM_TOP}/build
 
 WORKDIR /home/appuser/km/tests
-# this is needed for symlinks to work
-# RUN mkdir -p ../build/km ; cp ${KM_TOP}/build/opt_kontain/bin/km ../build/km
 
 ENV PATH=${KM_TEST_TOP}/bats/bin:.:$PATH
 ENV TIME_INFO ${KM_TEST_TOP}/time_info.txt

--- a/tests/test-fedora.dockerfile
+++ b/tests/test-fedora.dockerfile
@@ -23,8 +23,8 @@ FROM kontainapp/buildenv-km-${DTYPE}:${BUILDENV_IMAGE_VERSION}
 ARG branch
 ENV BRANCH=${branch}
 
-COPY libc.so /opt/kontain/runtime/libc.so
-COPY km /opt/kontain/bin/km
+USER root
+
 RUN test -f km.coverage && cp km.coverage /opt/kontain/coverage/bin/km || true
 
 ENV KM_TOP=/home/appuser/km
@@ -32,9 +32,15 @@ ENV KM_TEST_TOP=${KM_TOP}/tests
 RUN mkdir -p ${KM_TOP}
 RUN chown appuser ${KM_TOP}
 COPY --chown=appuser:appuser . ${KM_TEST_TOP}
+ADD --chown=appuser:appuser ./bldenv.tgz ${KM_TOP}
+# Due to Docker issue https://github.com/docker/for-linux/issues/360
+RUN chown -R appuser:appuser ${KM_TOP}/build
+
 WORKDIR /home/appuser/km/tests
 # this is needed for symlinks to work
-RUN mkdir -p ../build/km ; cp km ../build/km
+# RUN mkdir -p ../build/km ; cp ${KM_TOP}/build/opt_kontain/bin/km ../build/km
 
 ENV PATH=${KM_TEST_TOP}/bats/bin:.:$PATH
 ENV TIME_INFO ${KM_TEST_TOP}/time_info.txt
+
+USER appuser

--- a/tools/bin/Makefile
+++ b/tools/bin/Makefile
@@ -21,5 +21,7 @@ include ${TOP}/make/actions.mk
 
 all: kontain-gcc | ${KM_OPT_BIN_PATH}
 	cp kontain-gcc ${KM_OPT_BIN_PATH}
-	ln -f -s ${KM_OPT_BIN_PATH}/kontain-gcc ${KM_OPT_BIN_PATH}/kontain-g++
+	cp kontain-ar ${KM_OPT_BIN_PATH}
+	cp kontain-strip ${KM_OPT_BIN_PATH}
+	ln -sf kontain-gcc ${KM_OPT_BIN_PATH}/kontain-g++
 

--- a/tools/bin/Makefile
+++ b/tools/bin/Makefile
@@ -19,7 +19,7 @@ TOP := $(shell git rev-parse --show-toplevel)
 
 include ${TOP}/make/actions.mk
 
-all: kontain-gcc
+all: kontain-gcc | ${KM_OPT_BIN_PATH}
 	cp kontain-gcc ${KM_OPT_BIN_PATH}
 	ln -f -s ${KM_OPT_BIN_PATH}/kontain-gcc ${KM_OPT_BIN_PATH}/kontain-g++
 

--- a/tools/bin/create_release.sh
+++ b/tools/bin/create_release.sh
@@ -26,8 +26,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 TOP="$(realpath ../..)"
 BLDTOP=$TOP/build
 readonly TARBALL=${BLDTOP}/kontain.tar
-readonly OPT_KONTAIN=${BLDTOP}/opt_kontain
-readonly OPT_KONTAIN_TMP=${BLDTOP}/opt_kontain_tmp
+readonly OPT_KONTAIN=${BLDTOP}/opt/kontain
+readonly OPT_KONTAIN_TMP=${BLDTOP}/opt/kontain_tmp
 
 echo "Creating temporary directory"
 mkdir -p ${OPT_KONTAIN_TMP}

--- a/tools/bin/create_release.sh
+++ b/tools/bin/create_release.sh
@@ -35,9 +35,6 @@ mkdir -p ${OPT_KONTAIN_TMP}
 # we may need to modify all obj file so make sure we work on a copy
 cp -rf --preserve=links ${OPT_KONTAIN}/* ${OPT_KONTAIN_TMP}
 
-mkdir -p ${OPT_KONTAIN_TMP}/include
-cp ${TOP}/include/km_hcalls.h ${OPT_KONTAIN_TMP}/include/km_hcalls.h
-
 # include docker and podman config scripts in the tarball
 cp ${TOP}/container-runtime/{podman,docker}_config.sh ${OPT_KONTAIN_TMP}/bin
 cp ${TOP}/container-runtime/{podman,docker}_config.sh ${OPT_KONTAIN}/bin # for kontain_bin.tar ( since _TMP wil be deleted)
@@ -78,4 +75,4 @@ echo "Zipping $TARBALL.gz ..."
 gzip ${TARBALL}
 
 echo "Cleaning up"
-# rm -rf ${OPT_KONTAIN_TMP}
+rm -rf ${OPT_KONTAIN_TMP}

--- a/tools/bin/kontain-gcc
+++ b/tools/bin/kontain-gcc
@@ -53,7 +53,7 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-#defaults
+# defaults
 INSTALL_LOCATION=/opt/kontain
 target=kontain
 type=static
@@ -134,7 +134,6 @@ BUILD_LL=${BUILD_LOCATION}/alpine-lib/lib
 
 HCALL_DYNAMIC_LINKER=${RPATH_RT}/libc.so
 ALPINE_DYNAMIC_LINKER=${RPATH_LL}/ld-musl-x86_64.so.1
-
 
 # NOTE: libgcc location depends on gcc version in alpine container
 # We save it during docker build (see tests/buildenv-fedora.dockerfile)

--- a/tools/bin/kontain-gcc
+++ b/tools/bin/kontain-gcc
@@ -24,7 +24,7 @@
 # ------------------------------------
 # -kontain|-alpine Which binaries to build. Default 'kontain'
 # -kv              Print a few kontain-specific options and the final gcc command
-# --prefix=dir     Where to look for libs. Default /opt/kontain.This is internal debug option
+# --prefix=dir     Where resulting executable will look for dymanic libraries (rpath)
 #
 # Changes to behavior:
 #--------------------------------------
@@ -53,8 +53,6 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-dir=$(dirname ${BASH_SOURCE[0]})
-
 #defaults
 INSTALL_LOCATION=/opt/kontain
 target=kontain
@@ -82,7 +80,7 @@ do
          target_set=$target
          ;;
       --prefix=*)
-         BUILD_LOCATION="${1#*=}"
+         RPATH_LOCATION="${1#*=}"
          ;;
       -kv)
          verbose=1
@@ -107,37 +105,22 @@ do
     shift
 done
 
- #if no build location specified by the caller
-if [[ -z ${BUILD_LOCATION} ]]; then
-   # build location is parent directory of the script directory
-   # /opt/kontain/bin/kontain-gcc --> /opt/kontain/bin --> /opt/kontain   for production
-   # or
-   # /home/user/../km/build/opt/kontain/bin/kontain-gcc --> /home/user/../km/build/opt/kontain/bin --> /home/user/../km/build/opt/kontain/  for development build
-   # /usr/var/kontain/bin/kontain-gcc --> /usr/var/kontain/bin --> /usr/lib/kontain for non-standard installation
-   BUILD_LOCATION=$(dirname ${dir})
-fi
+# build location is parent directory of the script directory
+# /opt/kontain/bin/kontain-gcc --> /opt/kontain/bin --> /opt/kontain   for production
+# or
+# /home/user/..../km/build/opt/kontain/bin/kontain-gcc --> /home/user/..../km/build/opt/kontain/bin --> /home/user/..../km/build/opt/kontain/  for development build
+# /usr/var/kontain/bin/kontain-gcc --> /usr/var/kontain/bin --> /usr/var/kontain for non-standard installation
+BUILD_LOCATION=$(dirname $(dirname ${BASH_SOURCE[0]}))
 
 #build location must exists
 if [ ! -d $BUILD_LOCATION ] ; then
-   echo "Error: $PREFIX directory not found"
+   echo "Error: $BUILD_LOCATION directory not found"
    exit 1
 fi
 
-# now we figure out where to point RPATH and DYNAMIC LINKER
-if [[ ${BUILD_LOCATION} == ${INSTALL_LOCATION} ]] ; then
-   #if we calling from build location - rpath and dynlinker should be pointin gto the installation
-   RPATH_LOCATION={BUILD_LOCATION}
-else
-   # we building in location other then installation
-   if [  -f /.dockerenv ]; then
-      # building in teh container - rpath and dybliner should point to installation location
-      # as they are present in docker container
-      RPATH_LOCATION=/opt/kontain
-   else
-      RPATH_LOCATION=${BUILD_LOCATION}
-   fi
+if [ -z $RPATH_LOCATION ]; then
+   RPATH_LOCATION=${BUILD_LOCATION}
 fi
-
 
 RPATH_RT=${RPATH_LOCATION}/runtime
 RPATH_KL=${RPATH_LOCATION}/lib

--- a/tools/bin/kontain-gcc
+++ b/tools/bin/kontain-gcc
@@ -53,9 +53,8 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-cmd=$(basename ${BASH_SOURCE[0]})
 dir=$(dirname ${BASH_SOURCE[0]})
-TOP=$(realpath $dir/..)
+
 PREFIX=/opt/kontain
 
 # defaults

--- a/tools/bin/kontain-gcc
+++ b/tools/bin/kontain-gcc
@@ -55,9 +55,8 @@ trap cleanup EXIT
 
 dir=$(dirname ${BASH_SOURCE[0]})
 
-PREFIX=/opt/kontain
-
-# defaults
+#defaults
+INSTALL_LOCATION=/opt/kontain
 target=kontain
 type=static
 
@@ -83,7 +82,7 @@ do
          target_set=$target
          ;;
       --prefix=*)
-         PREFIX="${1#*=}"
+         BUILD_LOCATION="${1#*=}"
          ;;
       -kv)
          verbose=1
@@ -108,44 +107,81 @@ do
     shift
 done
 
-if [ ! -d $PREFIX ] ; then
+ #if no build location specified by the caller
+if [[ -z ${BUILD_LOCATION} ]]; then
+   # build location is parent directory of the script directory
+   # /opt/kontain/bin/kontain-gcc --> /opt/kontain/bin --> /opt/kontain   for production
+   # or
+   # /home/user/../km/build/opt/kontain/bin/kontain-gcc --> /home/user/../km/build/opt/kontain/bin --> /home/user/../km/build/opt/kontain/  for development build
+   # /usr/var/kontain/bin/kontain-gcc --> /usr/var/kontain/bin --> /usr/lib/kontain for non-standard installation
+   BUILD_LOCATION=$(dirname ${dir})
+fi
+
+#build location must exists
+if [ ! -d $BUILD_LOCATION ] ; then
    echo "Error: $PREFIX directory not found"
    exit 1
 fi
 
-RT=${PREFIX}/runtime
-KL=${PREFIX}/lib
-LC=${PREFIX}/alpine-lib/usr/lib
-LL=${PREFIX}/alpine-lib/lib
+# now we figure out where to point RPATH and DYNAMIC LINKER
+if [[ ${BUILD_LOCATION} == ${INSTALL_LOCATION} ]] ; then
+   #if we calling from build location - rpath and dynlinker should be pointin gto the installation
+   RPATH_LOCATION={BUILD_LOCATION}
+else
+   # we building in location other then installation
+   if [  -f /.dockerenv ]; then
+      # building in teh container - rpath and dybliner should point to installation location
+      # as they are present in docker container
+      RPATH_LOCATION=/opt/kontain
+   else
+      RPATH_LOCATION=${BUILD_LOCATION}
+   fi
+fi
+
+
+RPATH_RT=${RPATH_LOCATION}/runtime
+RPATH_KL=${RPATH_LOCATION}/lib
+RPATH_LC=${RPATH_LOCATION}/alpine-lib/usr/lib
+RPATH_LL=${RPATH_LOCATION}/alpine-lib/lib
+
+BUILD_RT=${BUILD_LOCATION}/runtime
+BUILD_KL=${BUILD_LOCATION}/lib
+BUILD_LC=${BUILD_LOCATION}/alpine-lib/usr/lib
+BUILD_LL=${BUILD_LOCATION}/alpine-lib/lib
+
+HCALL_DYNAMIC_LINKER=${RPATH_RT}/libc.so
+ALPINE_DYNAMIC_LINKER=${RPATH_LL}/ld-musl-x86_64.so.1
+
 
 # NOTE: libgcc location depends on gcc version in alpine container
 # We save it during docker build (see tests/buildenv-fedora.dockerfile)
 # and we use it during 'make .buildenv-local-lib'
-gcc_path_file=$PREFIX/alpine-lib/gcc-libs-path.txt
+gcc_path_file=${BUILD_LOCATION}/alpine-lib/gcc-libs-path.txt
 if [ ! -f $gcc_path_file ] ; then
    echo "Error: $gcc_path_file is not found - check installation."
    exit 1
 fi
-LGCC=${PREFIX}/alpine-lib$(cat $gcc_path_file)
+RPATH_LGCC=${BUILD_LOCATION}/alpine-lib$(cat $gcc_path_file)
+BUILD_LGCC=${BUILD_LOCATION}/alpine-lib$(cat $gcc_path_file)
 
 # For both static and dynamic buids, locations to scout for libs, and common flags
-ALPINE_PATH="-B${LL} -B${LC} -B${LGCC}"
-HCALL_PATH="-B${RT} ${ALPINE_PATH} -zseparate-code -zmax-page-size=0x1000"
+ALPINE_PATH="-B${BUILD_LL} -B${BUILD_LC} -B${BUILD_LGCC}"
+HCALL_PATH="-B${BUILD_RT} ${ALPINE_PATH} -zseparate-code -zmax-page-size=0x1000"
 
 # rpath for dynamic builds
-HCALL_RPATH="-Wl,-rpath=${KL} -Wl,-rpath=${RT} -Wl,-rpath=${LL} -Wl,-rpath=${LC} -Wl,-rpath=${LGCC}"
-ALPINE_RPATH="-Wl,-rpath=${LL} -Wl,-rpath=${LC} -Wl,-rpath=${LGCC}"
+HCALL_RPATH="-Wl,-rpath=${RPATH_KL} -Wl,-rpath=${RPATH_RT} -Wl,-rpath=${RPATH_LL} -Wl,-rpath=${RPATH_LC} -Wl,-rpath=${RPATH_LGCC}"
+ALPINE_RPATH="-Wl,-rpath=${RPATH_LL} -Wl,-rpath=${RPATH_LC} -Wl,-rpath=${RPATH_LGCC}"
 
 # Flags for building kontain (hypercall-based) unikernels
 HCALL_STATIC="-static   ${HCALL_PATH}                -no-pie -Wl,-Ttext-segment=0x200000"
 HCALL_STATIC+=${gc:+" -Wl,--gc-sections"}
-HCALL_DYNAMIC="-dynamic ${HCALL_PATH} ${HCALL_RPATH} -no-pie -Wl,-Ttext-segment=0x200000 -Wl,--dynamic-linker=${RT}/libc.so"
+HCALL_DYNAMIC="-dynamic ${HCALL_PATH} ${HCALL_RPATH} -no-pie -Wl,-Ttext-segment=0x200000 -Wl,--dynamic-linker=${HCALL_DYNAMIC_LINKER}"
 HCALL_SHARED="-shared   ${HCALL_PATH} ${HCALL_RPATH}"
 
 # Flags for alpine native and kontain (hcall) builds
 # Note: Alpine native dynamic work under KM only if built with explicit --pie or --Ttext-segment
 ALPINE_STATIC="-static ${ALPINE_PATH}"
-ALPINE_DYNAMIC="-dynamic ${ALPINE_PATH} ${ALPINE_RPATH} -pie -Wl,--dynamic-linker=${LL}/ld-musl-x86_64.so.1"
+ALPINE_DYNAMIC="-dynamic ${ALPINE_PATH} ${ALPINE_RPATH} -pie -Wl,--dynamic-linker=${ALPINE_DYNAMIC_LINKER}"
 # not tested:
 APLINE_SHARED="-shared ${ALPINE_PATH} ${ALPINE_RPATH}"
 
@@ -154,7 +190,7 @@ if [[ $target != alpine && $target != kontain ]] ; then
       echo "Error: Unknown target: $target (only alpine and kontain are supported)"
       exit 1
 fi
-for lib in ${RT}/libruntime.a ${RT}/libc.a ${RT}/libc.so ${LC}/libc.a ${LC}/libc.so; do
+for lib in ${BUILD_RT}/libruntime.a ${BUILD_RT}/libc.a ${BUILD_RT}/libc.so ${BUILD_LC}/libc.a ${BUILD_LC}/libc.so; do
    if [ ! -r $lib ] ; then
       echo "Error: can't find $lib - check installation"
       exit 1
@@ -193,9 +229,9 @@ fi
 
 if [ -n "$verbose" ] ; then
    cat <<EOF
-$(basename $0): Compiler='${REALGCC}', -type='$type', -target='$target', --prefix='$PREFIX'
+RPATH_$(basename $0): Compiler='${REALGCC}', -type='$type', -target='$target', --prefix='$PREFIX'
 $(basename $0): pie_requested='$pie_requested' nopie_requested='$no_pie_requested' kverbose='$verbose'"
-$(basename $0): Command: ${REALGCC} ${cargs[@]}
+RPATH_$(basename $0): Command: ${REALGCC} ${cargs[@]}
 
 EOF
 fi


### PR DESCRIPTION
Local build no longer needs /opt/kontain. Everything is build into build/opt/kontain directory. 

To build for testing locally use:
make -j 
make test

To build for testing with docker, you have to build with docker
make -j withdocker
make testing-image
make test-with docker

When building for release outside of release.yaml use 
make -j RPATH-/opt/kontain 

