### PR TITLE
retry failed node snap instead of simply sleep 1

### DIFF
--- a/payloads/node/scripts/test-run.sh
+++ b/payloads/node/scripts/test-run.sh
@@ -59,13 +59,14 @@ if [[ "$1" == "test" || "$1" == "test-all" ]]; then
    pid=$!
    tries=5
    curl -4 -s localhost:8080 --retry-connrefused  --retry $tries --retry-delay 1
-   sleep 1 # give them a chance to quiesce
    ${KM_CLI_BIN} -s ${MGMTPIPE} -t
    wait $pid
    ${KM_BIN} kmsnap &
+   pid=$!
    curl -4 -s localhost:8080 --retry-connrefused  --retry $tries --retry-delay 1
    curl localhost:8080
    curl -X POST localhost:8080 || echo Forcing srv to exit and ignoring curl 'empty reply'
+   wait $pid
 fi
 
 if [[ "$1" == "test-all" ]]; then


### PR DESCRIPTION
Simply remove the sleep and try the snapshot right after curl. The first attempt is likely to fail, but the subsequent one succeeds