### PR TITLE
Ubuntu gcc 11.2 gdb_sharedlib bats test fails

### DIFF
--- a/km/km_musl_related.c
+++ b/km/km_musl_related.c
@@ -101,9 +101,10 @@ int km_link_map_walk(link_map_visit_function_t* callme, void* visitargp)
    } else if (*((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_O0) == 0x48 &&
               *((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_O0 + 1) == 0x8b) {
       offset_to_load_head_instr = KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_O0;
-    } else if (*((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2) == 0x48 &&
-               *((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2 + 1) == 0x8b) {
-       offset_to_load_head_instr = KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2;
+   } else if (*((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2) == 0x48 &&
+              *((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2 + 1) ==
+                  0x8b) {
+      offset_to_load_head_instr = KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2;
    } else {
       km_warnx("Can't find the head of the payload's loaded library list");
       return rc;

--- a/km/km_musl_related.c
+++ b/km/km_musl_related.c
@@ -79,6 +79,7 @@ int km_link_map_walk(link_map_visit_function_t* callme, void* visitargp)
    static const uint64_t KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR = 17;          // gcc <= 11 -O2
    static const uint64_t KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_gcc_12 = 20;   // gcc 12 -O2
    static const uint64_t KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_O0 = 45;       // -O0 both versions
+   static const uint64_t KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2 = 21;
 
    static const uint64_t KM_DLOPEN_LOAD_HEAD_INSTR_LEN = 0x7;
 
@@ -100,8 +101,11 @@ int km_link_map_walk(link_map_visit_function_t* callme, void* visitargp)
    } else if (*((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_O0) == 0x48 &&
               *((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_O0 + 1) == 0x8b) {
       offset_to_load_head_instr = KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_O0;
+    } else if (*((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2) == 0x48 &&
+               *((uint8_t*)dlopen_kma + KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2 + 1) == 0x8b) {
+       offset_to_load_head_instr = KM_DLOPEN_OFFSET_TO_LOAD_HEAD_INSTR_ubuntu_gcc_11_2;
    } else {
-      km_infox(KM_TRACE_KVM, "Unexpected instruction in dlopen, has musl dlopen() changed?");
+      km_warnx("Can't find the head of the payload's loaded library list");
       return rc;
    }
 

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -528,17 +528,19 @@ fi
    wait_and_check $pid $(( $signal_flag + 11)) # expect KM to exit with SIGSEGV
 
    # test for symbols from a shared library brought in by dlopen()
-   km_with_timeout -g$km_gdb_port --putenv="LD_LIBRARY_PATH=`pwd`" gdb_sharedlib2_test$ext &
+   kmlog=/tmp/gdb_sharedlib.$$
+   km_with_timeout -g$km_gdb_port --putenv="LD_LIBRARY_PATH=`pwd`" gdb_sharedlib2_test$ext >$kmlog 2>&1 &
    pid=$!
    run gdb_with_timeout -q -nx --ex="target remote :$km_gdb_port" \
       --ex="source cmd_for_sharedlib2_test.gdb" --ex=q
    assert_success
    # If km can't find the head of the dynamic library list, fail now.
-   refute_line --partial "Can't find the head of the payload's loaded library list"
+   assert grep -v "Can't find the head of the payload's loaded library list" $kmlog
    assert_line --regexp "Yes         .*/dlopen_test_lib.so"
    assert_line --partial "Dump of assembler code for function do_function"
    assert_line --partial "Hit the breakpoint at do_function"
    wait_and_check $pid 0
+   rm -f $kmlog
 }
 
 #

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -533,6 +533,8 @@ fi
    run gdb_with_timeout -q -nx --ex="target remote :$km_gdb_port" \
       --ex="source cmd_for_sharedlib2_test.gdb" --ex=q
    assert_success
+   # If km can't find the head of the dynamic library list, fail now.
+   refute_line --partial "Can't find the head of the payload's loaded library list"
    assert_line --regexp "Yes         .*/dlopen_test_lib.so"
    assert_line --partial "Dump of assembler code for function do_function"
    assert_line --partial "Hit the breakpoint at do_function"


### PR DESCRIPTION
The ubuntu gcc 11.2 dlopen looks like this:

Dump of assembler code for function dlopen:
   0x00000000002625bc <+0>:     endbr64
   0x00000000002625c0 <+4>:     push   %r15
   0x00000000002625c2 <+6>:     push   %r14
   0x00000000002625c4 <+8>:     push   %r13
   0x00000000002625c6 <+10>:    push   %r12
   0x00000000002625c8 <+12>:    push   %rbp
   0x00000000002625c9 <+13>:    push   %rbx
   0x00000000002625ca <+14>:    sub    $0x1b8,%rsp
   0x00000000002625d1 <+21>:    mov    0x4f918(%rip),%rax        # 0x2b1ef0 <head>
   0x00000000002625d8 <+28>:    mov    %rdi,0x20(%rsp)
   0x00000000002625dd <+33>:    mov    %esi,0x14(%rsp)
   0x00000000002625e1 <+37>:    movq   $0x0,0x60(%rsp)
   0x00000000002625ea <+46>:    test   %rdi,%rdi
   0x00000000002625ed <+49>:    je     0x262d75 <dlopen+1977>

We need to get the head of the dynamically loaded library list from the instruction at offset +21.
This is a new offset for us so it needs to be added to the lib list walker code in km_link_map_walk().
In addition if we can't find the head of the library list we need to fail the gdb_sharedlib bats test with a clearer message.  If we see this message:
   "Can't find the head of the head of payload's loaded library list"
we will know that dlopen() has changed and we need to look at it.