### PR TITLE
TRIVIAL: keep core, snap, and log files for tests

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
+tmp/**
 km-bats-*.*
 gdb.txt
 .native*


### PR DESCRIPTION
I just realized that with our CI setup we put core files, snaps, and logs in `/tmp`, which of course disappears as soon as container is stopped. `kmcore` files and cores from km stay in tests directory so that's good.

This simply moves them from `/tmp` to `tests/tmp` so they stick around after container is stopped.