### PR TITLE
Test payload snapshots

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -238,7 +238,7 @@ int km_add_guest_fd_internal(
                                    0,
                                    __ATOMIC_SEQ_CST,
                                    __ATOMIC_SEQ_CST) == 0) {
-      km_errx(0, "file slot %d is taken unexpectedly", host_fd);
+      km_errx(0, "file slot %d for %s is taken unexpectedly", host_fd, name);
    }
    km_file_t* file = &km_fs()->guest_files[host_fd];
    file->ops = ops;
@@ -2200,12 +2200,12 @@ static inline size_t fs_core_write_socket(char* buf, size_t length, km_file_t* f
    }
 
    km_infox(KM_TRACE_SNAPSHOT,
-            "fd:%d ISOCK: how=%d %s other=0x%x ofd %d, datalength %ld",
+            "fd:%d ISOCK: how=%d %s other=0x%x state=%d, datalength %ld",
             fnote->fd,
             fnote->how,
             file->name,
             fnote->other,
-            file->ofd,
+            fnote->state,
             fnote->datalength);
    return cur - buf;
 }
@@ -2537,7 +2537,14 @@ static inline int km_fs_recover_socket(km_nt_socket_t* nt_sock, struct sockaddr*
       return -1;
    }
    km_fs_recover_fd(nt_sock->fd, host_fd, 0, km_get_nonfile_name(host_fd), -1, nt_sock->how);
-
+   if (nt_sock->state == KM_NT_SKSTATE_ERROR) {
+      file->error = -ECONNRESET;
+      free(file->name);
+      if ((file->name = strdup("socket error")) == NULL) {
+         km_warn("No memory for socket error name");
+         return -1;
+      }
+   }
    km_fd_socket_t sval = {
        .domain = nt_sock->domain,
        .type = nt_sock->type,
@@ -2555,22 +2562,6 @@ static inline int km_fs_recover_socket(km_nt_socket_t* nt_sock, struct sockaddr*
    }
    file->sockinfo = sockinfo;
 
-   return 0;
-}
-
-static inline int km_fs_recover_socket_error(km_nt_socket_t* nt_sock)
-{
-   if (nt_sock->fd < 0 || nt_sock->fd >= machine.filesys->nfdmap) {
-      km_warn("socket fd %d invalid", nt_sock->fd);
-      return -1;
-   }
-   km_file_t* file = &km_fs()->guest_files[nt_sock->fd];
-   *file = (km_file_t){.inuse = 1,
-                       .how = nt_sock->how,
-                       .name = strdup("socket error"),
-                       .ofd = nt_sock->other,
-                       .error = -ECONNRESET};
-   TAILQ_INIT(&file->events);
    return 0;
 }
 
@@ -2660,13 +2651,13 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
 
    int fd = open(name, nt_file->flags, 0);
    if (fd < 0) {
-      km_warn("cannon open %s", name);
+      km_warn("can't open %s for fd %d", name, nt_file->fd);
       return -1;
    }
 
    struct stat st;
    if (fstat(fd, &st) < 0) {
-      km_warn("cannon fstat %s", name);
+      km_warn("can't fstat %s", name);
       return -1;
    }
    if (st.st_mode != nt_file->mode) {
@@ -3330,9 +3321,6 @@ static int km_fs_recover_open_socket(char* ptr, size_t length)
          return -1;
       }
       return 0;
-   }
-   if (nt_sock->state == KM_NT_SKSTATE_ERROR) {
-      return km_fs_recover_socket_error(nt_sock);
    }
    if (nt_sock->how == KM_FILE_HOW_SOCKETPAIR0 || nt_sock->how == KM_FILE_HOW_SOCKETPAIR1) {
       return km_fs_recover_socketpair(nt_sock);

--- a/payloads/java/.gitignore
+++ b/payloads/java/.gitignore
@@ -1,3 +1,5 @@
 jdk-11*
+rest-service-11*
 *.class
 *.so
+*.jar

--- a/payloads/java/Makefile
+++ b/payloads/java/Makefile
@@ -29,7 +29,7 @@ define testenv_preprocess
 	./link-km.sh ${JDK_BUILD_DIR} /home/appuser/km/build/opt/kontain
 endef
 
-TESTENV_EXTRA_FILES := ${JDK_BUILD_DIR}/images/jdk/* ${JDK_BUILD_DIR}/images/jdk/bin/java.kmd
+TESTENV_EXTRA_FILES := ${JDK_BUILD_DIR}/images/jdk/* ${JDK_BUILD_DIR}/images/jdk/bin/java.kmd ${APP_JAR}
 # this is how we are running tests in the container
 CONTAINER_TEST_CMD := ./scripts/test-run.sh
 
@@ -57,7 +57,8 @@ RUNENV_VALIDATE_EXPECTED := Hello, World!
 RUNENV_VALIDATE_DEPENDENCIES := scripts/Hello.class \
 	scripts/SimpleHttpServer.class \
 	app.kontain/app/kontain/snapshots/Snapshot.class \
-	app.kontain/app/kontain/snapshots/libkm_java_native.so
+	app.kontain/app/kontain/snapshots/libkm_java_native.so \
+	sb.jar
 
 # runenv-image configs
 export define runenv_prep
@@ -158,6 +159,21 @@ in-blank-container: ## invoked in blank container by ``make all''. DO NOT invoke
 	tar -C /home/appuser/java -cf - . | tar -C ${JDK_BUILD_DIR} -xf -
 	./link-km.sh ${JDK_BUILD_DIR}
 
+REPO_COMMIT := f7f2acb31d27f57550d6a9d37bbe50e185d1ca4b
+SRC_REPO_DIR := rest-service-11
+SRC_DIR := ${SRC_REPO_DIR}/complete
+APP_JAR := ${SRC_DIR}/build/libs/rest-service-0.0.1-SNAPSHOT.jar
+
+${SRC_REPO_DIR}:
+	git clone https://github.com/spring-guides/gs-rest-service.git ${SRC_REPO_DIR}
+	cd ${SRC_REPO_DIR}; git reset --hard ${REPO_COMMIT}
+
+${APP_JAR}: | ${SRC_REPO_DIR}
+	docker run --rm -v $$(pwd)/${SRC_REPO_DIR}:/app:rw -w /app/complete -u $(shell id -u):$(shell id -g) openjdk:8u342-jdk ./gradlew -q --console=plain build
+
+sb.jar: ${APP_JAR}
+	cp ${APP_JAR} sb.jar
+
 JAVA_LD_PATH := ${CURDIR}/${JAVA_DIR}/lib/server:${CURDIR}/${JAVA_DIR}/lib/jli:${CURDIR}/${JAVA_DIR}/lib
 test: ${RUNENV_VALIDATE_DEPENDENCIES} api test_java.bats ## Basic test run
 	JAVA_DIR=${CURDIR}/${JAVA_DIR} JAVA_LD_PATH=${JAVA_LD_PATH} BLDDIR=${BLDDIR} \
@@ -186,6 +202,7 @@ clean:
 	rm -f ${JDK_BUILD_DIR}/images/jdk/bin/java.k*
 	rm -f app/kontain/*.class app/kontain/*.so
 	rm -f app/kontain/snapshots/*.class app/kontain/snapshots/*.so
+	rm -rf ${SRC_REPO_DIR} sb.jar
 	find . -name "*.class" -type f -delete
 	rm -rf ${BLDDIR}/*
 

--- a/payloads/java/test-fedora.dockerfile
+++ b/payloads/java/test-fedora.dockerfile
@@ -21,7 +21,7 @@ ARG JAVA_DIR=/home/appuser/km/build/opt/kontain
 ENV PATH=${JAVA_DIR}/bin:${PATH}
 COPY . ${JAVA_DIR}
 RUN mkdir -p /home/appuser/km/payloads/java
-COPY ./scripts/* /home/appuser/km/payloads/java/scripts/
+COPY scripts/* /home/appuser/km/payloads/java/scripts/
 
 ENV JAVA_DIR=${JAVA_DIR}
 ENV JAVA_LD_PATH=${JAVA_DIR}/lib/server:${JAVA_DIR}/lib/jli:${JAVA_DIR}/lib:/opt/kontain/runtime

--- a/payloads/node/Makefile
+++ b/payloads/node/Makefile
@@ -90,16 +90,16 @@ clean:
 	@echo "Note - 'clean' doesn't remove ./node artifacts. use 'clobber' to force remove build artifacts"
 
 test test-all: ${PAYLOAD_KM} ${TEST_KM}
-	scripts/test-run.sh $@ ${KM_BIN} ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
+	scripts/test-run.sh $@ ${KM_BIN} ${KM_CLI_BIN} ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
 
 # Command to run tests in testenv-image container:
-CONTAINER_TEST_CMD := scripts/test-run.sh test km ${PAYLOAD_KM} ${TEST_KM}
+CONTAINER_TEST_CMD := scripts/test-run.sh test km_cli ${PAYLOAD_KM} ${TEST_KM}
 
 # TODO: revert when kkm is fixed
 ifeq (${HYPERVISOR_DEVICE},/dev/kkm)
-CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test km ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
+CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test km km_cli ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
 else
-CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test-all km ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
+CONTAINER_TEST_ALL_CMD := scripts/test-run.sh test-all km km_cli ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
 endif
 
 # Use existing small dir for buildenv image builds (saves on sending data to docker svc)

--- a/payloads/node/Makefile
+++ b/payloads/node/Makefile
@@ -93,7 +93,7 @@ test test-all: ${PAYLOAD_KM} ${TEST_KM}
 	scripts/test-run.sh $@ ${KM_BIN} ${KM_CLI_BIN} ${PAYLOAD_KM} ${TEST_KM} ${NODETOP} ${BUILD}
 
 # Command to run tests in testenv-image container:
-CONTAINER_TEST_CMD := scripts/test-run.sh test km_cli ${PAYLOAD_KM} ${TEST_KM}
+CONTAINER_TEST_CMD := scripts/test-run.sh test km km_cli ${PAYLOAD_KM} ${TEST_KM}
 
 # TODO: revert when kkm is fixed
 ifeq (${HYPERVISOR_DEVICE},/dev/kkm)


### PR DESCRIPTION
Adds node snapshot tests both on local machine and on CI.

Add java snapshot on local machine only. Java has no real tests on CI because it uses bats. Need to enable that in java directory.

Discovered bug in recovery of open sockets. We populate our filesys structure BUT we don't open file on the host. Next open file on the host will conflict with the our data. The test for this is Java snapshot test which I only ran locally (see above).

I'd really like to push this ASAP and figure out CI in Java after that.