### PR TITLE
disable enlightened vmcs in CI, check for it in tests

### DIFF
--- a/cloud/azure/L0-image.pkr.hcl
+++ b/cloud/azure/L0-image.pkr.hcl
@@ -64,6 +64,13 @@ build {
     script          = "../scripts/L0-image-provision.sh"
   }
 
+  // TODO: https://github.com/kontainapp/km/issues/1600
+  // Disable enlightened vmcs for now until we figure the fix
+  provisioner "shell" {
+    execute_command = "{{ .Vars }} sudo -E sh '{{ .Path }}' ${var.username}"
+    inline          = ["echo 'options kvm_intel enlightened_vmcs=N'> /etc/modprobe.d/kvm_intel.conf"]
+  }
+
   // TBD azure Image should be "deprovisioned", see https://www.packer.io/docs/builders/azure/arm
   // see https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/agent-linux
   // turned off for now as it breaks the build

--- a/tests/run_bats_tests.sh
+++ b/tests/run_bats_tests.sh
@@ -155,6 +155,15 @@ if [ ! -c $device_node ] ; then
    exit 1
 fi
 
+# TODO: https://github.com/kontainapp/km/issues/1600
+# check for enlightened vmcs for now until we figure the fix
+if [[ $usevirt == "kvm" && -f /sys/module/kvm_intel/parameters/enlightened_vmcs ]] ; then
+   if [[ $(cat /sys/module/kvm_intel/parameters/enlightened_vmcs) == "Y" ]] ; then
+      echo -e "${RED}**ERROR** Enlightened VMCS is on, bailing ${NOCOLOR}"
+      exit 1
+   fi
+fi
+
 echo -e "${GREEN}**Running tests with virtualization $usevirt.${NOCOLOR}"
 
 if [ ! -x $km_bin ] ; then


### PR DESCRIPTION
Because of https://github.com/kontainapp/km/issues/1600 we have occasional CI failures. Disable enlightened VMCS in our L0 image on Azure for now until we have a fix. Also check in tests and refuse to run tests with enlightened VMCS