### PR TITLE
Add support for snapshoting data buffered in a socketpair

### DIFF
--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -127,8 +127,8 @@ typedef struct km_nt_file {
     *   __S_IFIFO  - 'other' fd in pipe
     *   __S_ISOCK  - 'other' fd in socketpair
     */
-   Elf64_Off data;   // depends on file type.
-   Elf64_Word datalength; // bytes of pipe contents following filename
+   Elf64_Off data;          // depends on file type.
+   Elf64_Word datalength;   // bytes of pipe contents following filename
    // Followed by file name
    // Followed by pipe or socketpair contents
 } km_nt_file_t;
@@ -145,7 +145,7 @@ typedef struct km_nt_socket {
    Elf64_Word protocol;
    Elf64_Word other;   // 'other' fd for socketpair(2)
    Elf64_Word addrlen;
-   Elf64_Word datalength; // bytes of to write back into this side
+   Elf64_Word datalength;   // bytes of to write back into this side
    // Address follows
    // Data queued in socket follows the address
 } km_nt_socket_t;

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -130,7 +130,7 @@ typedef struct km_nt_file {
    Elf64_Off data;          // depends on file type.
    Elf64_Word datalength;   // bytes of pipe contents following filename
    // Followed by file name
-   // Followed by pipe or socketpair contents
+   // Followed by data buffered in a pipe
 } km_nt_file_t;
 #define NT_KM_FILE 0x4b4d4644   // "KMFD" no null term
 
@@ -145,9 +145,12 @@ typedef struct km_nt_socket {
    Elf64_Word protocol;
    Elf64_Word other;   // 'other' fd for socketpair(2)
    Elf64_Word addrlen;
-   Elf64_Word datalength;   // bytes of to write back into this side
-   // Address follows
-   // Data queued in socket follows the address
+   Elf64_Word datalength;   // number of bytes to write back to the
+                            // write side of a socketpair.  The data
+                            // bytes follow the protocol address of
+                            // this note.
+   // Protocol address follows
+   // Data buffered in the "write side" of a socketpair follows
 } km_nt_socket_t;
 #define NT_KM_SOCKET 0x4b4d534b   // "KMSK" no null term
 
@@ -163,7 +166,16 @@ typedef struct km_nt_socket {
 #define KM_NT_SKSTATE_CONNECT 4
 #define KM_NT_SKSTATE_ERROR 5
 
-// Use a function so that we consistently roundup note related pieces in the rest of the code.
+/*
+ * Use a function so that we consistently roundup note related pieces in the rest of the code.
+ *
+ * Apparently elf note fields are supposed to be aligned on a 4 or 8 byte boundary.
+ * See: https://groups.google.com/g/generic-abi/c/vT-_QVcckXo?pli=1
+ * Which refers to: http://sco.com/developers/gabi/latest/ch5.pheader.html#note_section
+ * and: http://www.netbsd.org/docs/kernel/elf-notes.html#note-format
+ * So we align the length of data we add to the end of a note so the next sequential
+ * note will be aligned properly.
+ */
 static inline size_t km_nt_chunk_roundup(size_t size)
 {
    return roundup(size, 4);

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1892,7 +1892,8 @@ size_t km_fs_core_notes_length()
    return ret;
 }
 
-static inline size_t fs_core_save_pipe_contents(char* buf, size_t length, km_file_t* file, int writefd, size_t queuedbytes)
+static inline size_t
+fs_core_save_pipe_contents(char* buf, size_t length, km_file_t* file, int writefd, size_t queuedbytes)
 {
    km_assert(queuedbytes <= length);
 
@@ -1934,7 +1935,8 @@ static inline size_t fs_core_write_nonsocket(char* buf, size_t length, km_file_t
                              remain,
                              KM_NT_NAME,
                              NT_KM_FILE,
-                             sizeof(km_nt_file_t) + km_nt_file_padded_size(file->name) + roundup(queuedbytes, 4));
+                             sizeof(km_nt_file_t) + km_nt_file_padded_size(file->name) +
+                                 roundup(queuedbytes, 4));
    km_nt_file_t* fnote = (km_nt_file_t*)cur;
    cur += sizeof(km_nt_file_t);
    fnote->size = sizeof(km_nt_file_t);
@@ -1980,7 +1982,8 @@ static inline size_t fs_core_write_socket(char* buf, size_t length, km_file_t* f
                              remain,
                              KM_NT_NAME,
                              NT_KM_SOCKET,
-                             sizeof(km_nt_socket_t) + km_nt_chunk_roundup(file->sockinfo->addrlen) + km_nt_chunk_roundup(queuedbytes));
+                             sizeof(km_nt_socket_t) + km_nt_chunk_roundup(file->sockinfo->addrlen) +
+                                 km_nt_chunk_roundup(queuedbytes));
    km_nt_socket_t* fnote = (km_nt_socket_t*)cur;
    cur += sizeof(km_nt_socket_t);
    fnote->size = sizeof(km_nt_socket_t);
@@ -2019,7 +2022,7 @@ static inline size_t fs_core_write_socket(char* buf, size_t length, km_file_t* f
             file->name,
             fnote->other,
             file->ofd,
-	    fnote->datalength);
+            fnote->datalength);
    return cur - buf;
 }
 
@@ -2243,7 +2246,10 @@ static inline int km_fs_recover_pipedata(km_nt_file_t* nt_file, char* pipedata)
          return -1;
       }
       if (byteswritten != nt_file->datalength) {
-         km_warnx("expected to write %ld bytes of pipe data, but wrote %ld bytes to fd %d", nt_file->datalength, byteswritten, nt_file->fd);
+         km_warnx("expected to write %ld bytes of pipe data, but wrote %ld bytes to fd %d",
+                  nt_file->datalength,
+                  byteswritten,
+                  nt_file->fd);
          return -1;
       }
    }
@@ -2256,8 +2262,11 @@ static inline int km_fs_recover_pipe(km_nt_file_t* nt_file, char* name, char* pi
 
    km_infox(KM_TRACE_SNAPSHOT,
             "recovering pipe: file used %d, flags=0x%x, fd %d, data %d, datalength %ld",
-	    km_is_file_used(file),
-            nt_file->flags, nt_file->fd, nt_file->data, nt_file->datalength);
+            km_is_file_used(file),
+            nt_file->flags,
+            nt_file->fd,
+            nt_file->data,
+            nt_file->datalength);
 
    if (km_is_file_used(file) != 0) {
       // Created in by other side
@@ -2354,7 +2363,7 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
       return -1;
    }
    char* name = ptr + sizeof(km_nt_file_t);
-   char *pipedata = name + km_nt_file_padded_size(name);
+   char* pipedata = name + km_nt_file_padded_size(name);
    km_infox(KM_TRACE_SNAPSHOT,
             "fd=%d name=%s flags=0x%x mode=%o pos=%ld",
             nt_file->fd,
@@ -2978,14 +2987,17 @@ void km_close_stdio(int log_to_fd)
 static int km_fs_recover_socketdata(km_nt_socket_t* nt_sock)
 {
    if (nt_sock->datalength > 0) {
-      char *p = (char*)nt_sock + sizeof(km_nt_socket_t) + km_nt_chunk_roundup(nt_sock->addrlen);
+      char* p = (char*)nt_sock + sizeof(km_nt_socket_t) + km_nt_chunk_roundup(nt_sock->addrlen);
       ssize_t byteswritten = write(nt_sock->fd, p, nt_sock->datalength);
       if (byteswritten < 0) {
          km_warn("write %ld bytes queued data to fd %d failed", nt_sock->fd, nt_sock->datalength);
          return -1;
       }
       if (byteswritten < nt_sock->datalength) {
-         km_warnx("write to fd %d truncated, wrote %ld, expected to write %ld", nt_sock->fd, nt_sock->datalength, byteswritten);
+         km_warnx("write to fd %d truncated, wrote %ld, expected to write %ld",
+                  nt_sock->fd,
+                  nt_sock->datalength,
+                  byteswritten);
          return -1;
       }
    }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1121,15 +1121,15 @@ fi
    run km_with_timeout --snapshot=${SNAP} snapshot_fail_test$ext -e
    assert_failure
    assert_output --partial "Can't perform snapshot, epoll fd "
-   run km_with_timeout --snapshot=${SNAP} snapshot_fail_test$ext -p
-   assert_failure
-   assert_output --partial "Can't take a snapshot, fifo fd "
-   run km_with_timeout --snapshot=${SNAP} snapshot_fail_test$ext -s
-   assert_failure
-   assert_output --partial "Couldn't perform snapshot, socketpair fd "
    run km_with_timeout --snapshot=${SNAP} snapshot_fail_test$ext -t
    assert_failure
    assert_output --partial "Can't take a snapshot, active interval timer(s)"
+
+   # Verify that data buffered in pipes and socketpairs are snapshoted and restored
+   run km_with_timeout --snapshot=${SNAP} snapshot_fail_test$ext -p
+   assert_success
+   run km_with_timeout --snapshot=${SNAP} snapshot_fail_test$ext -s
+   assert_success
 
    # make sure resume with payloads args fails
    run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext

--- a/tests/snapshot_fail_test.c
+++ b/tests/snapshot_fail_test.c
@@ -40,10 +40,11 @@ char* SOCKET_PORT = "SOCKET_PORT";
  * A simple test to verify that snapshots fail if the following are found in the
  * payload being snapshotted.
  * - epoll fd's with events
- * - pipes with queued data
- * - socketpair's with queued data
  * - sockets that are in a connected state.
  * - interval timers that are running (setitimer() and timer_create())
+ * Now the following conditions are supported.  So test that they work.
+ * - pipes with queued data
+ * - socketpair's with queued data
  * We can try each of these things with different command line options.
  * We verify success by this program exiting with an error status and an error message.
  * Command line flags:
@@ -117,23 +118,46 @@ int main(int argc, char* argv[])
          break;
 
       // Snapshot when a pipe has queued data
+#define PIPEDATA "stuff"
       case 'p':;
          if (pipe(pipefd) < 0) {
             fprintf(stderr, "Couldn't create pipe, %s\n", strerror(errno));
             exit(100);
          }
-         bc = write(pipefd[1], "stuff", sizeof("stuff"));
+         bc = write(pipefd[1], PIPEDATA, sizeof("stuff"));
          if (bc != sizeof("stuff")) {
             fprintf(stderr, "Couldn't write to pipe, bc %d, %s\n", bc, strerror(errno));
             exit(100);
          }
          snapshotargs = (km_hc_args_t){.arg1 = (uint64_t) "snaptest_label",
                                        .arg2 = (uint64_t) "Snapshot pipe with data",
-                                       .arg3 = 1};
+                                       .arg3 = 0};
          km_hcall(HC_snapshot, &snapshotargs);
-         // We expect the snapshot to fail because of the queued pipe data.
-         fprintf(stderr, "snapshot when pipe has queued data returned?\n");
-         exit(100);
+         if (snapshotargs.hc_ret != 0) {
+            fprintf(stderr, "snapshot pipe with data failed, error %ld\n", snapshotargs.hc_ret);
+            exit(100);
+         } else {
+            // We should resume from the snapshot here.  So, read the pipe contents.
+            char buf[32];
+            ssize_t bytesread = read(pipefd[0], buf, sizeof(buf));
+            if (bytesread < 0) {
+               fprintf(stderr, "read from pipe failed %s\n", strerror(errno));
+               exit(120);
+            }
+	    buf[bytesread] = 0;
+            fprintf(stdout, "pipedata >>>>%s<<<<\n", buf);
+            if (bytesread != sizeof(PIPEDATA)) {
+               fprintf(stderr, "Read %ld bytes back from pipe, expected %ld", bytesread, sizeof(PIPEDATA));
+               exit(121);
+            }
+            if (strcmp(buf, PIPEDATA) != 0) {
+               fprintf(stderr, "pipe data is wrong, expected %s, got %s\n", PIPEDATA, buf);
+               exit(122);
+            }
+            close(pipefd[0]);
+            close(pipefd[1]);
+	    exit(0);
+         }
          break;
 
       // Snapshot with a connected network connection
@@ -220,21 +244,77 @@ int main(int argc, char* argv[])
          break;
 
       // Snapshot when a socketpair has queued data
+#define SOCKETPAIRDATA0 "chocolate chip cookie"
+#define SOCKETPAIRDATA1 "krik's steak burger"
       case 's':;
          int sp[2];
          if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp) < 0) {
             fprintf(stderr, "Couldn't create socketpair, %s\n", strerror(errno));
             exit(100);
          }
-         bc = write(sp[1], "stuff", sizeof("stuff"));
-         if (bc != sizeof("stuff")) {
-            fprintf(stderr, "Couldn't write to socketpair, bc %d, %s\n", bc, strerror(errno));
+         bc = write(sp[0], SOCKETPAIRDATA0, sizeof(SOCKETPAIRDATA0));
+         if (bc != sizeof(SOCKETPAIRDATA0)) {
+            fprintf(stderr, "Couldn't write to socketpair end 0, bc %d, %s\n", bc, strerror(errno));
+            exit(100);
+         }
+         bc = write(sp[1], SOCKETPAIRDATA1, sizeof(SOCKETPAIRDATA1));
+         if (bc != sizeof(SOCKETPAIRDATA1)) {
+            fprintf(stderr, "Couldn't write to socketpair end 1, bc %d, %s\n", bc, strerror(errno));
             exit(100);
          }
          snapshotargs = (km_hc_args_t){.arg1 = (uint64_t) "snaptest_label",
                                        .arg2 = (uint64_t) "Snapshot socketpair with data",
-                                       .arg3 = 1};
+                                       .arg3 = 0};
          km_hcall(HC_snapshot, &snapshotargs);
+         if (snapshotargs.hc_ret != 0) {
+            fprintf(stderr, "snapshot socketpair with data failed, error %ld\n", snapshotargs.hc_ret);
+            exit(100);
+         } else {
+            // We should resume from the snapshot here.  So, read the socket contents from each end.
+            char buf[64];
+            ssize_t bytesread;
+
+            fprintf(stdout, "Attempt to read socketpair buffered data after snapshot resume\n");
+
+	    // read from sp[0]
+            bytesread = read(sp[0], buf, sizeof(buf));
+            if (bytesread < 0) {
+               fprintf(stderr, "read from socketpair 0 failed %s\n", strerror(errno));
+               exit(120);
+            }
+	    buf[bytesread] = 0;
+            fprintf(stdout, "socketpair 0 data length %ld, >>>>%s<<<<\n", bytesread, buf);
+            if (bytesread != sizeof(SOCKETPAIRDATA1)) {
+               fprintf(stderr, "Read %ld bytes back from socketpair 0, expected %ld", bytesread, sizeof(SOCKETPAIRDATA1));
+               exit(121);
+            }
+            if (strcmp(buf, SOCKETPAIRDATA1) != 0) {
+               fprintf(stderr, "socketpair 0 data is wrong, expected <%s>, got <%s>\n", SOCKETPAIRDATA1, buf);
+               exit(122);
+            }
+
+            // read from sp[1]
+            bytesread = read(sp[1], buf, sizeof(buf));
+            if (bytesread < 0) {
+               fprintf(stderr, "read from socketpair 1 failed %s\n", strerror(errno));
+               exit(120);
+            }
+	    buf[bytesread] = 0;
+            fprintf(stdout, "socketpair 1 data length %ld >>>>%s<<<<\n", bytesread, buf);
+            if (bytesread != sizeof(SOCKETPAIRDATA0)) {
+               fprintf(stderr, "Read %ld bytes back from socketpair 1, expected %ld", bytesread, sizeof(SOCKETPAIRDATA0));
+               exit(121);
+            }
+            if (strcmp(buf, SOCKETPAIRDATA0) != 0) {
+               fprintf(stderr, "socketpair 1 data is wrong, expected <%s>, got <%s>\n", SOCKETPAIRDATA0, buf);
+               exit(122);
+            }
+
+            close(sp[0]);
+            close(sp[1]);
+            fprintf(stdout, "socketpair buffered data test succeeds\n");
+	    exit(0);
+         }
          // We expect the snapshot to fail because of the queued socket data.
          fprintf(stderr, "snapshot when socketpair has queued data returned?\n");
          exit(100);

--- a/tests/snapshot_fail_test.c
+++ b/tests/snapshot_fail_test.c
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
          exit(100);
          break;
 
-      // Snapshot when a pipe has queued data
+         // Snapshot when a pipe has queued data
 #define PIPEDATA "stuff"
       case 'p':;
          if (pipe(pipefd) < 0) {
@@ -144,7 +144,7 @@ int main(int argc, char* argv[])
                fprintf(stderr, "read from pipe failed %s\n", strerror(errno));
                exit(120);
             }
-	    buf[bytesread] = 0;
+            buf[bytesread] = 0;
             fprintf(stdout, "pipedata >>>>%s<<<<\n", buf);
             if (bytesread != sizeof(PIPEDATA)) {
                fprintf(stderr, "Read %ld bytes back from pipe, expected %ld", bytesread, sizeof(PIPEDATA));
@@ -156,7 +156,7 @@ int main(int argc, char* argv[])
             }
             close(pipefd[0]);
             close(pipefd[1]);
-	    exit(0);
+            exit(0);
          }
          break;
 
@@ -243,7 +243,7 @@ int main(int argc, char* argv[])
          exit(100);
          break;
 
-      // Snapshot when a socketpair has queued data
+         // Snapshot when a socketpair has queued data
 #define SOCKETPAIRDATA0 "chocolate chip cookie"
 #define SOCKETPAIRDATA1 "krik's steak burger"
       case 's':;
@@ -276,20 +276,26 @@ int main(int argc, char* argv[])
 
             fprintf(stdout, "Attempt to read socketpair buffered data after snapshot resume\n");
 
-	    // read from sp[0]
+            // read from sp[0]
             bytesread = read(sp[0], buf, sizeof(buf));
             if (bytesread < 0) {
                fprintf(stderr, "read from socketpair 0 failed %s\n", strerror(errno));
                exit(120);
             }
-	    buf[bytesread] = 0;
+            buf[bytesread] = 0;
             fprintf(stdout, "socketpair 0 data length %ld, >>>>%s<<<<\n", bytesread, buf);
             if (bytesread != sizeof(SOCKETPAIRDATA1)) {
-               fprintf(stderr, "Read %ld bytes back from socketpair 0, expected %ld", bytesread, sizeof(SOCKETPAIRDATA1));
+               fprintf(stderr,
+                       "Read %ld bytes back from socketpair 0, expected %ld",
+                       bytesread,
+                       sizeof(SOCKETPAIRDATA1));
                exit(121);
             }
             if (strcmp(buf, SOCKETPAIRDATA1) != 0) {
-               fprintf(stderr, "socketpair 0 data is wrong, expected <%s>, got <%s>\n", SOCKETPAIRDATA1, buf);
+               fprintf(stderr,
+                       "socketpair 0 data is wrong, expected <%s>, got <%s>\n",
+                       SOCKETPAIRDATA1,
+                       buf);
                exit(122);
             }
 
@@ -299,21 +305,27 @@ int main(int argc, char* argv[])
                fprintf(stderr, "read from socketpair 1 failed %s\n", strerror(errno));
                exit(120);
             }
-	    buf[bytesread] = 0;
+            buf[bytesread] = 0;
             fprintf(stdout, "socketpair 1 data length %ld >>>>%s<<<<\n", bytesread, buf);
             if (bytesread != sizeof(SOCKETPAIRDATA0)) {
-               fprintf(stderr, "Read %ld bytes back from socketpair 1, expected %ld", bytesread, sizeof(SOCKETPAIRDATA0));
+               fprintf(stderr,
+                       "Read %ld bytes back from socketpair 1, expected %ld",
+                       bytesread,
+                       sizeof(SOCKETPAIRDATA0));
                exit(121);
             }
             if (strcmp(buf, SOCKETPAIRDATA0) != 0) {
-               fprintf(stderr, "socketpair 1 data is wrong, expected <%s>, got <%s>\n", SOCKETPAIRDATA0, buf);
+               fprintf(stderr,
+                       "socketpair 1 data is wrong, expected <%s>, got <%s>\n",
+                       SOCKETPAIRDATA0,
+                       buf);
                exit(122);
             }
 
             close(sp[0]);
             close(sp[1]);
             fprintf(stdout, "socketpair buffered data test succeeds\n");
-	    exit(0);
+            exit(0);
          }
          // We expect the snapshot to fail because of the queued socket data.
          fprintf(stderr, "snapshot when socketpair has queued data returned?\n");


### PR DESCRIPTION
Also support for snapshotting data buffered in a pipe.
The buffered data is stored in the elf note for the write side
of the pipe or socketpair fd's in the snapshot.
The data in the pipe or socketpair is read out to perform the
snapshot and written back into the write side of the pipe so
the application can get its data if it were to resume after the
snapshot request returns.
Changed the bats snapshot_fail_test to now verify that data buffered
in a pipe or socketpair is now available when the snapshot is
restarted.