### PR TITLE
remove exit race with gdb

### DIFF
--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -460,9 +460,6 @@ static void km_vcpu_exit_all(km_vcpu_t* vcpu)
 {
    machine.exit_group = 1;   // make sure we exit and not waiting for gdb
    km_vcpu_pause_all(vcpu, ALL);
-   if (km_gdb_client_is_attached() != 0) {
-      km_gdb_notify(vcpu, GDB_KMSIGNAL_THREADEXIT);
-   }
    km_signal_machine_fini();
    km_vcpu_stopped(vcpu);
 }


### PR DESCRIPTION
This is pretty intricate scenario. Depending on which thread - vcpu or gdb - is faster, we occasionally end up with gdb thread waiting for the input from client while all of the vcpus are stopped. Delay sending exit even to gdb after the last vcpu truly exits.

Tested for half a day in a loop on Azure VM. 