### PR TITLE
Give better error when the SNAP_LISTEN_PORT env var can't be decoded

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -214,6 +214,8 @@ void light_snap_listen(int elf_fd)
 
       // Get rid of vm related fd's and payload fd's we inherited from the previous instance of km
       km_vmstate_destroy(snap_listen_sock, elf_fd);
+   } else {
+      km_errx(2, "env var %s's value %s is invalid", KM_SNAP_LISTEN_PORT, port);
    }
 
    // will adjust the backlog value to that of the snapshot later


### PR DESCRIPTION
light_snap_listen() decodes what is stored in the SNAP_LISTEN_PORT env var.  If it can't decide the variable, it just drops thru to the listen call with an invalid fd which causes listen() to fail. This change adds code to print a message showing the contents of SNAP_LISTEN_PORT before exiting km.