### PR TITLE
Serge/handle dup

### DIFF
--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -117,6 +117,8 @@ typedef struct km_nt_guest {
 typedef struct km_nt_file {
    Elf64_Word size;    // Size of record
    Elf64_Word fd;      // Open fd number
+   Elf64_Word dev;     // Device number - for dup detection
+   Elf64_Word ino;     // Inode number
    Elf64_Word how;     // How file was created
    Elf64_Word flags;   // open(2) flags
    Elf64_Word mode;    // file mode (includes type)
@@ -133,10 +135,14 @@ typedef struct km_nt_file {
    // Followed by data buffered in a pipe
 } km_nt_file_t;
 #define NT_KM_FILE 0x4b4d4644   // "KMFD" no null term
+// eventfd
+#define NT_KM_EVENTFD 0x4b4d4556   // "KMEV" no null term
 
 typedef struct km_nt_socket {
    Elf64_Word size;      // Size of record
    Elf64_Word fd;        // Open fd number
+   Elf64_Word dev;       // Device number - for dup detection
+   Elf64_Word ino;       // Inode number
    Elf64_Word how;       // How socket was created
    Elf64_Word state;     // state of socket
    Elf64_Word backlog;   // listen backlog
@@ -194,17 +200,17 @@ typedef struct km_nt_event {
 } km_nt_event_t;
 
 // eventfd (epoll_create)
-typedef struct km_nt_eventfd {
+typedef struct km_nt_epollfd {
    Elf64_Word size;         // Size of record
    Elf64_Word fd;           // Open event fd
+   Elf64_Word dev;          // Device number - for dup detection
+   Elf64_Word ino;          // Inode number
    Elf64_Word flags;        // flags
    Elf64_Word event_size;   // size of event records that follow
    Elf64_Word nevent;       // number of event records that follow
-} km_nt_eventfd_t;
+   // Followed by event records km_nt_event_t
+} km_nt_epollfd_t;
 #define NT_KM_EPOLLFD 0x4b4d4550   // "KMEP"
-
-// eventfd
-#define NT_KM_EVENTFD 0x4b4d4556   // "KMEV" no null term
 
 /*
  * Elf note record for signal handler.

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1132,7 +1132,7 @@ fi
    assert_success
 
    # make sure resume with payloads args fails
-   run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext
+   run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext $snapshot_test_port
    assert_success
    assert [ -f ${SNAP} ]
    assert [ ! -f ${CORE} ]
@@ -1149,7 +1149,7 @@ fi
    fi
    for i in $(seq $cnt) ; do
       # snapshot resume that successfully exits
-      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext
+      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext $snapshot_test_port
       assert_success
       assert [ -f ${SNAP} ]
       assert [ ! -f ${CORE} ]
@@ -1168,7 +1168,7 @@ fi
       rm -f ${SNAP} ${KMLOG} ${SNAP_OUTPUT}
 
       # snapshot with closed stdio
-      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -c
+      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -c $snapshot_test_port
       assert_success
       assert [ -f ${SNAP} ]
       assert [ ! -f ${CORE} ]
@@ -1186,7 +1186,7 @@ fi
       rm -f ${SNAP} ${KMLOG} ${SNAP_OUTPUT}
 
       # snapshot resume that core dumps
-      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -a
+      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -a $snapshot_test_port
       assert_success
       assert [ -f ${SNAP} ]
       check_kmcore ${SNAP}
@@ -1203,7 +1203,7 @@ fi
       rm -f ${SNAP} ${CORE} ${KMLOG} ${SNAP_OUTPUT}
 
       # 'live' snapshot
-      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -l
+      run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -l $snapshot_test_port
       assert_success
       assert [ -f ${SNAP} ]
       check_kmcore ${SNAP}


### PR DESCRIPTION
Record dev/inode numbers for file descriptor on snapshot. Use that to discover duped fds on restore. Simply do dup{2,3} on restore when dup is detected.

Added tests for duped files and sockets.

This implementation has a drawback. It will incorrectly handle two fds that were open on the same file, not duped. The file offset will by tied for them together after the recover as the algorithm will mistake them for dups. See https://github.com/kontainapp/km/issues/1671