### PR TITLE
Fix snapshot recovery of established network connections, and more

### DIFF
--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -133,7 +133,7 @@ typedef struct km_nt_dup {
 typedef struct km_nt_file {
    Elf64_Word size;       // Size of record
    Elf64_Word fd;         // Open fd number
-   Elf64_Word how;        // How file was created
+   Elf64_Word how;        // How file was created, values from km_file_how_t
    Elf64_Word flags;      // open(2) flags
    Elf64_Word mode;       // file mode (includes type)
    Elf64_Word pipesize;   // if how == KM_FILE_HOW_PIPE_0/1 the size of the
@@ -163,8 +163,8 @@ typedef struct km_nt_socket {
    Elf64_Word domain;
    Elf64_Word type;
    Elf64_Word protocol;
-   Elf64_Word other;   // 'other' fd for socketpair(2)
-   Elf64_Word addrlen;
+   Elf64_Word other;        // 'other' fd for socketpair(2)
+   Elf64_Word addrlen;      // if zero, no local address is bound
    Elf64_Word datalength;   // number of bytes to write back to the
                             // write side of a socketpair.  The data
                             // bytes follow the protocol address of
@@ -175,16 +175,13 @@ typedef struct km_nt_socket {
 #define NT_KM_SOCKET 0x4b4d534b   // "KMSK" no null term
 
 // values for 'how' field in km_nt_socket
-#define KM_NT_SKHOW_SOCKETPAIR 0
-#define KM_NT_SKHOW_SOCKET 1
-#define KM_NT_SKHOW_ACCEPT 2
+#define KM_NT_SKHOW_SOCKETPAIR ((Elf64_Word)KM_FILE_HOW_SOCKETPAIR0)
+#define KM_NT_SKHOW_SOCKET ((Elf64_Word)KM_FILE_HOW_SOCKET)
 
-#define KM_NT_SKSTATE_OPEN 0
-#define KM_NT_SKSTATE_BIND 1
-#define KM_NT_SKSTATE_LISTEN 2
-#define KM_NT_SKSTATE_ACCEPT 3
-#define KM_NT_SKSTATE_CONNECT 4
-#define KM_NT_SKSTATE_ERROR 5
+// Values for 'state' field in km_nt_socket
+#define KM_NT_SKSTATE_OPEN ((Elf64_Word)KM_SOCK_STATE_UNCONNECTED)
+#define KM_NT_SKSTATE_LISTEN ((Elf64_Word)KM_SOCK_STATE_LISTENING)
+#define KM_NT_SKSTATE_ERROR ((Elf64_Word)KM_SOCK_STATE_CONNLOST)
 
 /*
  * Use a function so that we consistently roundup note related pieces in the rest of the code.

--- a/km/km_exec_fd_save_recover.c
+++ b/km/km_exec_fd_save_recover.c
@@ -478,7 +478,7 @@ static int km_exec_restore_socketpair(int fd, km_file_how_t how, int ofd)
       km_fs_destroy_fd(fd);
       return -1;
    }
-   file->sockinfo->state = KM_SOCK_STATE_CONNECT;
+   file->sockinfo->state = KM_SOCK_STATE_CONNECTED;
    file->sockinfo->backlog = 0;
    file->sockinfo->addrlen = 0;
 

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1675,6 +1675,11 @@ km_fs_accept4(km_vcpu_t* vcpu, int sockfd, struct sockaddr* addr, socklen_t* add
    if (ret >= 0) {
       km_fd_socket_t* sock = km_fs()->guest_files[sockfd].sockinfo;
       ret = km_add_socket_fd(vcpu, ret, NULL, 0, sock->domain, sock->type, sock->protocol, KM_FILE_HOW_ACCEPT);
+      if (ret < 0) {
+         close(ret);
+      } else {
+         sock->state = KM_SOCK_STATE_CONNECTED;
+      }
    }
    return ret;
 }

--- a/km/km_filesys_private.h
+++ b/km/km_filesys_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Kontain Inc
+ * Copyright 2021-2022 Kontain Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,6 @@
  * getting big and we need to split out functionality to another file.
  */
 
-typedef enum km_sock_state {
-   KM_SOCK_STATE_OPEN = 0,
-   KM_SOCK_STATE_BIND = 1,
-   KM_SOCK_STATE_LISTEN = 2,
-   KM_SOCK_STATE_ACCEPT = 3,
-   KM_SOCK_STATE_CONNECT = 4,
-} km_sock_state_t;
-
 // Each km_file_t has an optional point to socket state described by this structure.
 typedef struct km_fd_socket {
    km_sock_state_t state;
@@ -47,20 +39,6 @@ typedef struct km_fs_event {
    int fd;
    struct epoll_event event;
 } km_fs_event_t;
-
-// Valid values for the how field in km_file_t
-typedef enum km_file_how {
-   KM_FILE_HOW_OPEN = 0,    /* Regular open */
-   KM_FILE_HOW_PIPE_0 = 1,  /* read half of pipe */
-   KM_FILE_HOW_PIPE_1 = 2,  /* write half of pipe */
-   KM_FILE_HOW_EPOLLFD = 3, /* epoll_create() */
-   KM_FILE_HOW_SOCKET = 4,
-   KM_FILE_HOW_ACCEPT = 5,
-   KM_FILE_HOW_SOCKETPAIR0 = 6,
-   KM_FILE_HOW_SOCKETPAIR1 = 7,
-   KM_FILE_HOW_RECVMSG = 8,
-   KM_FILE_HOW_EVENTFD = 9, /* eventfd() */
-} km_file_how_t;
 
 // Each file opened by the guest has one of these structures.
 typedef struct km_file {

--- a/km/km_management.c
+++ b/km/km_management.c
@@ -151,7 +151,7 @@ void km_mgt_init(char* path)
    }
    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
 
-   km_info(KM_TRACE_SNAPSHOT, "snapshot pipe name is %s", path);
+   km_infox(KM_TRACE_SNAPSHOT, "snapshot pipe name is %s", path);
 
    if ((sock = km_mgt_listen(AF_UNIX, SOCK_STREAM, 0)) < 0) {
       km_warn("mgt socket %s", addr.sun_path);

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1074,7 +1074,7 @@ fi
 }
 
 @test "basic_snapshot($test_type): snapshot and resume(snapshot_test$ext)" {
-   # this test uses a single port, so the next free port will be 22
+   # this test uses a 2 ports, so the next free port will be 23
    local port_id=21
    local snapshot_test_port=$(( $port_range_start + $port_id))
 
@@ -1607,8 +1607,8 @@ fi
 }
 
 @test "continue_after_snapshot($test_type): resume payload after taking a snapshot (hello_html_test$ext)" {
-   # this test uses a single port, so the next free port will be 23
-   local port_id=22
+   # this test uses a single port, so the next free port will be 24
+   local port_id=23
    local socket_port=$(($port_range_start + $port_id))
    local MGTPIPE=resume_after_mgtpipe.$$
    local SNAPDIR=snapdir.$$


### PR DESCRIPTION
This change started out to fix the problem of connections that are establish when a snapshot is taken should be recovered as unconnected and return an error when a system call using the now disconnection connection. That is fixed but more stuff ended up being piled in here. The other stuff fixed is:

- clear the error field of the km_file_t when a file is opened. It should probably be cleared after an error is returned but this fix is already pretty big.

- Add tests to tests/snapshot_test.c to verify that socket bound addresses are being recovered.

- Reduce the number of values used to describe how an fd came into existence and the state of a socket.  Formerly there were values stored in the km_file_t an the km_fd_socket_t and in the snapshot elf notes.  Now we only use the km_file_t and km_fd_socket_t values in km_file_t and the elf notes.

- a socket with a local address bound is not really in a different state.  We were representing such sockets as being in a different state.  Being bound is just a property of a socket.  If you read the ip(7) man page you will find that binding an address is not required for a listen to be performed and you can bind a local address to a socket that will never be performing a connect.  The code in snapshot is changed to treat the bound local address as a socket property now.

- the shutdown() system call changes the "connected" state of a socket. km was not handling this at all.  It does now.
