### PR TITLE
Revisited duped fd processing

### DIFF
--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -510,6 +510,10 @@ static inline int km_core_write_notes(km_vcpu_t* vcpu,
     * see things that are not snapshotable (like established network connections).
     */
    if (dumptype == KM_DO_SNAP) {
+      ret = km_fs_core_dup_write(cur, remain);
+      cur += ret;
+      remain -= ret;
+
       ret = km_fs_core_notes_write(cur, remain);
       cur += ret;
       remain -= ret;
@@ -642,6 +646,7 @@ km_core_notes_length(km_vcpu_t* vcpu, const char* label, const char* description
    }
 
    if (dumptype == KM_DO_SNAP) {
+      alloclen += km_fs_dup_notes_length();
       alloclen += km_fs_core_notes_length();
    }
    alloclen += km_sig_core_notes_length();

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -117,8 +117,6 @@ typedef struct km_nt_guest {
 typedef struct km_nt_file {
    Elf64_Word size;    // Size of record
    Elf64_Word fd;      // Open fd number
-   Elf64_Word dev;     // Device number - for dup detection
-   Elf64_Word ino;     // Inode number
    Elf64_Word how;     // How file was created
    Elf64_Word flags;   // open(2) flags
    Elf64_Word mode;    // file mode (includes type)
@@ -141,8 +139,6 @@ typedef struct km_nt_file {
 typedef struct km_nt_socket {
    Elf64_Word size;      // Size of record
    Elf64_Word fd;        // Open fd number
-   Elf64_Word dev;       // Device number - for dup detection
-   Elf64_Word ino;       // Inode number
    Elf64_Word how;       // How socket was created
    Elf64_Word state;     // state of socket
    Elf64_Word backlog;   // listen backlog
@@ -192,7 +188,7 @@ static inline size_t km_nt_file_padded_size(const char* str)
    return km_nt_chunk_roundup(strlen(str) + 1);
 }
 
-// Single event on eventfd (epoll_create)
+// Single event on epollfd (epoll_create)
 typedef struct km_nt_event {
    Elf64_Word fd;   // fd to monitor
    Elf64_Word event;
@@ -201,14 +197,11 @@ typedef struct km_nt_event {
 
 // eventfd (epoll_create)
 typedef struct km_nt_epollfd {
-   Elf64_Word size;         // Size of record
-   Elf64_Word fd;           // Open event fd
-   Elf64_Word dev;          // Device number - for dup detection
-   Elf64_Word ino;          // Inode number
-   Elf64_Word flags;        // flags
-   Elf64_Word event_size;   // size of event records that follow
-   Elf64_Word nevent;       // number of event records that follow
-   // Followed by event records km_nt_event_t
+   Elf64_Word size;           // Size of record
+   Elf64_Word fd;             // Open event fd
+   Elf64_Word flags;          // flags
+   Elf64_Word nevent;         // number of event records that follow
+   km_nt_event_t events[0];   // Followed by event records km_nt_event_t
 } km_nt_epollfd_t;
 #define NT_KM_EPOLLFD 0x4b4d4550   // "KMEP"
 

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -112,6 +112,22 @@ typedef struct km_nt_guest {
 #define NT_KM_DYNLINKER 0x4b4d444c   // "KMDL" no null term
 
 /*
+ * Elf note for dup data
+ */
+
+typedef Elf64_Word km_nt_dup_fd_t;
+typedef struct km_nt_dup_grp {
+   Elf64_Word size;
+   km_nt_dup_fd_t fds[0];
+} km_nt_dup_grp_t;
+
+typedef struct km_nt_dup {
+   Elf64_Word size;
+   km_nt_dup_grp_t grp[0];
+} km_nt_dup_t;
+#define NT_KM_DUP_DATA 0x4b4d4455   // "KMDU" no null term
+
+/*
  * Elf note record for open file.
  */
 typedef struct km_nt_file {

--- a/km/km_exec_fd_save_recover.c
+++ b/km/km_exec_fd_save_recover.c
@@ -485,8 +485,8 @@ static int km_exec_restore_socketpair(int fd, km_file_how_t how, int ofd)
    return 0;
 }
 
-static int
-km_exec_restore_socket(int fd, km_file_how_t how, km_sock_state_t state, int backlog, int ofd, km_fd_socket_t* sockinfo)
+static int km_exec_restore_socket(
+    int fd, km_file_how_t how, km_sock_state_t state, int backlog, int ofd, km_fd_socket_t* sockinfo)
 {
    km_file_t* file;
    km_exec_get_file_pointer(fd, &file, NULL);

--- a/km/km_exec_fd_save_recover.c
+++ b/km/km_exec_fd_save_recover.c
@@ -329,7 +329,7 @@ static void km_fs_destroy_fd(int fd)
    km_set_file_used(file, 0);
 }
 
-static int km_exec_restore_file(int fd, int how, int flags, int index)
+static int km_exec_restore_file(int fd, km_file_how_t how, int flags, int index)
 {
    km_file_t* file;
 
@@ -392,7 +392,7 @@ static int km_exec_restore_eventfd(int fd, int flags)
    return 0;
 }
 
-static int km_exec_restore_pipe(int fd, int how, int flags, unsigned long ofd)
+static int km_exec_restore_pipe(int fd, km_file_how_t how, int flags, unsigned long ofd)
 {
    km_file_t* file;
    km_exec_get_file_pointer(fd, &file, NULL);
@@ -451,7 +451,7 @@ static int km_exec_socket_get_sockopts(int fd)
    return 0;
 }
 
-static int km_exec_restore_socketpair(int fd, int how, int ofd)
+static int km_exec_restore_socketpair(int fd, km_file_how_t how, int ofd)
 {
    km_file_t* file;
    km_exec_get_file_pointer(fd, &file, NULL);
@@ -486,7 +486,7 @@ static int km_exec_restore_socketpair(int fd, int how, int ofd)
 }
 
 static int
-km_exec_restore_socket(int fd, int how, int state, int backlog, int ofd, km_fd_socket_t* sockinfo)
+km_exec_restore_socket(int fd, km_file_how_t how, km_sock_state_t state, int backlog, int ofd, km_fd_socket_t* sockinfo)
 {
    km_file_t* file;
    km_exec_get_file_pointer(fd, &file, NULL);

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -625,7 +625,6 @@ uint64_t km_fs_fcntl(km_vcpu_t* vcpu, int fd, int cmd, uint64_t arg)
                                    (cmd == F_DUPFD) ? 0 : O_CLOEXEC,
                                    file->sockinfo,
                                    file->how);
-            km_fs_add_to_dup_data(ret, host_fd);
          } else {
             ret = km_add_guest_fd_internal(vcpu,
                                            ret,
@@ -634,6 +633,7 @@ uint64_t km_fs_fcntl(km_vcpu_t* vcpu, int fd, int cmd, uint64_t arg)
                                            file->how,
                                            ops);
          }
+         km_fs_add_to_dup_data(ret, host_fd);
       }
    }
    return ret;

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -72,6 +72,9 @@ static char* km_my_exec;   // my executable per /proc/self/exe to check with in 
 static int km_fs_g2h_filename(const char* name, char* buf, size_t bufsz, km_file_ops_t** ops);
 static int km_fs_g2h_readlink(const char* name, char* buf, size_t bufsz);
 
+km_fd_dup_data_t dup_data;
+pthread_mutex_t dup_data_mtx;
+
 /*
  * Tells whether a file is inuse or not.
  */
@@ -83,6 +86,123 @@ int km_is_file_used(km_file_t* file)
 void km_set_file_used(km_file_t* file, int val)
 {
    __atomic_store_n(&file->inuse, val, __ATOMIC_SEQ_CST);
+}
+
+/*
+ * On snap recover check if the fd was involved in dup. If it was check if other fds in the same dup
+ * group exist already. If they are dup them, if not we are fist so recrate normally.
+ *
+ * This is called during snapshot recovery, single threaded, no lock necessary
+ */
+static int km_fs_check_for_dups_nolock(int fd)
+{
+   for (int grp = 0; grp < dup_data.size; grp++) {
+      km_fd_dup_grp_t* group = dup_data.groups[grp];
+      int i;
+      for (i = 0; i < group->size; i++) {
+         if (fd == group->fds[i]) {
+            break;
+         }
+      }
+      if (i == group->size) {   // we are not in this group
+         continue;
+      }
+      for (int i = 0; i < group->size; i++) {
+         int ofd = group->fds[i];
+         // not us and already exists - we are dup of it
+         if (ofd != fd && km_is_file_used(&km_fs()->guest_files[ofd])) {
+            return ofd;
+         }
+      }
+      return -2;   // found ourselves in the group but others aren't ready - we are the first
+   }
+   return -1;   // not dup
+}
+
+static void km_fs_add_fd_to_dup_group(int fd, km_fd_dup_grp_t* group)
+{
+   if ((group->fds = realloc(group->fds, (group->size + 1) * sizeof(group->fds[0]))) == NULL) {
+      km_err(2, "no memory for dup group");
+   }
+   group->fds[group->size++] = fd;
+}
+
+/*
+ * Called during normal run to record dup operation
+ */
+static void km_fs_add_to_dup_data(int new_fd, int old_fd)
+{
+   if (machine.mmaps.recovery_mode != 0) {
+      // during snapshot recovery dup data gets restored fist, then used to restore files
+      return;
+   }
+   km_mutex_lock(&dup_data_mtx);
+   for (int grp = 0; grp < dup_data.size; grp++) {
+      km_fd_dup_grp_t* group = dup_data.groups[grp];
+      for (int i = 0; i < group->size; i++) {
+         int fd = group->fds[i];
+         if (fd == old_fd) {
+            // old_fd already in a group, add ourselves to it
+            km_fs_add_fd_to_dup_group(new_fd, group);
+            km_mutex_unlock(&dup_data_mtx);
+            return;
+         }
+      }
+   }
+   // new group
+   km_fd_dup_grp_t* group = malloc(sizeof(km_fd_dup_grp_t));
+   if (group == NULL) {
+      km_err(2, "no memory for dup group");
+   }
+   group->size = 2;
+   if ((group->fds = malloc(2 * sizeof(group->fds[0]))) == NULL) {
+      km_err(2, "no memory for dup group fds");
+   }
+   group->fds[0] = old_fd;
+   group->fds[1] = new_fd;
+   if ((dup_data.groups =
+            realloc(dup_data.groups, (dup_data.size + 1) * sizeof(dup_data.groups[0]))) == NULL) {
+      km_err(2, "no memory for dup data groups");
+   }
+   dup_data.groups[dup_data.size++] = group;
+   km_mutex_unlock(&dup_data_mtx);
+}
+
+/*
+ * Called during normal run to record closes of duped fds
+ */
+static void km_fd_close_dup(int fd)
+{
+   km_mutex_lock(&dup_data_mtx);
+   for (int grp = 0; grp < dup_data.size; grp++) {
+      km_fd_dup_grp_t* group = dup_data.groups[grp];
+      for (int i = 0; i < group->size; i++) {
+         if (fd == group->fds[i]) {
+            if (group->size > 2) {   // there are more than 2 dups - remove ourselves
+               if (i < group->size - 1) {
+                  memmove(&group->fds[i],
+                          &group->fds[i + 1],
+                          (group->size - 1 - i) * sizeof(group->fds[0]));
+               }
+               group->size--;
+               group->fds = realloc(group->fds, group->size * sizeof(group->fds[0]));
+            } else {   // only 2 dups - remove the group
+               free(group->fds);
+               free(group);
+               if (grp < dup_data.size - 1) {
+                  memmove(&dup_data.groups[grp],
+                          &dup_data.groups[grp + 1],
+                          (dup_data.size - 1 - grp) * sizeof(dup_data.groups[0]));
+               }
+               dup_data.size--;
+               dup_data.groups = realloc(dup_data.groups, dup_data.size * sizeof(dup_data.groups[0]));
+            }
+            km_mutex_unlock(&dup_data_mtx);
+            return;
+         }
+      }
+   }
+   km_mutex_unlock(&dup_data_mtx);
 }
 
 /*
@@ -201,6 +321,7 @@ static inline void del_guest_fd(km_vcpu_t* vcpu, int fd)
       TAILQ_REMOVE(&file->events, eventp, link);
       free(eventp);
    }
+   km_fd_close_dup(fd);
    if (file->ofd != -1) {
       km_file_t* other = &km_fs()->guest_files[file->ofd];
       file->ofd = -1;
@@ -504,6 +625,7 @@ uint64_t km_fs_fcntl(km_vcpu_t* vcpu, int fd, int cmd, uint64_t arg)
                                    (cmd == F_DUPFD) ? 0 : O_CLOEXEC,
                                    file->sockinfo,
                                    file->how);
+            km_fs_add_to_dup_data(ret, host_fd);
          } else {
             ret = km_add_guest_fd_internal(vcpu,
                                            ret,
@@ -1143,6 +1265,7 @@ uint64_t km_fs_dup(km_vcpu_t* vcpu, int fd)
       } else {
          ret = km_add_guest_fd_internal(vcpu, ret, name, 0, file->how, ops);
       }
+      km_fs_add_to_dup_data(ret, host_fd);
    }
    km_infox(KM_TRACE_FILESYS, "dup(%d) - %d", fd, ret);
    return ret;
@@ -1186,6 +1309,7 @@ uint64_t km_fs_dup3(km_vcpu_t* vcpu, int fd, int newfd, int flags)
       } else {
          ret = km_add_guest_fd(vcpu, ret, name, flags, ops);
       }
+      km_fs_add_to_dup_data(ret, host_fd);
    }
    km_infox(KM_TRACE_FILESYS, "dup3(%d, %d, 0x%x) - %d", fd, newfd, flags, ret);
    return ret;
@@ -1844,11 +1968,20 @@ uint64_t km_fs_prlimit64(km_vcpu_t* vcpu,
  * == Snapshot generation
  */
 
+size_t km_fs_dup_notes_length(void)
+{
+   size_t ret = km_note_header_size(KM_NT_NAME) + sizeof(km_nt_dup_t);
+   for (int i = 0; i < dup_data.size; i++) {
+      ret += sizeof(km_nt_dup_grp_t) + dup_data.groups[i]->size * sizeof(km_nt_dup_fd_t);
+   }
+   return ret;
+}
+
 // Helper function to return the number of bytes in a pipe or connection
 static int ioctlfionread(int fd)
 {
-   int bytesavailable;
-   if (ioctl(fd, FIONREAD, &bytesavailable) < 0) {
+   int bytesavailable = 0;
+   if (fd >= 0 && ioctl(fd, FIONREAD, &bytesavailable) < 0) {
       km_err(1, "ioctl FIONREAD on fd %d failed", fd);
    }
    return bytesavailable;
@@ -1857,7 +1990,7 @@ static int ioctlfionread(int fd)
 /*
  * Compute how much space all of the notes will need.
  */
-size_t km_fs_core_notes_length()
+size_t km_fs_core_notes_length(void)
 {
    ssize_t queuedbytes;
    size_t ret = 0;
@@ -2206,6 +2339,31 @@ static inline size_t fs_core_write_epollfd(char* buf, size_t length, km_file_t* 
    return cur - buf;
 }
 
+size_t km_fs_core_dup_write(char* buf, size_t length)
+{
+   char* cur = buf;
+   size_t remain = length;
+
+   cur += km_add_note_header(cur,
+                             remain,
+                             KM_NT_NAME,
+                             NT_KM_DUP_DATA,
+                             km_fs_dup_notes_length() - km_note_header_size(KM_NT_NAME));
+   km_nt_dup_t* dupnote = (km_nt_dup_t*)cur;
+   cur += sizeof(km_nt_dup_t);
+   dupnote->size = dup_data.size;
+   for (int i = 0; i < dup_data.size; i++) {
+      km_nt_dup_grp_t* dupgrp = (km_nt_dup_grp_t*)cur;
+      cur += sizeof(km_nt_dup_grp_t);
+      dupgrp->size = dup_data.groups[i]->size;
+      for (int j = 0; j < dup_data.groups[i]->size; j++) {
+         cur += sizeof(dupgrp->fds[j]);
+         dupgrp->fds[j] = dup_data.groups[i]->fds[j];
+      }
+   }
+   return cur - buf;
+}
+
 size_t km_fs_core_notes_write(char* buf, size_t length)
 {
    char* cur = buf;
@@ -2267,12 +2425,8 @@ km_fs_recover_fd(int guestfd, int hostfd, int flags, char* name, int ofd, km_fil
             how);
 }
 
-static int km_fs_check_for_dups(int fd)
-{
-   return -1;
-}
-
-static inline int km_fs_recover_fdpair(int guestfd[2], int hostfd[2], km_file_how_t how[2], int flags[2])
+static inline int
+km_fs_recover_fdpair(int guestfd[2], int hostfd[2], km_file_how_t how[2], int flags[2])
 {
    km_infox(KM_TRACE_SNAPSHOT,
             "recover_fdpair: guest:%d,%d host:%d,%d how:%d,%d flags:%d,%d",
@@ -2390,6 +2544,10 @@ static inline int km_fs_recover_socket(km_nt_socket_t* nt_sock, struct sockaddr*
        .protocol = nt_sock->protocol,
    };
    km_fd_socket_t* sockinfo = (km_fd_socket_t*)malloc(sizeof(km_fd_socket_t));
+   if (sockinfo == NULL) {
+      km_err(2, "No memory for sockinfo");
+      return -1;
+   }
    *sockinfo = sval;
    if (addrlen > 0) {
       sockinfo->addrlen = addrlen;
@@ -2413,6 +2571,38 @@ static inline int km_fs_recover_socket_error(km_nt_socket_t* nt_sock)
                        .ofd = nt_sock->other,
                        .error = -ECONNRESET};
    TAILQ_INIT(&file->events);
+   return 0;
+}
+
+static int km_fs_recover_dup_data(char* ptr, size_t length)
+{
+   km_nt_dup_t* nt_dup = (km_nt_dup_t*)ptr;
+   ptr += sizeof(km_nt_dup_t);
+   dup_data.size = nt_dup->size;
+   if ((dup_data.groups = malloc(dup_data.size * sizeof(dup_data.groups))) == NULL) {
+      km_err(2, "No memory for dup_data.groups*");
+      return -1;
+   }
+   for (int i = 0; i < dup_data.size; i++) {
+      km_nt_dup_grp_t* nt_dup_grp = (km_nt_dup_grp_t*)ptr;
+      ptr += sizeof(km_nt_dup_grp_t);
+      km_fd_dup_grp_t* group = malloc(sizeof(km_fd_dup_grp_t));
+      if (group == NULL) {
+         km_err(2, "No memory for dup_data.groups");
+         return -1;
+      }
+      dup_data.groups[i] = group;
+      group->size = nt_dup_grp->size;
+      if ((group->fds = malloc(group->size * sizeof(dup_data.groups[0]->fds[0]))) == NULL) {
+         km_err(2, "No memory for dup_data.groups");
+         return -1;
+      }
+      for (int i = 0; i < group->size; i++) {
+         group->fds[i] = nt_dup_grp->fds[i];
+      }
+
+      ptr += sizeof(km_nt_dup_fd_t) * group->size;
+   }
    return 0;
 }
 
@@ -2452,7 +2642,7 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
       km_warnx("bad file descriptor=%d", nt_file->fd);
       return -1;
    }
-   int dup_fd = km_fs_check_for_dups(nt_file->fd);
+   int dup_fd = km_fs_check_for_dups_nolock(nt_file->fd);
    if (dup_fd >= 0) {
       if (km_fs_dup3(NULL, dup_fd, nt_file->fd, nt_file->flags & O_CLOEXEC) < 0) {
          return -1;
@@ -3134,7 +3324,7 @@ static int km_fs_recover_open_socket(char* ptr, size_t length)
       km_warnx("nt_km_socket_t size mismatch - old snapshot?");
       return -1;
    }
-   int dup_fd = km_fs_check_for_dups(nt_sock->fd);
+   int dup_fd = km_fs_check_for_dups_nolock(nt_sock->fd);
    if (dup_fd >= 0) {
       if (km_fs_dup2(NULL, dup_fd, nt_sock->fd) < 0) {
          return -1;
@@ -3151,13 +3341,6 @@ static int km_fs_recover_open_socket(char* ptr, size_t length)
       return km_fs_recover_socket_accepted(nt_sock);
    }
 
-   int dup_fd = km_fs_check_for_dups(nt_sock->dev, nt_sock->ino);
-   if (dup_fd >= 0) {
-      if (km_fs_dup2(NULL, dup_fd, nt_sock->fd) < 0) {
-         return -1;
-      }
-      return 0;
-   }
    /*
     * Assume socket optionally bound for listening
     */
@@ -3173,9 +3356,9 @@ static int km_fs_recover_open_socket(char* ptr, size_t length)
 
    if (nt_sock->state == KM_SOCK_STATE_BIND || nt_sock->state == KM_SOCK_STATE_LISTEN) {
       int hostfd = km_fs_g2h_fd(nt_sock->fd, NULL);
-      // If snapshot is being recovered right after it was taken there is a chance there are sockets
-      // in TIME_WAIT state from the remaining from the initial run, so the following bind() will
-      // fail. This avoid the falure.
+      // If snapshot is being recovered right after it was taken there is a chance there are
+      // sockets in TIME_WAIT state from the remaining from the initial run, so the following
+      // bind() will fail. This avoid the falure.
       int flag = 1;
       if (setsockopt(hostfd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) != 0) {
          km_warn("recover setsockopt(SO_REUSEADDR) failed");
@@ -3209,7 +3392,7 @@ static int km_fs_recover_eventfd(char* ptr, size_t length)
    if (km_is_file_used(file) != 0) {
       km_errx(2, "eventfd file %d in use.", nt_file->fd);
    }
-   int dup_fd = km_fs_check_for_dups(nt_file->fd);
+   int dup_fd = km_fs_check_for_dups_nolock(nt_file->fd);
    if (dup_fd >= 0) {
       if (km_fs_dup3(NULL, dup_fd, nt_file->fd, nt_file->flags & O_CLOEXEC) < 0) {
          return -1;
@@ -3251,7 +3434,7 @@ static int km_fs_recover_epollfd(char* ptr, size_t length)
    if (km_is_file_used(file) != 0) {
       km_errx(2, "file %d in use. %s", nt_epollfd->fd, file->name);
    }
-   int dup_fd = km_fs_check_for_dups(nt_epollfd->fd);
+   int dup_fd = km_fs_check_for_dups_nolock(nt_epollfd->fd);
    if (dup_fd >= 0) {
       if (km_fs_dup3(NULL, dup_fd, nt_epollfd->fd, nt_epollfd->flags & O_CLOEXEC) < 0) {
          return -1;
@@ -3290,6 +3473,9 @@ static int km_fs_recover_epollfd(char* ptr, size_t length)
 
 int km_fs_recover(char* notebuf, size_t notesize)
 {
+   if (km_snapshot_notes_apply(notebuf, notesize, NT_KM_DUP_DATA, km_fs_recover_dup_data) < 0) {
+      km_errx(2, "recover open files failed");
+   }
    if (km_snapshot_notes_apply(notebuf, notesize, NT_KM_FILE, km_fs_recover_open_file) < 0) {
       km_errx(2, "recover open files failed");
    }

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -106,7 +106,8 @@ char* km_get_nonfile_name(int hostfd)
  * Assigns lowest available guest fd, just like the kernel.
  * TODO: Support open flags (O_CLOEXEC in particular)
  */
-int km_add_guest_fd_internal(km_vcpu_t* vcpu, int host_fd, char* name, int flags, int how, km_file_ops_t* ops)
+int km_add_guest_fd_internal(
+    km_vcpu_t* vcpu, int host_fd, char* name, int flags, km_file_how_t how, km_file_ops_t* ops)
 {
    km_assert(host_fd >= 0 && host_fd < km_fs()->nfdmap);
    int available = 0;
@@ -146,7 +147,7 @@ static inline void km_connect_files(km_vcpu_t* vcpu, int guestfd[2])
 }
 
 static inline int km_add_socket_fd(
-    km_vcpu_t* vcpu, int hostfd, char* name, int flags, int domain, int type, int protocol, int how)
+    km_vcpu_t* vcpu, int hostfd, char* name, int flags, int domain, int type, int protocol, km_file_how_t how)
 {
    int ret = km_add_guest_fd_internal(vcpu, hostfd, name, flags, how, NULL);
    if (ret >= 0) {
@@ -158,8 +159,8 @@ static inline int km_add_socket_fd(
    return ret;
 }
 
-static inline int
-km_dup_socket_fd(km_vcpu_t* vcpu, int hostfd, char* name, int flags, km_fd_socket_t* sockinfo, int how)
+static inline int km_dup_socket_fd(
+    km_vcpu_t* vcpu, int hostfd, char* name, int flags, km_fd_socket_t* sockinfo, km_file_how_t how)
 {
    int ret = km_add_guest_fd_internal(vcpu, hostfd, name, flags, how, NULL);
    if (ret >= 0) {
@@ -1986,8 +1987,6 @@ static inline size_t fs_core_write_nonsocket(char* buf, size_t length, km_file_t
    cur += sizeof(km_nt_file_t);
    fnote->size = sizeof(km_nt_file_t);
    fnote->fd = fd;
-   fnote->dev = st.st_dev;
-   fnote->ino = st.st_ino;
    fnote->flags = file->flags;
    fnote->mode = st.st_mode;
    if (fnote->mode & S_IFIFO) {
@@ -2040,8 +2039,6 @@ static inline size_t fs_core_write_socket(char* buf, size_t length, km_file_t* f
    cur += sizeof(km_nt_socket_t);
    fnote->size = sizeof(km_nt_socket_t);
    fnote->fd = fd;
-   fnote->dev = st.st_dev;
-   fnote->ino = st.st_ino;
    fnote->domain = file->sockinfo->domain;
    fnote->type = file->sockinfo->type;
    fnote->protocol = file->sockinfo->protocol;
@@ -2138,8 +2135,6 @@ static inline size_t fs_core_write_eventfd(char* buf, size_t length, km_file_t* 
    cur += sizeof(km_nt_file_t);
    fnote->size = sizeof(km_nt_file_t);
    fnote->fd = fd;
-   fnote->dev = st.st_dev;
-   fnote->ino = st.st_ino;
    fnote->flags = file->flags;
 
    uint64_t eventfd_count;
@@ -2193,10 +2188,7 @@ static inline size_t fs_core_write_epollfd(char* buf, size_t length, km_file_t* 
    km_nt_epollfd_t fval = {
        .size = sizeof(km_nt_epollfd_t),
        .fd = fd,
-       .dev = st.st_dev,
-       .ino = st.st_ino,
        .flags = file->flags,
-       .event_size = sizeof(km_nt_event_t),
        .nevent = nevent,
 
    };
@@ -2242,7 +2234,8 @@ size_t km_fs_core_notes_write(char* buf, size_t length)
 /*
  * == Snapshot recovery
  */
-static inline void km_fs_recover_fd(int guestfd, int hostfd, int flags, char* name, int ofd, int how)
+static inline void
+km_fs_recover_fd(int guestfd, int hostfd, int flags, char* name, int ofd, km_file_how_t how)
 {
    km_file_t* file = &km_fs()->guest_files[guestfd];
 
@@ -2274,34 +2267,12 @@ static inline void km_fs_recover_fd(int guestfd, int hostfd, int flags, char* na
             how);
 }
 
-typedef struct km_dup_data {
-   dev_t dev;
-   ino_t ino;
-} km_dup_data_t;
-
-static km_dup_data_t* dup_data;
-
-/*
- * Record inode and decv of recovered file for dup detection. Note that inode and dev are from the
- * snashot, so the actual values on this instance likely different. We use the values only to detect
- * the dups.
- */
-static inline void km_fs_record_dev_ino(int fd, dev_t dev, ino_t ino)
+static int km_fs_check_for_dups(int fd)
 {
-   dup_data[fd] = (km_dup_data_t){.dev = dev, .ino = ino};
-}
-
-static int km_fs_check_for_dups(dev_t dev, ino_t ino)
-{
-   for (int i = 0; i < km_fs()->nfdmap; i++) {
-      if (dup_data[i].dev == dev && dup_data[i].ino == ino) {   // we are dup of i
-         return i;
-      }
-   }
    return -1;
 }
 
-static inline int km_fs_recover_fdpair(int guestfd[2], int hostfd[2], int how[2], int flags[2])
+static inline int km_fs_recover_fdpair(int guestfd[2], int hostfd[2], km_file_how_t how[2], int flags[2])
 {
    km_infox(KM_TRACE_SNAPSHOT,
             "recover_fdpair: guest:%d,%d host:%d,%d how:%d,%d flags:%d,%d",
@@ -2386,13 +2357,12 @@ static inline int km_fs_recover_pipe(km_nt_file_t* nt_file, char* name, char* pi
       wfd = nt_file->fd;
    }
    int guestfd[2] = {rfd, wfd};
-   int how[2] = {KM_FILE_HOW_PIPE_0, KM_FILE_HOW_PIPE_1};
+   km_file_how_t how[2] = {KM_FILE_HOW_PIPE_0, KM_FILE_HOW_PIPE_1};
    int flags[2] = {syscall_flags, syscall_flags};
 
    if (km_fs_recover_fdpair(guestfd, hostfd, how, flags) < 0) {
       return -1;
    }
-   km_fs_record_dev_ino(nt_file->fd, nt_file->dev, nt_file->ino);
    // Recover queued pipe contents
    return km_fs_recover_pipedata(nt_file, pipedata);
 }
@@ -2413,7 +2383,6 @@ static inline int km_fs_recover_socket(km_nt_socket_t* nt_sock, struct sockaddr*
       return -1;
    }
    km_fs_recover_fd(nt_sock->fd, host_fd, 0, km_get_nonfile_name(host_fd), -1, nt_sock->how);
-   km_fs_record_dev_ino(nt_sock->fd, nt_sock->dev, nt_sock->ino);
 
    km_fd_socket_t sval = {
        .domain = nt_sock->domain,
@@ -2483,7 +2452,7 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
       km_warnx("bad file descriptor=%d", nt_file->fd);
       return -1;
    }
-   int dup_fd = km_fs_check_for_dups(nt_file->dev, nt_file->ino);
+   int dup_fd = km_fs_check_for_dups(nt_file->fd);
    if (dup_fd >= 0) {
       if (km_fs_dup3(NULL, dup_fd, nt_file->fd, nt_file->flags & O_CLOEXEC) < 0) {
          return -1;
@@ -2516,7 +2485,6 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
    }
 
    km_fs_recover_fd(nt_file->fd, fd, nt_file->flags, strdup(name), nt_file->data, nt_file->how);
-   km_fs_record_dev_ino(nt_file->fd, nt_file->dev, nt_file->ino);
    if ((nt_file->mode & __S_IFMT) == __S_IFREG && nt_file->data != 0) {
       if (lseek(nt_file->fd, nt_file->data, SEEK_SET) != nt_file->data) {
          km_warn("lseek failed");
@@ -3136,7 +3104,7 @@ static int km_fs_recover_socketpair(km_nt_socket_t* nt_sock)
    int otherfd = nt_sock->other;
    if (nt_sock->how == KM_FILE_HOW_SOCKETPAIR0) {
       int guestfd[2] = {nt_sock->fd, otherfd};
-      int how[2] = {KM_FILE_HOW_SOCKETPAIR0, KM_FILE_HOW_SOCKETPAIR1};
+      km_file_how_t how[2] = {KM_FILE_HOW_SOCKETPAIR0, KM_FILE_HOW_SOCKETPAIR1};
       int flags[2] = {0, 0};
       if (km_fs_recover_fdpair(guestfd, host_sv, how, flags) < 0) {
          return -1;
@@ -3144,13 +3112,12 @@ static int km_fs_recover_socketpair(km_nt_socket_t* nt_sock)
 
    } else {
       int guestfd[2] = {otherfd, nt_sock->fd};
-      int how[2] = {KM_FILE_HOW_SOCKETPAIR1, KM_FILE_HOW_SOCKETPAIR0};
+      km_file_how_t how[2] = {KM_FILE_HOW_SOCKETPAIR1, KM_FILE_HOW_SOCKETPAIR0};
       int flags[2] = {0, 0};
       if (km_fs_recover_fdpair(guestfd, host_sv, how, flags) < 0) {
          return -1;
       }
    }
-   km_fs_record_dev_ino(nt_sock->fd, nt_sock->dev, nt_sock->ino);
    // Recover any data that needs to be written on this fd.
    return km_fs_recover_socketdata(nt_sock);
 }
@@ -3166,6 +3133,13 @@ static int km_fs_recover_open_socket(char* ptr, size_t length)
    if (nt_sock->size != sizeof(km_nt_socket_t)) {
       km_warnx("nt_km_socket_t size mismatch - old snapshot?");
       return -1;
+   }
+   int dup_fd = km_fs_check_for_dups(nt_sock->fd);
+   if (dup_fd >= 0) {
+      if (km_fs_dup2(NULL, dup_fd, nt_sock->fd) < 0) {
+         return -1;
+      }
+      return 0;
    }
    if (nt_sock->state == KM_NT_SKSTATE_ERROR) {
       return km_fs_recover_socket_error(nt_sock);
@@ -3235,6 +3209,13 @@ static int km_fs_recover_eventfd(char* ptr, size_t length)
    if (km_is_file_used(file) != 0) {
       km_errx(2, "eventfd file %d in use.", nt_file->fd);
    }
+   int dup_fd = km_fs_check_for_dups(nt_file->fd);
+   if (dup_fd >= 0) {
+      if (km_fs_dup3(NULL, dup_fd, nt_file->fd, nt_file->flags & O_CLOEXEC) < 0) {
+         return -1;
+      }
+      return 0;
+   }
 
    int hostfd = eventfd(nt_file->data, nt_file->flags);
    if (hostfd < 0) {
@@ -3247,15 +3228,12 @@ static int km_fs_recover_eventfd(char* ptr, size_t length)
                     km_get_nonfile_name(hostfd),
                     nt_file->data,
                     KM_FILE_HOW_EVENTFD);
-   km_fs_record_dev_ino(nt_file->fd, nt_file->dev, nt_file->ino);
    return 0;
 }
 
 static int km_fs_recover_epollfd(char* ptr, size_t length)
 {
-   char* cur = ptr;
-   km_nt_epollfd_t* nt_epollfd = (km_nt_epollfd_t*)cur;
-   cur += sizeof(km_nt_epollfd_t);
+   km_nt_epollfd_t* nt_epollfd = (km_nt_epollfd_t*)ptr;
 
    km_infox(KM_TRACE_SNAPSHOT, "EPOLLFD fd=%d", nt_epollfd->fd);
    if (nt_epollfd->size != sizeof(km_nt_epollfd_t)) {
@@ -3273,6 +3251,13 @@ static int km_fs_recover_epollfd(char* ptr, size_t length)
    if (km_is_file_used(file) != 0) {
       km_errx(2, "file %d in use. %s", nt_epollfd->fd, file->name);
    }
+   int dup_fd = km_fs_check_for_dups(nt_epollfd->fd);
+   if (dup_fd >= 0) {
+      if (km_fs_dup3(NULL, dup_fd, nt_epollfd->fd, nt_epollfd->flags & O_CLOEXEC) < 0) {
+         return -1;
+      }
+      return 0;
+   }
 
    int hostfd = epoll_create1(nt_epollfd->flags);
    if (hostfd < 0) {
@@ -3280,9 +3265,8 @@ static int km_fs_recover_epollfd(char* ptr, size_t length)
       return -1;
    }
    km_fs_recover_fd(nt_epollfd->fd, hostfd, 0, km_get_nonfile_name(hostfd), -1, KM_FILE_HOW_EPOLLFD);
-   km_fs_record_dev_ino(nt_epollfd->fd, nt_epollfd->dev, nt_epollfd->ino);
    for (int i = 0; i < nt_epollfd->nevent; i++) {
-      km_nt_event_t* nt_event = (km_nt_event_t*)cur;
+      km_nt_event_t* nt_event = &nt_epollfd->events[i];
       int host_efd = km_fs_g2h_fd(nt_event->fd, NULL);
       if (host_efd < 0) {
          km_warnx("monitored fd=%d does not exist", nt_event->fd);
@@ -3299,7 +3283,6 @@ static int km_fs_recover_epollfd(char* ptr, size_t length)
       event->event.events = nt_event->event;
       event->event.data.u64 = nt_event->data;
       TAILQ_INSERT_TAIL(&file->events, event, link);
-      cur += sizeof(km_nt_event_t);
    }
 
    return 0;
@@ -3307,10 +3290,6 @@ static int km_fs_recover_epollfd(char* ptr, size_t length)
 
 int km_fs_recover(char* notebuf, size_t notesize)
 {
-   if ((dup_data = calloc(km_fs()->nfdmap, sizeof(km_dup_data_t))) == NULL) {
-      km_err(2, "km_fs_recover: calloc failed");
-   }
-
    if (km_snapshot_notes_apply(notebuf, notesize, NT_KM_FILE, km_fs_recover_open_file) < 0) {
       km_errx(2, "recover open files failed");
    }
@@ -3323,7 +3302,5 @@ int km_fs_recover(char* notebuf, size_t notesize)
    if (km_snapshot_notes_apply(notebuf, notesize, NT_KM_EPOLLFD, km_fs_recover_epollfd) < 0) {
       km_errx(2, "recover open epollfd's failed");
    }
-   free(dup_data);
-   dup_data = NULL;
    return 0;
 }

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -292,8 +292,9 @@ uint64_t km_fs_prlimit64(km_vcpu_t* vcpu,
                          int resource,
                          const struct rlimit* new_limit,
                          struct rlimit* old_limit);
-
-size_t km_fs_core_notes_length();
+size_t km_fs_dup_notes_length(void);
+size_t km_fs_core_dup_write(char* buf, size_t length);
+size_t km_fs_core_notes_length(void);
 size_t km_fs_core_notes_write(char* cur, size_t remain);
 
 void km_redirect_msgs(const char* name);

--- a/km/km_filesys_private.h
+++ b/km/km_filesys_private.h
@@ -93,4 +93,17 @@ static inline km_filesys_t* km_fs()
 int km_is_file_used(km_file_t* file);
 void km_set_file_used(km_file_t* file, int val);
 
+// fds that are all dups of each other
+typedef struct km_fd_dup_grp {
+   int size;   // number of fds in the group. Never less than 2 - the original and the dup
+   int* fds;
+} km_fd_dup_grp_t;
+
+typedef struct km_fd_dup_data_s {
+   int size;   // number of groups
+   km_fd_dup_grp_t** groups;
+} km_fd_dup_data_t;
+
+extern km_fd_dup_data_t dup_data;
+
 #endif   // !defined(__KM_FILESYS_PRIVATE_H__)

--- a/tests/snapshot_test.c
+++ b/tests/snapshot_test.c
@@ -138,7 +138,7 @@ void setup_process_state()
 
    CHECK_SYSCALL(dup_fd[0] = open("/etc/passwd", O_RDONLY));
    CHECK_SYSCALL(dup_fd[1] = dup(dup_fd[0]));
-   CHECK_SYSCALL(dup_fd[2] = dup(dup_fd[0]));
+   CHECK_SYSCALL(dup_fd[2] = fcntl(dup_fd[0], F_DUPFD, 0));
    close(dup_fd[1]);
 
    CHECK_SYSCALL(dup_fd[3] = open("/etc/passwd", O_RDONLY));


### PR DESCRIPTION
This is better/correct way to handle duped fd.

During the run we monitor all sources of duped fds - dup{,2,3} and F_DUPFD fcntl, also we monitor close. That allows us to maintain a table of dup groups. Each group is a list of fds that are dups of each other. There could be many of them.

On snapshot we create a new note to pass these groups along. On restore we restore that before fds. When we restore fds we check with the duped groups. FOr each fd that is restored first in the group we restore in normally. But for the subsequent ones we do the dup.

tested with normal test extended a bit. Also checked node snapshot works. Will be testing more, likely adding more tests. But appreciate a review.
