### PR TITLE
tighten clone test

### DIFF
--- a/tests/clone_test.c
+++ b/tests/clone_test.c
@@ -23,6 +23,8 @@
 #include <sys/utsname.h>
 #include <sys/wait.h>
 
+int flag;   // child waits for this to become non-zero before proceeding
+
 #define errExit(msg)                                                                               \
    do {                                                                                            \
       perror(msg);                                                                                 \
@@ -31,8 +33,10 @@
 
 static int childFunc(void* arg)
 {
+   while (flag == 0)   // wait for main to print
+      ;
    fprintf(stderr, "Hello from clone\n");
-   return 0; /* Child terminates now */
+   _Exit(EXIT_SUCCESS);
 }
 
 #define STACK_SIZE (1024 * 1024) /* Stack size for cloned child */
@@ -56,6 +60,7 @@ int main(int argc, char* argv[])
    }
    printf("clone() returned %ld\n", (long)pid);
 
-   usleep(100000);
-   exit(EXIT_SUCCESS);
+   flag = 1;   // tell child to proceed
+   pause();
+   exit(EXIT_FAILURE);
 }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -475,7 +475,7 @@ fi
    assert_success
 
    # Verify we "next"ed thru clone()
-   assert_line --regexp "^#0  main.* at clone_test.c:54$"
+   assert_line --regexp "^#0  main.* at clone_test.c:58$"
    wait_and_check $pid 0 # expect KM to exit normally
 }
 


### PR DESCRIPTION
CI failure https://github.com/kontainapp/km/runs/7531538116?check_suite_focus=true#step:3:559 shows that raw clone test can fail because of timing in the threads. Child thread might not get a chance to print what the test is expecting before exit. 

Make main thread tell the child thread to proceed and pause. Child thread then prints what it needs to print and does exit.