### PR TITLE
Support KM_LOGTO environment variable.

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -467,6 +467,7 @@ static const struct timespec _1ms = {
  * Environment Variables
  */
 static const_string_t KM_VERBOSE = "KM_VERBOSE";
+static const_string_t KM_LOGTO = "KM_LOGTO";
 static const_string_t KM_MGTPIPE = "KM_MGTPIPE";
 static const_string_t KM_KILL_UNIMPL_SCALL = "KM_KILL_UNIMPL_SCALL";
 

--- a/km/km_trace.c
+++ b/km/km_trace.c
@@ -223,6 +223,10 @@ void km_trace_setup(int argc, char* argv[])
       // has anything to say.
       trace_regex = getenv(KM_VERBOSE);
    }
+   if (kmlogto == NULL) {
+      // See if the environment tells us where to log if not specified on the command line.
+      kmlogto = getenv(KM_LOGTO);
+   }
    if (trace_regex != NULL) {
       if (*trace_regex == 0) {
          km_info_trace.level = KM_TRACE_INFO;

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1439,6 +1439,13 @@ fi
    run grep -q "calling hc = 231 (exit_group)" $LOGFILE
    assert_failure
    rm -f $LOGFILE
+
+   # Verify that the KM_LOGTO environment variable can control where km logging goes.
+   KM_LOGTO=$LOGFILE run ${KM_BIN} -V ${KM_ARGS_PRIVATE} hello_test$ext
+   assert_success
+   run grep -q "calling hc = 231 (exit_group)" $LOGFILE
+   assert_success
+   rm -f $LOGFILE
 }
 
 # Verify that gdb can follow an execve() system call to the new executable.


### PR DESCRIPTION
Allows us to direct km's logging to somewhere else using an environment
variable.  We can use this to tell payloads running in a container to
trace to stderr which can appear in a container's log which we can
retrieve using "docker logs ..." or some similar command.

Added a test for this to the bats km_logging test.