### PR TITLE
Change bats basic_snapshot to tolerate multiple pids from pidof

### DIFF
--- a/tests/buildenv-fedora.dockerfile
+++ b/tests/buildenv-fedora.dockerfile
@@ -80,7 +80,7 @@ RUN dnf install -y \
    python3-markupsafe libffi-devel parallel \
    automake autoconf libcap-devel yajl-devel libseccomp-devel \
    python3-libmount libtool cmake makeself \
-   systemd-devel valgrind \
+   systemd-devel valgrind lsof \
    && dnf upgrade -y && dnf clean all && rm -rf /var/cache/{dnf,yum}
 
 FROM buildenv-early AS buildclangformat

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1103,7 +1103,16 @@ fi
    tries=5
    while [ ! -S ${MGMTPIPE} ] && [ $tries -gt 0 ]; do sleep 1; tries=`expr $tries - 1`; done
    assert [ $tries -gt 0 ]
-   pid=`pidof hello_html_test$ext`
+   pidlist=`pidof hello_html_test$ext`
+   # Find our pid if pidof returned multiple pids
+   pid=""
+   for p in $pidlist; do
+      if lsof -p $p | grep " 729u .* $MGMTPIPE " >/dev/null 2>&1; then
+         pid=$p
+         break
+      fi
+   done
+   assert [ ! -z "$pid" ]
    run ${KM_CLI_BIN} -p $pid -d $SNAPDIR
    assert_success
    assert [ -f $SNAPDIR/hello_html_test$ext.$pid.kmsnap ]

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1107,7 +1107,7 @@ fi
    # Find our pid if pidof returned multiple pids
    pid=""
    for p in $pidlist; do
-      if lsof -p $p | grep " 729u .* $MGMTPIPE " >/dev/null 2>&1; then
+      if lsof -p $p |& grep -q  " 729u .* $MGMTPIPE "; then
          pid=$p
          break
       fi


### PR DESCRIPTION
The basic_snapshot test uses the pidof command to find the pid of a command it wants to snapshot.  When the bats tests run with concurrency enabled pidof can return multiple pids which isn't handled. Add a small loop to traverse the list of pids returned by pidof to find which pid we need for the test.