### PR TITLE
Increase coverage of km_decode.c. Fix bug in mod/rm decode.

### DIFF
--- a/tests/decode_test.c
+++ b/tests/decode_test.c
@@ -168,7 +168,6 @@ TEST copyout_test()
 
 TEST mem_source_test()
 {
-
    /*
     * Make sure we decode correctly when memory is the source.
     * Use RDX because it is also used by guest interrupt
@@ -364,7 +363,6 @@ TEST test_allreg()
 
    PASS();
 }
-
 
 TEST mem_RSI_RDIaddress_test()
 {

--- a/tests/decode_test.c
+++ b/tests/decode_test.c
@@ -109,6 +109,24 @@ TEST mode1_test()
    PASS();
 }
 
+TEST mode2_test()
+{
+   ASSERT_EQ(0, setup());
+
+   asm volatile("mov %0, %%r10\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, 1000(%%r10)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r10", "%rax");
+
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+
+   ASSERT_EQ(0, teardown());
+   PASS();
+}
+
 TEST memset_test()
 {
    ASSERT_EQ(0, setup());
@@ -150,13 +168,13 @@ TEST copyout_test()
 
 TEST mem_source_test()
 {
-   ASSERT_EQ(0, setup());
 
    /*
     * Make sure we decode correctly when memory is the source.
     * Use RDX because it is also used by guest interrupt
     * handlers and this makes sure it gets restored correctly.
     */
+   ASSERT_EQ(0, setup());
    asm volatile("mov %0, %%rdx\n\t"
                 "mov (%%rdx), %%rax"
                 : /* No output */
@@ -165,8 +183,32 @@ TEST mem_source_test()
 
    ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
    ASSERT_EQ(datapage_page, failing_page());
-
    ASSERT_EQ(0, teardown());
+
+   // Same on bx
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%rbx\n\t"
+                "mov (%%rbx), %%rax"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%rbx", "%rax");
+
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   // same on cx
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%rcx\n\t"
+                "mov (%%rcx), %%rax"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%rcx", "%rax");
+
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
    PASS();
 }
 
@@ -199,6 +241,130 @@ TEST mem_RDIaddress_test()
    ASSERT_EQ(0, teardown());
    PASS();
 }
+
+TEST test_movsd()
+{
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%rsi\n\t"
+                "mov %1, %%rdi\n\t"
+                "movsd"
+                : /* No output */
+                : "r"(datapage_page), "r"(goodbuf)
+                : "%rsi", "%rdi");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%rsi\n\t"
+                "mov %1, %%rdi\n\t"
+                "movsd"
+                : /* No output */
+                : "r"(goodbuf), "r"(datapage_page)
+                : "%rsi", "%rdi");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   PASS();
+}
+
+/*
+ * Failing indirect access through all registers.
+ */
+TEST test_allreg()
+{
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r8\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r8)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r8", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r9\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r9)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r9", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r10\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r10)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r10", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r11\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r11)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r11", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r12\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r12)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r12", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r13\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r13)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r13", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r14\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r14)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r14", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   ASSERT_EQ(0, setup());
+   asm volatile("mov %0, %%r15\n\t"
+                "xor %%rax, %%rax\n\t"
+                "test %%rax, (%%r15)"
+                : /* No output */
+                : "r"(datapage_page)
+                : "%r15", "%rax");
+   ASSERT_EQ(SIGSEGV, datapage_siginfo.si_signo);
+   ASSERT_EQ(datapage_page, failing_page());
+   ASSERT_EQ(0, teardown());
+
+   PASS();
+}
+
 
 TEST mem_RSI_RDIaddress_test()
 {
@@ -271,6 +437,8 @@ int main(int argc, char* argv[])
 
    RUN_TEST(mode0_test);
    RUN_TEST(mode1_test);
+   RUN_TEST(mode2_test);
+   RUN_TEST(test_allreg);
    RUN_TEST(memset_test);
    RUN_TEST(copyin_test);
    RUN_TEST(copyout_test);
@@ -278,6 +446,7 @@ int main(int argc, char* argv[])
    RUN_TEST(mem_RSIaddress_test);
    RUN_TEST(mem_RDIaddress_test);
    RUN_TEST(mem_RSI_RDIaddress_test);
+   RUN_TEST(test_movsd);
    RUN_TEST(test_2byte);
    RUN_TEST(test_3byte);
    RUN_TEST(test_avx);


### PR DESCRIPTION
This started as an exercise to increase code coverage of `km_decode.c`. While working on it, I found bugs in `mod/rm` processing and `sib` byte processing. Those are fixed here.