### PR TITLE
Add debug for the bats continue_after_snapshot test

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -497,6 +497,7 @@ extern const_string_t km_cmd_short_options;
 
 void km_trace_fini(void);
 void km_trace_setup(int argc, char* argv[]);
+void km_pathetic_stacktrace(void);
 
 extern int km_collect_hc_stats;
 

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -233,12 +233,8 @@ int km_add_guest_fd_internal(
    int available = 0;
    int taken = 1;
    km_file_t* file = &km_fs()->guest_files[host_fd];
-   if (__atomic_compare_exchange_n(&file->inuse,
-                                   &available,
-                                   taken,
-                                   0,
-                                   __ATOMIC_SEQ_CST,
-                                   __ATOMIC_SEQ_CST) == 0) {
+   if (__atomic_compare_exchange_n(&file->inuse, &available, taken, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) ==
+       0) {
       km_abortx("open file slot %d already open on file %s, new file %s ", host_fd, file->name, name);
    }
    file->ops = ops;

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -232,15 +232,15 @@ int km_add_guest_fd_internal(
    km_assert(host_fd >= 0 && host_fd < km_fs()->nfdmap);
    int available = 0;
    int taken = 1;
-   if (__atomic_compare_exchange_n(&km_fs()->guest_files[host_fd].inuse,
+   km_file_t* file = &km_fs()->guest_files[host_fd];
+   if (__atomic_compare_exchange_n(&file->inuse,
                                    &available,
                                    taken,
                                    0,
                                    __ATOMIC_SEQ_CST,
                                    __ATOMIC_SEQ_CST) == 0) {
-      km_errx(0, "file slot %d for %s is taken unexpectedly", host_fd, name);
+      km_abortx("open file slot %d already open on file %s, new file %s ", host_fd, file->name, name);
    }
-   km_file_t* file = &km_fs()->guest_files[host_fd];
    file->ops = ops;
    file->how = how;
    file->ofd = -1;

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -235,6 +235,7 @@ int km_add_guest_fd_internal(
    km_file_t* file = &km_fs()->guest_files[host_fd];
    if (__atomic_compare_exchange_n(&file->inuse, &available, taken, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) ==
        0) {
+      km_pathetic_stacktrace();
       km_abortx("open file slot %d already open on file %s, new file %s ", host_fd, file->name, name);
    }
    file->ops = ops;

--- a/km/km_trace.c
+++ b/km/km_trace.c
@@ -15,6 +15,7 @@
  */
 
 #include <errno.h>
+#include <execinfo.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdarg.h>
@@ -25,7 +26,6 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <execinfo.h>
 
 #include "km.h"
 #include "km_exec.h"
@@ -261,8 +261,8 @@ void km_trace_setup(int argc, char* argv[])
 void km_pathetic_stacktrace(void)
 {
    int nretaddrs;
-   void *return_addresses[MAX_STACK_DEPTH];
-   char **symbolic_ra;
+   void* return_addresses[MAX_STACK_DEPTH];
+   char** symbolic_ra;
 
    nretaddrs = backtrace(return_addresses, MAX_STACK_DEPTH);
    symbolic_ra = backtrace_symbols(return_addresses, nretaddrs);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1629,24 +1629,27 @@ fi
    # How many spins is enough?
    for ((i=0; i<25; i++))
    do
-      run ${KM_CLI_BIN} -r -d $SNAPDIR -s $MGTPIPE
-      assert_success
+      #run ${KM_CLI_BIN} -r -d $SNAPDIR -s $MGTPIPE
+      #assert_success
+      ${KM_CLI_BIN} -r -d $SNAPDIR -s $MGTPIPE
+      if test "$?" -ne 0; then
+         sed -e "s/^/# /" $TRACEFILE >&3
+         fail "km_cli failed, km trace is in the bats log"
+      fi
       assert [ -f $SNAPDIR/kmsnap ]
 
-      run curl localhost:$socket_port
-      assert_success
+      #run curl localhost:$socket_port
+      #assert_success
+      curl localhost:$socket_port
+      if test "$?" -ne 0; then
+         sed -e "s/^/# /" $TRACEFILE >&3
+         fail "curl failed, km trace is in the bats log"
+      fi
 
       rm -f $SNAPDIR/kmsnap
    done
    # Get the html server to stop
    curl localhost:$socket_port/stop
-
-   # Wait for the test to terminate.
-   # If the test program failed, spew its km trace into the bats log.
-   wait $pid
-   if test "$?" -ne 0; then
-      sed -e "s/^/# /" $TRACEFILE >&3
-   fi
 
    # cleanup
    rm -fr $SNAPDIR $MGTPIPE $TRACEFILE


### PR DESCRIPTION
The continue_after_snapshot bats test occasionally fails with this message:
```
07:12:47.612374 km_add_guest_fd_inte 241  vcpu-0  file slot 1 for (null) is taken unexpectedly
```
We don't know what is wrong here.  To maybe get some clues I've changed km's options to generate debug tracing into a file for this test.
I've also changed the km code that generates this message to abort instead of just exiting with a message.

Hopefully in a week or 2 we will run into the problem again and there will be some trace data to look at.
