### PR TITLE
WIP: Rework VDSO handing for Snapshots

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -394,6 +394,7 @@ int km_clone(km_vcpu_t* vcpu,
 long km_clone3(km_vcpu_t* vcpu, struct clone_args* cl_args, size_t cl_args_len);
 uint64_t km_set_tid_address(km_vcpu_t* vcpu, km_gva_t tidptr);
 void km_exit(km_vcpu_t* vcpu);
+void handle_km_auxv(char **penvp);
 
 void km_vcpu_stopped(km_vcpu_t* vcpu);
 km_vcpu_t* km_vcpu_get(void);

--- a/km/km_init_guest.c
+++ b/km/km_init_guest.c
@@ -372,3 +372,32 @@ void km_exit(km_vcpu_t* vcpu)
    }
    km_delayed_munmap(vcpu);
 }
+
+void handle_km_auxv(char **penvp)
+{
+   Elf64_Ehdr* ehdr = NULL;
+
+   // Find VDSO ELF HDR.
+   while (*penvp++ != NULL);
+   Elf64_auxv_t *auxv = (Elf64_auxv_t*) penvp;
+   for (int i = 0; auxv[i].a_type != AT_NULL;  i++) {
+      if (auxv[i].a_type == AT_SYSINFO_EHDR) {
+         ehdr = (Elf64_Ehdr*)auxv[i].a_un.a_val;
+         break;
+      }
+   }
+   if (ehdr == NULL) {
+      km_err(2, "KM VDSO EHDR not found in AUXV");
+      return;
+   }
+
+   //km_warn("VDSO EHDR: 0x%lx", (uint64_t) ehdr);
+   /*
+    * TODO: 
+    * ehdr is a full ELF representation of the VDSO that KM is 
+    * loaded with, including symbol tables. How much of this
+    * state is included in the snapshot/resume path?
+    * Compatability between VDSO versions is dependent on what?
+    * The entrypoints being at the same offsets? Anything else?
+    */
+}

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -607,7 +607,7 @@ static inline int km_need_pause_all(void)
            (km_called_via_exec() != 0 && km_gdb_client_is_attached() != 0));
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[], char** _penvp)
 {
    km_vcpu_t* vcpu = NULL;
    int envc;   // payload env
@@ -618,6 +618,11 @@ int main(int argc, char* argv[])
    km_trace_setup(argc, argv);   // setup trace settings as early as possible
 
    km_gdbstub_init();
+
+   /*
+    * Process KM's AUXV vector.
+    */
+   handle_km_auxv(_penvp);
 
    if (km_exec_recover_kmstate() < 0) {   // exec state is messed up
       km_errx(2, "Problems in performing post exec processing");


### PR DESCRIPTION
This is the beginning of a rework of the VDSO handing for snapshot/restore. 

The AUXV vector of KM itself contains a full ELF description of the VDSO in the AT_SYSINFO_EHDR field, including symbols.