### PR TITLE
Change km_cli -s to use the snapdir argument

### DIFF
--- a/tests/hello_html_test.c
+++ b/tests/hello_html_test.c
@@ -104,19 +104,27 @@ int main(int argc, char const* argv[])
    char buf[4096];
    int listen_sd, sd;
    size_t ret;
+   int keep_running;
 
    if (argc == 2) {
       PORT = atoi(argv[1]);
    }
+   keep_running = (getenv("KEEP_RUNNING") != NULL);
+
    listen_sd = tcp_listen();
    printf("Listening on %d\n", PORT);
-   sd = tcp_accept(listen_sd);
-   ret = read(sd, buf, 4096);
-   ret = write(sd, wbuf, sizeof(wbuf));
-   // suppress compiler warning about unused var
-   if (ret)
-      ;
-   tcp_close(sd);
+   do {
+      sd = tcp_accept(listen_sd);
+      ret = read(sd, buf, 4096);
+      ret = write(sd, wbuf, sizeof(wbuf));
+      // suppress compiler warning about unused var
+      if (ret)
+         ;
+      tcp_close(sd);
+      if (strstr(buf, "stop") != NULL) {
+         break;
+      }
+   } while (keep_running != 0);
    tcp_close(listen_sd);
    exit(0);
 }

--- a/tests/hello_html_test.c
+++ b/tests/hello_html_test.c
@@ -112,10 +112,15 @@ int main(int argc, char const* argv[])
    keep_running = (getenv("KEEP_RUNNING") != NULL);
 
    listen_sd = tcp_listen();
-   printf("Listening on %d\n", PORT);
+   printf("Listening on port %d\n", PORT);
    do {
       sd = tcp_accept(listen_sd);
-      ret = read(sd, buf, 4096);
+      ret = read(sd, buf, sizeof(buf) - 1);
+      if (ret >= 0) {
+         buf[ret] = 0;
+      } else {
+         buf[0] = 0;
+      }
       ret = write(sd, wbuf, sizeof(wbuf));
       // suppress compiler warning about unused var
       if (ret)

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1566,6 +1566,7 @@ fi
    run curl -s -S localhost:$socket_port --retry-connrefused  --retry 25 --retry-delay 1
    rv=$?
    if [ $rv -ne 0 ]; then sed -e "s/^/# /" <$KMLOG; fi
+   assert [ $rv -eq 0 ]
    assert [ -S $MGTPIPE ]
 
    # just do snapshots and html requests for a while

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1562,11 +1562,10 @@ fi
    # startup the toy html server and wait for it to get going.
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
-   KEEP_RUNNING=yes run km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port &
+   KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port &
    run curl -s -S localhost:$socket_port --retry-connrefused  --retry 25 --retry-delay 1
-   rv=$?
-   if [ $rv -ne 0 ]; then sed -e "s/^/# /" <$KMLOG; fi
-   assert [ $rv -eq 0 ]
+   sed -e "s/^/# /" <$KMLOG >&3
+   assert [ $status -eq 0 ]
    assert [ -S $MGTPIPE ]
 
    # just do snapshots and html requests for a while

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1557,16 +1557,13 @@ fi
    local socket_port=$(($port_range_start + $port_id))
    local MGTPIPE=resume_after_mgtpipe.$$
    local SNAPDIR=snapdir.$$
-   local KMLOG=/tmp/hello_html_test.kmlog.$$
-   local STDERR=/tmp/hello_html_test.stderr.$$
 
    # startup the toy html server and wait for it to get going.
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
-   KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port 2>$STDERR &
+   KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE hello_html_test$ext $socket_port &
+   # Use "curl -4" to make sure we use ipv4.
    run curl -4 -s -S --retry-connrefused  --retry 25 --retry-delay 1 localhost:$socket_port
-   sed -e "s/^/# /" <$KMLOG >&3
-   sed -e "s/^/# /" <$STDERR >&3
    assert [ $status -eq 0 ]
    assert [ -S $MGTPIPE ]
 
@@ -1589,5 +1586,4 @@ fi
    # cleanup
    rm -f $MGTPIPE
    rm -fr $SNAPDIR
-   rm -f $KMLOG
 }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1558,13 +1558,15 @@ fi
    local MGTPIPE=resume_after_mgtpipe.$$
    local SNAPDIR=snapdir.$$
    local KMLOG=/tmp/hello_html_test.kmlog.$$
+   local STDERR=/tmp/hello_html_test.stderr.$$
 
    # startup the toy html server and wait for it to get going.
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
-   KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port &
+   KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port 2>$STDERR &
    run curl -s -S localhost:$socket_port --retry-connrefused  --retry 25 --retry-delay 1
    sed -e "s/^/# /" <$KMLOG >&3
+   sed -e "s/^/# /" <$STDERR >&3
    assert [ $status -eq 0 ]
    assert [ -S $MGTPIPE ]
 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1562,7 +1562,7 @@ fi
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
    KEEP_RUNNING=yes run km_with_timeout --mgtpipe=$MGTPIPE hello_html_test$ext $socket_port &
-   run curl -s localhost:$socket_port --retry-connrefused  --retry 3 --retry-delay 1
+   run curl -s -S localhost:$socket_port --retry-connrefused  --retry 3 --retry-delay 1
    assert_success
    assert [ -S $MGTPIPE ]
 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1557,13 +1557,15 @@ fi
    local socket_port=$(($port_range_start + $port_id))
    local MGTPIPE=resume_after_mgtpipe.$$
    local SNAPDIR=snapdir.$$
+   local KMLOG=/tmp/hello_html_test.kmlog.$$
 
    # startup the toy html server and wait for it to get going.
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
-   KEEP_RUNNING=yes run km_with_timeout --mgtpipe=$MGTPIPE hello_html_test$ext $socket_port &
+   KEEP_RUNNING=yes run km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port &
    run curl -s -S localhost:$socket_port --retry-connrefused  --retry 25 --retry-delay 1
-   assert_success
+   rv=$?
+   if [ $rv -ne 0 ]; then sed -e "s/^/# /" <$KMLOG; fi
    assert [ -S $MGTPIPE ]
 
    # just do snapshots and html requests for a while
@@ -1585,4 +1587,5 @@ fi
    # cleanup
    rm -f $MGTPIPE
    rm -fr $SNAPDIR
+   rm -f $KMLOG
 }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1564,7 +1564,7 @@ fi
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
    KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port 2>$STDERR &
-   run curl -s -S localhost:$socket_port --retry-connrefused  --retry 25 --retry-delay 1
+   run curl -s -S --retry-connrefused  --retry 25 --retry-delay 1 localhost:$socket_port
    sed -e "s/^/# /" <$KMLOG >&3
    sed -e "s/^/# /" <$STDERR >&3
    assert [ $status -eq 0 ]

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1584,6 +1584,5 @@ fi
    curl localhost:$socket_port/stop
 
    # cleanup
-   rm -f $MGTPIPE
-   rm -fr $SNAPDIR
+   rm -fr $SNAPDIR $MGTPIPE
 }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1562,7 +1562,7 @@ fi
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
    KEEP_RUNNING=yes run km_with_timeout --mgtpipe=$MGTPIPE hello_html_test$ext $socket_port &
-   run curl -s -S localhost:$socket_port --retry-connrefused  --retry 3 --retry-delay 1
+   run curl -s -S localhost:$socket_port --retry-connrefused  --retry 8 --retry-delay 1
    assert_success
    assert [ -S $MGTPIPE ]
 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1562,7 +1562,7 @@ fi
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
    KEEP_RUNNING=yes run km_with_timeout --mgtpipe=$MGTPIPE hello_html_test$ext $socket_port &
-   run curl -s -S localhost:$socket_port --retry-connrefused  --retry 8 --retry-delay 1
+   run curl -s -S localhost:$socket_port --retry-connrefused  --retry 25 --retry-delay 1
    assert_success
    assert [ -S $MGTPIPE ]
 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1563,7 +1563,7 @@ fi
    mkdir -p $SNAPDIR
    KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE hello_html_test$ext $socket_port &
    # Use "curl -4" to make sure we use ipv4.
-   run curl -4 -s -S --retry-connrefused  --retry 25 --retry-delay 1 localhost:$socket_port
+   run curl -4 -s -S --retry-connrefused  --retry 3 --retry-delay 1 localhost:$socket_port
    assert [ $status -eq 0 ]
    assert [ -S $MGTPIPE ]
 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1564,7 +1564,7 @@ fi
    rm -f $MGTPIPE
    mkdir -p $SNAPDIR
    KEEP_RUNNING=yes km_with_timeout --mgtpipe=$MGTPIPE --km-log-to=$KMLOG -V hello_html_test$ext $socket_port 2>$STDERR &
-   run curl -s -S --retry-connrefused  --retry 25 --retry-delay 1 localhost:$socket_port
+   run curl -4 -s -S --retry-connrefused  --retry 25 --retry-delay 1 localhost:$socket_port
    sed -e "s/^/# /" <$KMLOG >&3
    sed -e "s/^/# /" <$STDERR >&3
    assert [ $status -eq 0 ]


### PR DESCRIPTION
Added the -t flag to km_cli to specify whether the payload terminates
after the snapshot is complete.

Fixed a bug where the request length was not supplied with km mgmt requests.