### PR TITLE
Change gdb_lots_of_threads.c to wait for all threads to be running

### DIFF
--- a/tests/cmd_for_attach_test.gdb
+++ b/tests/cmd_for_attach_test.gdb
@@ -24,6 +24,14 @@
 set pagination off
 print stop_running
 
+# Wait for all of the threads to be running
+# The breakpoint should be on this line: while (wait_for_gdb != 0) {
+if all_running == 0
+   print all threads are not running
+   br main.c:180
+   continue
+end
+
 if wait_for_gdb != 0
    print "set BP"
    br usleep if wait_for_gdb != 0

--- a/tests/gdb_lots_of_threads_test.c
+++ b/tests/gdb_lots_of_threads_test.c
@@ -45,6 +45,7 @@ time_t starttime;
 int stop_after_seconds;
 int wait_for_gdb = 1;
 int running_count = 0;
+int all_running = 0;
 
 pthread_mutex_t rand_serialize = PTHREAD_MUTEX_INITIALIZER;
 
@@ -170,9 +171,10 @@ int main(int argc, char* argv[])
 
    // Wait for all the threads to be running.
    // Yes, sometimes the threads have been created but are not yet joinable.
-   while (running_count < i) {
+   while (__atomic_load_n(&running_count, __ATOMIC_SEQ_CST) < i) {
       usleep(100);
    }
+   all_running = 1;
 
    // Wait for gdb to attach.
    while (wait_for_gdb != 0) {

--- a/tests/gdb_lots_of_threads_test.c
+++ b/tests/gdb_lots_of_threads_test.c
@@ -44,6 +44,7 @@ int stop_running;
 time_t starttime;
 int stop_after_seconds;
 int wait_for_gdb = 1;
+int running_count = 0;
 
 pthread_mutex_t rand_serialize = PTHREAD_MUTEX_INITIALIZER;
 
@@ -77,6 +78,7 @@ void* do_nothing_thread(void* instance)
    int depth;
    unsigned long iteration = 0;
 
+   __atomic_add_fetch(&running_count, 1, __ATOMIC_SEQ_CST);
    for (;;) {
       depth = 0;
       do_random_sleep((uint64_t)instance, &depth);
@@ -166,6 +168,13 @@ int main(int argc, char* argv[])
       }
    }
 
+   // Wait for all the threads to be running.
+   // Yes, sometimes the threads have been created but are not yet joinable.
+   while (running_count < i) {
+      usleep(100);
+   }
+
+   // Wait for gdb to attach.
    while (wait_for_gdb != 0) {
       usleep(100);
    }


### PR DESCRIPTION
I have found that threads created by pthread_create() are not running immediately and can't be pthread_join()'ed until they are running. This fix is being put in because the gdb_attch bats test failed because gdb info threads reported all threads were on vcpu-0. I don't understand how that would happen but I think those new threads were not ready to be debugged because pthread_create() for the vcpu threads in km were not done with their work.
Since this test does do pthread_join() we should wait for the threads to be running before doing the join so this change doesn't hurt.