### PR TITLE
Change snapshot to handle data buffered in half open pipes and socket…

### DIFF
--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -131,11 +131,13 @@ typedef struct km_nt_dup {
  * Elf note record for open file.
  */
 typedef struct km_nt_file {
-   Elf64_Word size;    // Size of record
-   Elf64_Word fd;      // Open fd number
-   Elf64_Word how;     // How file was created
-   Elf64_Word flags;   // open(2) flags
-   Elf64_Word mode;    // file mode (includes type)
+   Elf64_Word size;       // Size of record
+   Elf64_Word fd;         // Open fd number
+   Elf64_Word how;        // How file was created
+   Elf64_Word flags;      // open(2) flags
+   Elf64_Word mode;       // file mode (includes type)
+   Elf64_Word pipesize;   // if how == KM_FILE_HOW_PIPE_0/1 the size of the
+                          // kernel buffer for this pipe
    /*
     * The contents of data depends on the file type
     *   __S_IFREG  - lseek position
@@ -168,11 +170,11 @@ typedef struct km_nt_socket {
                             // bytes follow the protocol address of
                             // this note.
    // Protocol address follows
-   // Data buffered in the "write side" of a socketpair follows
+   // Data buffered in the "read side" of a socketpair follows
 } km_nt_socket_t;
 #define NT_KM_SOCKET 0x4b4d534b   // "KMSK" no null term
 
-// values for 'how' field
+// values for 'how' field in km_nt_socket
 #define KM_NT_SKHOW_SOCKETPAIR 0
 #define KM_NT_SKHOW_SOCKET 1
 #define KM_NT_SKHOW_ACCEPT 2

--- a/km/km_fork.h
+++ b/km/km_fork.h
@@ -20,5 +20,6 @@
 extern void km_forward_sigchild(int signo, siginfo_t* sinfo, void* ucontext_unused);
 extern int km_before_fork(km_vcpu_t* vcpu, km_hc_args_t* arg, uint8_t is_clone);
 extern int km_dofork(int* in_child);
+extern unsigned int km_have_forked(void);
 
 #endif /* !defined(__KM_FORK_H__) */

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -33,6 +33,7 @@
 #include "km_coredump.h"
 #include "km_elf.h"
 #include "km_filesys.h"
+#include "km_fork.h"
 #include "km_gdb.h"
 #include "km_guest.h"
 #include "km_mem.h"
@@ -518,6 +519,10 @@ int km_snapshot_create(km_vcpu_t* vcpu, char* label, char* description, char* du
    // No snapshots while GDB is running
    if (km_gdb_is_enabled() != 0) {
       km_warnx("Cannot create snapshot with GDB running");
+      return -EBUSY;
+   }
+   if (km_have_forked() != 0) {
+      km_warnx("Cannot create snapshot after forking");
       return -EBUSY;
    }
 


### PR DESCRIPTION
…pairs.

Move buffered pipe and socketpair data to the elf note for the read end of the pipe or socketpair.  We formerly kept the data in the elf note for the write end of the pipe/socketpair.  With a half open pipe or socketpair the written fd is closed after all data has been written.  The data stays queued until the other end is ready to read it.
We can't really tell where the other end of these half open pipes/socketpairs is.  It may still be in another process or it may have been created local to the process and then closed.  We can snapshot the pipe/socketpair that is local to the process being snapshotted. We can't snapshot the data buffered in a pipe/socketpair where the other end is in a different process since we don't support multi-process snapshot.

So a new restriction on snapshot is being imposed.  If a process has successfully forked, it can not be snapshotted.  This avoids dealing with "apparently" half open pipe/socketpairs where the other end may be in another process.

Added code to save and restore the size of data that can be buffered in the kernel in a pipe.  No test for this yet.

Added new bats tests for snapshotting processes with half open pipes and socketpairs and processes that have forked.