### PR TITLE
Fix script quote issues and km mgmt listen issue.

### DIFF
--- a/km/km_management.c
+++ b/km/km_management.c
@@ -44,11 +44,6 @@ static void* mgt_main(void* arg)
    mgmtreply_t mgmtreply;
    int wewanttodie;
 
-   if (listen(sock, 1) < 0) {
-      km_warn("listen");
-      return NULL;
-   }
-
    /*
     * First implementation is really dumb. Listen on a socket. When a connect
     * happens, snapshot the guest. This has the advantage of not doing anything
@@ -121,6 +116,10 @@ void km_mgt_init(char* path)
    }
    if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
       km_warn("bind failure: %s", path);
+      goto err;
+   }
+   if (listen(sock, 1) < 0) {
+      km_warn("listen");
       goto err;
    }
    if (pthread_create(&thread, NULL, mgt_main, NULL) != 0) {

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -918,7 +918,7 @@ fi
    #       concurrent_open_test runs in a loop. The3 default is
    #       10000. We use 500 here to accomodate azure, where the
    #       open/close cycle is ~40ms vs 1ms on a local workstation.
-   run km_with_timeout filepath_test$ext ${DIRNAME} 500
+   run km_with_timeout filepath_test$ext "${DIRNAME}" 500
    assert_success
    rm -rf ${DIRNAME}
 }
@@ -1100,7 +1100,7 @@ fi
    while [ ! -S ${MGMTPIPE} ] && [ $tries -gt 0 ]; do sleep 1; tries=`expr $tries - 1`; done
    assert [ $tries -gt 0 ]
    # valgrind executables don't have the payload's name so pidof doesn't work.
-   if [ -z ${VALGRIND} ]; then
+   if [ -z "${VALGRIND}" ]; then
       pidlist=`pidof hello_html_test$ext`
       # Find our pid if pidof returned multiple pids
       pid=""
@@ -1353,7 +1353,7 @@ fi
    f1=/tmp/f1$$
    f2=/tmp/f2$$
    flog=/tmp/xx$$
-   if [ -z ${VALGRIND} ]; then
+   if [ -z "${VALGRIND}" ]; then
       to=5s
    else
       to=25s
@@ -1415,7 +1415,7 @@ fi
 # In addition this may expose other problems such as misdeclared km arrays like km_hcargs[].
 #
 @test "threads_create($test_type): create a large number of threads that run briefly (gdb_lots_of_threads$ext)" {
-   if [ -z ${VALGRIND} ]; then
+   if [ -z "${VALGRIND}" ]; then
       run km_with_timeout --timeout 5s gdb_lots_of_threads_test$ext -a 2 -t 287 -w
    else
       run km_with_timeout --timeout 25s gdb_lots_of_threads_test$ext -a 10 -t 287 -w

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -177,7 +177,7 @@ function km_with_timeout () {
    # Per timeout(1) it returns 124 on timeout, and 128+signal when killed by signal
    s=$?; if [[ $s == 124  ]] ; then
       echo -e "\nTime out in $t : ${CMD} $@"
-   elif [[ $s > 128 ]] ; then
+   elif [[ $s -gt 128 ]] ; then
       echo -e "\nKilled by signal. Timeout returns $s: ${CMD} $@"
    fi
    return $s


### PR DESCRIPTION
${VALGRIND} is not quoted in some places in km_core_tests.bats causing shell tests to fail which is interpreted as a false test result. 
Listening on the management pipe is potentially delayed in time after binding the listening address.  
Leaving a window where the mgmt pipe exists but nothing is listening for connection attempts.