### PR TITLE
Fix signal delivery, stopping vcpus, tighten vcpu related locks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ TOP := $(shell git rev-parse --show-toplevel)
 
 # scan all these and 'make' stuff there
 # do not build dynamic krun for ci
-ifneq (${RUN_IN_CI}, )
+ifneq (${RUN_IN_CI},)
 	SUBDIRS := lib km km_cli runtime tests tools/bin include
 else
 	SUBDIRS := lib km km_cli runtime tests container-runtime tools/bin include

--- a/km/km.h
+++ b/km/km.h
@@ -684,12 +684,11 @@ km_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex, struct timespec*
       }                                                                                            \
    } while (0)
 
-#define km_pkill(vcpu, signo)                                                                      \
+#define km_pkill(thread, signo, val)                                                               \
    do {                                                                                            \
       int ret;                                                                                     \
-      sigval_t val = {.sival_ptr = vcpu};                                                          \
-      if ((ret = pthread_sigqueue(vcpu->vcpu_thread, signo, val)) != 0) {                          \
-         km_err(ret, "pthread_sigqueue(" #vcpu "->vcpu_thread, " #signo ") Failed ");              \
+      if ((ret = pthread_sigqueue(thread, signo, val)) != 0) {                                     \
+         km_err(ret, "pthread_sigqueue(" #thread ", " #signo ", " #val ") Failed ");               \
       }                                                                                            \
    } while (0)
 

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1794,6 +1794,7 @@ uint64_t km_fs_epoll_pwait(km_vcpu_t* vcpu,
       return -EBADF;
    }
 
+   km_queue_sig_sleep(vcpu);
    int ret = __syscall_6(SYS_epoll_pwait,
                          host_epfd,
                          (uintptr_t)events,
@@ -1801,6 +1802,7 @@ uint64_t km_fs_epoll_pwait(km_vcpu_t* vcpu,
                          timeout,
                          (uintptr_t)sigmask,
                          sigsetsize);
+   km_dequeue_sig_sleep(vcpu);
    return ret;
 }
 

--- a/km/km_fork.c
+++ b/km/km_fork.c
@@ -163,7 +163,8 @@ static void km_fork_remove_parent_vmstate(void)
    // Should try to free all of the stacks for the now defunt vcpu threads?
    for (int i = 0; i < machine.vm_vcpu_cnt; i++) {
       if (machine.vm_vcpus[i] != NULL) {
-         km_vcpu_fini(machine.vm_vcpus[i], 0);
+         machine.vm_vcpus[i]->vcpu_thread = 0;   // that thread was in parent
+         km_vcpu_fini(machine.vm_vcpus[i]);
       }
    }
 

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -1122,14 +1122,11 @@ static int build_thread_list_entry(km_vcpu_t* vcpu, void* data)
    char threadname[MAX_THREADNAME_SIZE];
    char threadlistentry[MAX_THREADLISTENTRY_SIZE];
 
-   km_lock_vcpu_thr(vcpu);
    if (vcpu->state == STARTING) {
       // This thread is not fully instantiated.
-      km_unlock_vcpu_thr(vcpu);
       return 0;
    }
    km_getname_np(vcpu->vcpu_thread, threadname, sizeof(threadname));
-   km_unlock_vcpu_thr(vcpu);
 
    snprintf(threadlistentry,
             sizeof(threadlistentry),

--- a/km/km_signal.c
+++ b/km/km_signal.c
@@ -369,8 +369,8 @@ static inline void km_signal_vcpu_signal(km_vcpu_t* vcpu)
 static int km_can_interrupt(km_vcpu_t* vcpu, void* data)
 {
    int signo = *(int*)data;
-   if (signo >= 0 && km_sigismember(&vcpu->sigmask, signo) == 0 && vcpu->state == HYPERCALL &&
-       vcpu->hypercall == SYS_epoll_pwait) {
+   if (signo >= 0 && km_sigismember(&vcpu->sigmask, signo) == 0 &&
+       (vcpu->state == HYPERCALL || vcpu->state == HCALL_INT) && vcpu->hypercall == SYS_epoll_pwait) {
       km_signal_vcpu_signal(vcpu);
       km_infox(KM_TRACE_SIGNALS, "interrupting vcpu %d to deliver signal %d", vcpu->vcpu_id, signo);
       *(int*)data = -1;   // we only want to interrupt one payload thread

--- a/km/km_signal.h
+++ b/km/km_signal.h
@@ -47,6 +47,9 @@ uint64_t km_rt_sigsuspend(km_vcpu_t* vcpu, km_sigset_t* mask, size_t masksize);
 uint64_t km_rt_sigtimedwait(
     km_vcpu_t* vcpu, km_sigset_t* set, siginfo_t* info, struct timespec* timeout, size_t setlen);
 
+void km_queue_sig_sleep(km_vcpu_t* vcpu);
+void km_dequeue_sig_sleep(km_vcpu_t* vcpu);
+
 static inline int km_sigindex(int signo)
 {
    return signo - 1;

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -623,7 +623,7 @@ fi
 }
 
 @test "threads_basic($test_type): threads with TLS, create, exit and join (hello_2_loops_tls_test$ext)" {
-   run km_with_timeout hello_2_loops_tls_test.km
+   run km_with_timeout hello_2_loops_tls_test$ext
    assert_success
    if [ $test_type != "static" ] ; then
       refute_line --partial 'BAD'
@@ -631,11 +631,7 @@ fi
 }
 
 @test "threads_basic_tsd($test_type): threads with TSD, create, exit and join (hello_2_loops_test$ext)" {
-   for i in $(seq 1 3); do # only fail if all 3 tries failed
-      echo pass $i
-      run km_with_timeout hello_2_loops_test$ext
-      if [ $status == 0 ] ; then break; fi
-   done
+   run km_with_timeout hello_2_loops_test$ext
    assert_success
 }
 
@@ -854,20 +850,11 @@ fi
 }
 
 @test "pthread_cancel($test_type): (pthread_cancel_test$ext)" {
-   for i in $(seq 1 3); do # only fail if all 3 tries failed
-      echo pass $i
-      run km_with_timeout pthread_cancel_test$ext -v
-      if [[ $status == 0 && \
-         ! "$output" =~ "PTHREAD_CANCEL_ASYNCHRONOUS" && \
-         "$output" =~ "PTHREAD_CANCEL_DEFERRED" &&
-         "$output" =~ "thread_func(): end of DISABLE_CANCEL_TEST" ]]
-      then break; else status=1; fi
-   done
+   run km_with_timeout pthread_cancel_test$ext -v
    assert_success
-   # This is what we really need to check once, once pthread_cancel stops being noisy
-   # assert_line --partial "thread_func(): end of DISABLE_CANCEL_TEST"
-   # refute_line --partial "PTHREAD_CANCEL_ASYNCHRONOUS"
-   # assert_line --partial "PTHREAD_CANCEL_DEFERRED"
+   assert_line --partial "thread_func(): end of DISABLE_CANCEL_TEST"
+   refute_line --partial "PTHREAD_CANCEL_ASYNCHRONOUS"
+   assert_line --partial "PTHREAD_CANCEL_DEFERRED"
 }
 
 # C++ tests


### PR DESCRIPTION
Some of the tests were flaky, particularly the glibc version of them. They occasionally would fail with km locked up in processing of exit_grp. To make CI more reproducible we made these run in a loop for a few times, failing only if all attempts fail. This removes the loops, and fixes the flakiness

The fixes are:
- Two types of sending signal to VCPU - one for payload signal delivery, one for stopping VCPU. Use signal si_value field. It is 8 byte field, so we use 2 bytes for vcpu_id (instead of pointer), and another 2 bytes for flag. If flag is set this is VCPU stopping request.
- Tighten the locks on vcpus for processing vcpu pause and vcpu stop
- Drop pthread_cancel as it requires cleanup
- use pthread_cond_signal() to wake up parked VCPUs


Fixes https://github.com/kontainapp/km/issues/1455?