### PR TITLE
eliminate race between exit_grp and clone

### DIFF
--- a/km/gdb/vcpus.gdb
+++ b/km/gdb/vcpus.gdb
@@ -1,0 +1,11 @@
+handle SIG63 pass nostop
+
+define print_vcpu_state
+set $id = 0
+while machine.vm_vcpus[$id] != 0
+   if machine.vm_vcpus[$id].state != PARKED_IDLE
+      set $state = $_as_string(machine.vm_vcpus[$id].state)
+      printf "vcpu[%3d]->state \t%s\n", $id, $state
+   end
+   set $id++
+end

--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -283,6 +283,9 @@ km_vcpu_t* km_vcpu_get(void)
 {
    km_vcpu_t* vcpu;
 
+   if (machine.exit_group != 0) {
+      return NULL;
+   }
    km_mutex_lock(&machine.vm_vcpu_mtx);
    if ((vcpu = SLIST_FIRST(&machine.vm_idle_vcpus.head)) != 0) {
       SLIST_REMOVE_HEAD(&machine.vm_idle_vcpus.head, next_idle);

--- a/km/km_cpu_init.c
+++ b/km/km_cpu_init.c
@@ -283,10 +283,11 @@ km_vcpu_t* km_vcpu_get(void)
 {
    km_vcpu_t* vcpu;
 
+   km_mutex_lock(&machine.vm_vcpu_mtx);
    if (machine.exit_group != 0) {
+      km_mutex_unlock(&machine.vm_vcpu_mtx);
       return NULL;
    }
-   km_mutex_lock(&machine.vm_vcpu_mtx);
    if ((vcpu = SLIST_FIRST(&machine.vm_idle_vcpus.head)) != 0) {
       SLIST_REMOVE_HEAD(&machine.vm_idle_vcpus.head, next_idle);
       machine.vm_vcpu_run_cnt++;

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -77,7 +77,7 @@ static inline void usage()
 "\n"
 "Options:\n"
 "\t--verbose[=regexp] (-V[regexp])     - Verbose print where internal info tag matches 'regexp'\n"
-"\t--gdb-server-port[=port] (-g[port]) - Enable gbd server listening on <port> (default 2159)\n"
+"\t--gdb-server-port[=port] (-g[port]) - Enable gdb server listening on <port> (default 2159)\n"
 "\t--gdb-listen                        - gdb server listens for client while payload runs\n"
 "\t--gdb-dynlink                       - gdb server waits for client attach before dyn link runs\n"
 "\t--version (-v)                      - Print version info and exit\n"

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -466,11 +466,16 @@ static int hypercall(km_vcpu_t* vcpu, int* hc_ret)
 
 static void km_vcpu_exit_all(km_vcpu_t* vcpu)
 {
+   int exiting_already;
+
    km_mutex_lock(&machine.vm_vcpu_mtx);
+   exiting_already = machine.exit_group;
    machine.exit_group = 1;   // make sure we exit and not waiting for gdb
    km_mutex_unlock(&machine.vm_vcpu_mtx);
-   km_vcpu_pause_all(vcpu, ALL);
-   km_signal_machine_fini();
+   if (exiting_already == 0) {
+      km_vcpu_pause_all(vcpu, ALL);
+      km_signal_machine_fini();
+   }
    km_vcpu_stopped(vcpu);
 }
 

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -466,7 +466,9 @@ static int hypercall(km_vcpu_t* vcpu, int* hc_ret)
 
 static void km_vcpu_exit_all(km_vcpu_t* vcpu)
 {
+   km_mutex_lock(&machine.vm_vcpu_mtx);
    machine.exit_group = 1;   // make sure we exit and not waiting for gdb
+   km_mutex_unlock(&machine.vm_vcpu_mtx);
    km_vcpu_pause_all(vcpu, ALL);
    km_signal_machine_fini();
    km_vcpu_stopped(vcpu);


### PR DESCRIPTION
If `km_vcpu_get()` is called after `exit_grp()` it is possible to get a vcpu that already done `pthread_exit()`. That vcpu will never run hence never exit hence never accounted as exit. km main thread would wait forever.

