### PR TITLE
Increase the CI timeout for the bats popen and files_on_exec tests

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1418,7 +1418,7 @@ fi
    f2=/tmp/f2$$
    flog=/tmp/xx$$
    if [ -z "${VALGRIND}" ]; then
-      to=5s
+      to=10s
    else
       to=25s
    fi
@@ -1465,7 +1465,7 @@ fi
 }
 
 @test "files_on_exec($test_type): passing /proc and such to execed process (fs_exec_test$ext)" {
-   run km_with_timeout --timeout 5s fs_exec_test$ext parent
+   run km_with_timeout --timeout 10s fs_exec_test$ext parent
    assert_success
    assert_line --regexp "parent exe: /[^[:space:]]*/tests/fs_exec_test$ext parent"
    assert_line --regexp "child  exe: /[^[:space:]]*/tests/fs_exec_test$ext child"


### PR DESCRIPTION
These 2 tests timeout periodically in the CI bats tests. These tests don't do much but the cloud is punishing them once in a while and the tests time out.
So, increase the timeouts to 10 seconds from 5 seconds.