### PR TITLE
Change km_cli -c to do exact command name matches

### DIFF
--- a/km_cli/km_client.c
+++ b/km_cli/km_client.c
@@ -249,7 +249,7 @@ int processidmatches(pid_t processid, pid_t* processids)
 int commandnamematches(char* commandname, char* commandnames[])
 {
    for (int i = 0; commandnames[i] != NULL; i++) {
-      if (strstr(commandname, commandnames[i]) != NULL) {
+      if (strcmp(commandname, commandnames[i]) == 0) {
          if (debug > 0) {
             fprintf(stderr,
                     "commandname %s matches commandnames[%d] %s\n",


### PR DESCRIPTION
Formerly the -c arg was used to do partial matches which would match other commands when that is not what was intended.