### PR TITLE
valgrind builds expect to find km_cli in build/opt/kontain/valgrind/bin

### DIFF
--- a/make/images.mk
+++ b/make/images.mk
@@ -129,7 +129,7 @@ define coverage_testenv_prep =
 			build/opt/kontain/alpine-lib/usr/lib/libgcc_s.so \
 			build/opt/kontain/runtime/libpthread.so \
 			build/opt/kontain/coverage/bin/km \
-			build/opt/kontain/bin/km_cli \
+			build/opt/kontain/coverage/bin/km_cli \
 			build/km/coverage \
 			km \
 			include \
@@ -157,7 +157,7 @@ define valgrind_testenv_prep =
 			build/opt/kontain/alpine-lib/usr/lib/libgcc_s.so \
 			build/opt/kontain/runtime/libpthread.so \
 			build/opt/kontain/valgrind/bin/km \
-			build/opt/kontain/bin/km_cli \
+			build/opt/kontain/valgrind/bin/km_cli \
 			build/km/valgrind \
 			km \
 			include \

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -35,6 +35,10 @@ fi
 # TODO: gdb_delete_breakpoint and gdb_server_race are caused by race described in https://github.com/kontainapp/km/issues/821.
 # Disable them for now to improve signal/noise ratio
 todo_generic='gdb_delete_breakpoint gdb_server_race clock_gettime'
+if [ -n "${VALGRIND}" ]; then
+   # valground executables don't have the payload's name so pidof doesn't work.
+   todo_generic="$todo_generic basic_snapshot"
+fi
 
 not_needed_static='gdb_sharedlib dlopen'
 todo_static=''


### PR DESCRIPTION
My previous change told make to keep looking in build/opt/kontain/bin.
Change the valgrind_testenv_prep make macro to look there,
not in build/opt/kontain/bin
Also changed the coverage_testenv_prep to get km_cli in
build/opt/kontain/coverage/bin