### PR TITLE
change variable signedness so we can detect read/write errors

### DIFF
--- a/tests/hello_html_test.c
+++ b/tests/hello_html_test.c
@@ -132,7 +132,6 @@ int main(int argc, char const* argv[])
          buf[0] = 0;
       }
       ret = write(sd, wbuf, sizeof(wbuf));
-      // suppress compiler warning about unused var
       if (ret < 0) {
          printf("write failed, %s\n", strerror(errno));
       }


### PR DESCRIPTION
Plus add checks for ignored errors in the hello_html_test program.

Decided to fix these "problems" since hello_html_test was involved in the odd km failure where the kernel returned an fd that km thought was already in use.