### PR TITLE
Ez leka/local dev

### DIFF
--- a/.github/actions/configure-krun/action.yaml
+++ b/.github/actions/configure-krun/action.yaml
@@ -8,6 +8,10 @@ inputs:
   token:
     description: github token
     required: true
+  build-only:
+    description: set to true to skip actual docker configuration
+    required: false
+    default: 'no'
 
 runs:
   using: "composite"
@@ -63,6 +67,11 @@ runs:
         sudo cp container-runtime/docker_config.sh ${{inputs.target-dir}}/bin/docker_config.sh
         [[ ${{inputs.target-dir}} == /opt/* ]] && sudo mv build/opt/kontain/bin/km /opt/kontain/bin/km
         sudo chmod +x ${{inputs.target-dir}}/bin/km ${{inputs.target-dir}}/bin/krun
+      shell: bash
+
+    - name: Configure Docker and Podman
+      if: ${{ inputs.build-only == 'no' }}
+      run: |
         sudo bash ./container-runtime/podman_config.sh
         sudo bash ./container-runtime/docker_config.sh
       shell: bash

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -203,6 +203,7 @@ jobs:
         with:
           target-dir: build/opt/kontain
           token: ${{secrets.GH_TOKEN}}
+          build-only: "yes"
 
       - name: Login into Azure Repository
         run: make -C cloud/azure login-cli

--- a/.github/workflows/km-ci-workflow.yaml
+++ b/.github/workflows/km-ci-workflow.yaml
@@ -175,6 +175,7 @@ jobs:
       - uses: ./.github/actions/configure-krun
         with:
           token: ${{secrets.GH_TOKEN}}
+          build-only: 'yes'
 
   # Build the k8s release artifact. Static KRUN is built separately and
   # in parallel from the rest of KM. The k8s artifact contains:

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,12 @@ edge-release: ## Trigger edge-release building pipeline
 	git tag -a ${RELEASE_TAG} --message "${EDGE_RELEASE_MESSAGE}"
 	git push ${REPO_URL} ${RELEASE_TAG}
 
+install-dev-runtime: ## Configure docker and podman to use build/opt/kontain/krun and km
+	make -C container-runtime install-dev-runtime MAKEFLAGS="$(MAKEFLAGS)"
+
+uninstall-dev-runtime: ## Remove docker and podman configuration for local build
+	make -C container-runtime uninstall-dev-runtime MAKEFLAGS="$(MAKEFLAGS)"
+
 ## Prepares release by
 ##  -- updating km-releases/current_release.txt  with passed in version number
 ##  --

--- a/cloud/scripts/L0-image-provision.sh
+++ b/cloud/scripts/L0-image-provision.sh
@@ -42,7 +42,7 @@ apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_re
 
 # Install stuff
 apt-get update --yes -q
-apt-get install --yes -q git make makeself gcc linux-headers-$(uname -r) \
+apt-get install --yes -q git make makeself gcc linux-headers-$(uname -r) jq \
                          docker-ce docker-ce-cli containerd.io azure-cli \
                          vagrant packer virtualbox
 

--- a/container-runtime/Makefile
+++ b/container-runtime/Makefile
@@ -57,6 +57,20 @@ static:
 	cp -f ${CRUNDIR_ABS}/result/bin/crun ${CRUNDIR_ABS}/krun.static
 	ln -f ${CRUNDIR_ABS}/krun.static ${CRUNDIR_ABS}/krun.static-label-trigger
 
+install-dev-runtime:
+	@if [[ -z "${RUNTIME}" ]] || [[ "${RUNTIME}" = "krun" ]]; then \
+		echo -e "$(RED)Parameter RUNTIME=<your name> is required and cannot be krun$(NOCOLOR)" && false; \
+	fi
+	sudo ./docker_config.sh --runtime-name=${RUNTIME} --runtime-path=${KM_OPT_BIN}/krun
+	sudo ./podman_config.sh --runtime-name=${RUNTIME} --runtime-path=${KM_OPT_BIN}/krun
+
+uninstall-dev-runtime:
+	@if [[ -z "${RUNTIME}" ]] || [[ "${RUNTIME}" = "krun" ]]; then \
+		echo -e "$(RED)Parameter RUNTIME=<your name> is required and cannot be krun$(NOCOLOR)" && false; \
+	fi
+	sudo ./docker_config.sh -u --runtime-name=${RUNTIME}
+	sudo ./podman_config.sh -u --runtime-name=${RUNTIME}
+
 # Run crun's tests
 test:	all
 	@if [ ! -x ${KM_OPT_KM} ] ; then \

--- a/container-runtime/docker_config.sh
+++ b/container-runtime/docker_config.sh
@@ -23,6 +23,26 @@ set -e ; [ "$TRACE" ] && set -x
 # This script must be run as root.
 [ `id -u` != "0" ] && echo "Must run as root" && exit 1
 
+# read arguments id any
+UNINSTALL=
+RUNTIME_NAME="krun"
+KRUN_PATH="/opt/kontain/bin/krun" 
+
+for arg in "$@"
+do
+   case "$arg" in
+        -u)
+            UNINSTALL=yes
+        ;;
+        --runtime-name=*)
+            RUNTIME_NAME="${1#*=}"
+        ;;
+        --runtime-path=*)
+            KRUN_PATH="${1#*=}"
+        ;;
+    esac
+    shift
+done
 # Can we assume docker is installed?
 #apt-get update
 #apt-get install -y -q docker.io
@@ -34,7 +54,6 @@ DOCKERPATH=$(which docker) || echo "Docker is not present on this system"
 
 # docker config file locations
 ETC_DAEMON_JSON=/etc/docker/daemon.json
-KRUN_PATH=/opt/kontain/bin/krun
 
 RESTART_DOCKER_FEDORA="systemctl restart docker.service "
 RESTART_DOCKER_UBUNTU="service docker restart"
@@ -51,16 +70,12 @@ function restart_docker()
 }
 
 # UNINSTALL
-if [ $# -eq 1 -a "$1" = "-u" ]; then
+if [ -n "$UNINSTALL" ]; then
     echo "Removing kontain docker config changes"
     if [ "$DOCKERPATH" != "" ]; then
-        if [ -e $ETC_DAEMON_JSON.kontainsave ]; then
-            cp $ETC_DAEMON_JSON.kontainsave $ETC_DAEMON_JSON
-            rm -f $ETC_DAEMON_JSON.kontainsave
-        else
-            # No .kontainsave file, they didn't have a daemon.json file
-            rm -f $ETC_DAEMON_JSON
-        fi
+        # remove specified config
+        jq --arg RNAME "$RUNTIME_NAME" 'del(.runtimes[$RNAME])' $ETC_DAEMON_JSON > /tmp/daemon.json$$
+        cp /tmp/daemon.json$$ $ETC_DAEMON_JSON
         restart_docker
     fi
     exit 0
@@ -69,13 +84,13 @@ fi
 # We configure docker to use krun here.  krun may need some packages that
 # are not installed by default.  We don't install them here but instead depend
 # on podman_config.sh to install them for us.
-if [ ! -e $ETC_DAEMON_JSON ]; then
+if [ ! -e "$ETC_DAEMON_JSON" ]; then
     # doesn't exist, create what we need
     echo "$ETC_DAEMON_JSON does not exist, creating"
    cat <<EOF >/tmp/daemon.json$$
 {
   "runtimes": {
-    "krun": {
+    "$RUNTIME_NAME": {
       "path": "$KRUN_PATH"
     }
   }
@@ -90,10 +105,10 @@ else
     # update existing file.  I've found if the file is not really json (it is an empty file),
     # jq fails without returning an error.
     cp $ETC_DAEMON_JSON $ETC_DAEMON_JSON.kontainsave
-    krun=`jq '.runtimes["krun"]' $ETC_DAEMON_JSON`
+    krun=`jq --arg RNAME "$RUNTIME_NAME" '.runtimes[$RNAME]' $ETC_DAEMON_JSON`
     if test "$krun" = "null"
     then
-        jq '.runtimes["krun"].path = "/opt/kontain/bin/krun"' $ETC_DAEMON_JSON >/tmp/daemon.json$$
+        jq --arg RNAME "$RUNTIME_NAME" --arg RPATH "$KRUN_PATH" '.runtimes[$RNAME].path=$RPATH'  $ETC_DAEMON_JSON >/tmp/daemon.json$$
         cp /tmp/daemon.json$$ $ETC_DAEMON_JSON
         # get docker to ingest the new daemon.json file
         if test $? -eq 0
@@ -102,7 +117,7 @@ else
         fi
         rm -f /tmp/daemon.json$$
     else
-        echo "krun already configured in $ETC_DAEMON_JSON"
-        echo "\"krun\": $krun"
+        echo "$RUNTIME_NAME already configured in $ETC_DAEMON_JSON"
+        echo "\"$RUNTIME_NAME\": $krun"
     fi
 fi

--- a/container-runtime/docker_config.sh
+++ b/container-runtime/docker_config.sh
@@ -26,7 +26,9 @@ set -e ; [ "$TRACE" ] && set -x
 # read arguments id any
 UNINSTALL=
 RUNTIME_NAME="krun"
-KRUN_PATH="/opt/kontain/bin/krun" 
+KRUN_PATH="/opt/kontain/bin/krun"
+KM_PATH="/opt/kontain/bin/km"
+
 
 for arg in "$@"
 do
@@ -39,10 +41,23 @@ do
         ;;
         --runtime-path=*)
             KRUN_PATH="${1#*=}"
+            KM_PATH=$(echo "${KRUN_PATH}" | sed 's/krun/km/')
         ;;
     esac
     shift
 done
+
+# check that KRUN_PATH points to an executable file
+if [ ! -x "$KRUN_PATH" ] && [ -z "$UNINSTALL" ]; then
+   echo "Runtime path must be full path to an existing krun executable"
+   exit 1
+fi
+# check that KM_PATH points to an executable file
+if [ ! -x "$KM_PATH" ] && [ -z "$UNINSTALL" ]; then
+   echo "KM execuable is not found or is not executable"
+   exit 1
+fi
+
 # Can we assume docker is installed?
 #apt-get update
 #apt-get install -y -q docker.io

--- a/container-runtime/podman_config.sh
+++ b/container-runtime/podman_config.sh
@@ -60,6 +60,7 @@ KKM_DEVICE=/dev/kkm
 
 # Podman configuration related
 DOCKER_INIT=$(docker info -f '{{json .}}' | jq -r '.InitBinary')
+DOCKER_INIT=$(which "$DOCKER_INIT")
 # if running under sudo, update the invokers containers.conf, not root's
 # Note that the shell nazi's think eval to expand ~ is evil but I can't find a better way
 HOME_CONTAINERS_CONF=`eval echo ~${SUDO_USER}/.config/containers/containers.conf`

--- a/docs/build.md
+++ b/docs/build.md
@@ -227,15 +227,26 @@ make test-withdocker
 Once you have kontain source code in your working directory you need to install podman and then configure podman and docker to
 use krun and km to run payloads.
 
+/opt/kontain/ contains Kontain release if one has been installe and runtime krun in both docker and podman will point to that release
+
+To configure docker and podman with local version you've just built run
+
 ```
-sudo container-runtime/podman_config.sh
-sudo container-runtime/docker_config.sh
+make install-dev-runtime RUNTIME=<give it a distinct name>
+```
+To remove this configuration:
+```
+make uninstall-dev-runtime RUNTIME=<name from prev step>
 ```
 
-Now docker and podman will try to use krun and km when the "--runtime krun" argument is supplied with "docker run" or "podman run".
+Now docker and podman will try to use krun and km when the "--runtime your-runtime-name" argument is supplied with "docker run" or "podman run".
 Without --runtime, runc will be the default container runtime.
 
-The kontain makefile clean target cleans out /opt/kontain/bin so you will find that docker or podman run fail because
+To test payloads with development runtime
+```
+make -C payloads validate-runenv-image RUNTIME=your-runtime-name
+```
+The kontain makefile clean target cleans out build/opt/kontain/bin so you will find that docker or podman run fail because
 these two programs are missing.
 Just rebuild them.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -227,7 +227,7 @@ make test-withdocker
 Once you have kontain source code in your working directory you need to install podman and then configure podman and docker to
 use krun and km to run payloads.
 
-/opt/kontain/ contains Kontain release if one has been installe and runtime krun in both docker and podman will point to that release
+/opt/kontain/ contains Kontain release if one has been install and runtime krun in both docker and podman will point to that release
 
 To configure docker and podman with local version you've just built run
 
@@ -248,7 +248,7 @@ make -C payloads validate-runenv-image RUNTIME=your-runtime-name
 ```
 The kontain makefile clean target cleans out build/opt/kontain/bin so you will find that docker or podman run fail because
 these two programs are missing.
-Just rebuild them.
+Just rebuild them. There is no need to re-install runtime when you re-build as it will continue to point to your local development directory. 
 
 ## Following are various tools
 

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -113,7 +113,8 @@ DOCKER_RUN_CLEANUP ?= --rm
 # When running tests in containers on CI, we can't use tty and interactive
 DOCKER_INTERACTIVE ?= -it
 
-DOCKER_KRUN_RUNTIME ?= --runtime krun
+RUNTIME ?= krun
+DOCKER_KRUN_RUNTIME = --runtime ${RUNTIME}
 DOCKER_RUN := docker run --sysctl net.ipv4.ip_unprivileged_port_start=1024 ${DOCKER_RUN_CLEANUP}
 # DOCKER_RUN_BUILD are used for building and other operations that requires
 # output of files to volumes. When we need to write files to the volumes mapped
@@ -124,7 +125,7 @@ DOCKER_RUN_TEST := ${DOCKER_RUN} ${DOCKER_INTERACTIVE} --device=${HYPERVISOR_DEV
 
 # These PODMAN_* variables mirror the docker related ones.
 # Initially we use these to verify that runenv-images work with podman
-PODMAN_KRUN_RUNTIME ?= --runtime krun
+PODMAN_KRUN_RUNTIME = --runtime ${RUNTIME}
 PODMAN_RUN := podman run ${DOCKER_RUN_CLEANUP}
 PODMAN_RUN_TEST := ${PODMAN_RUN} ${DOCKER_INTERACTIVE} --init
 


### PR DESCRIPTION
No change in main-stream product. Strictly dev environment convenience. 
------------------------
Configure docker and podman to use development build of run and km (build/opt/kontain/bin)

```
make install-dev-runtime RUNTIME=<give it a distinct name>
```
To remove this configuration:
```
make uninstall-dev-runtime RUNTIME=<name from prev step>
```

Now docker and podman will try to use krun and km when the "--runtime your-runtime-name" argument is supplied with "docker run" or "podman run".
Without --runtime, runc will be the default container runtime.

To test payloads with development runtime
```
make -C payloads validate-runenv-image RUNTIME=your-runtime-name
```