### PR TITLE
Couple of fixes found during valgrind work

### DIFF
--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -103,6 +103,13 @@ void km_vcpu_fini(km_vcpu_t* vcpu, int join_thr)
  */
 void km_machine_fini(void)
 {
+   for (int i = 0; i < KVM_MAX_VCPUS; i++) {
+      km_vcpu_t* vcpu;
+
+      if ((vcpu = machine.vm_vcpus[i]) != NULL) {
+         km_vcpu_fini(vcpu, 1);
+      }
+   }
    free(machine.auxv);
    if (km_guest.km_filename != NULL) {
       free((void*)km_guest.km_filename);
@@ -118,13 +125,6 @@ void km_machine_fini(void)
    }
    km_mem_fini();
    km_signal_fini();
-   for (int i = 0; i < KVM_MAX_VCPUS; i++) {
-      km_vcpu_t* vcpu;
-
-      if ((vcpu = machine.vm_vcpus[i]) != NULL) {
-         km_vcpu_fini(vcpu, 1);
-      }
-   }
    close(machine.shutdown_fd);
    /* check if there are any memory regions */
    for (int i = KM_MEM_SLOTS - 1; i >= 0; i--) {

--- a/tests/cmd_for_attach_test.gdb
+++ b/tests/cmd_for_attach_test.gdb
@@ -24,6 +24,14 @@
 set pagination off
 print stop_running
 
+if wait_for_gdb != 0
+   print "set BP"
+   br usleep if wait_for_gdb != 0
+   print "continue from BP"
+   continue
+   set var wait_for_gdb = 0
+end
+
 # just do something to prove we are attached to the target
 info threads
 thread 4

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1345,7 +1345,11 @@ fi
 # In addition this may expose other problems such as misdeclared km arrays like km_hcargs[].
 #
 @test "threads_create($test_type): create a large number of threads that run briefly (gdb_lots_of_threads$ext)" {
+   if [ -z ${VALGRIND} ]; then
    run km_with_timeout --timeout 5s gdb_lots_of_threads_test$ext -a 2 -t 287
+   else
+   run km_with_timeout --timeout 25s gdb_lots_of_threads_test$ext -a 10 -t 287 -w
+   fi
    assert_success
 }
 


### PR DESCRIPTION
Stop vcpus before memory fini. Otherwise occasionally vcpu thread blows up stepping on unmapped memory

Fix race in gdb_attach. Since valgrind makes everything run slow, gdb would attach to the process *before* all the threads are started, hence the incompatible results. Make sure guest is at the right state when attaching.