### PR TITLE
Have km management thread fail requests until the payload is started

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -498,6 +498,7 @@ extern char* km_snapshot_name;
 extern char* km_mgtdir;
 extern struct option km_cmd_long_options[];
 extern const_string_t km_cmd_short_options;
+extern int km_vcpus_are_started;
 
 void km_trace_fini(void);
 void km_trace_setup(int argc, char* argv[]);

--- a/km/km_management.c
+++ b/km/km_management.c
@@ -73,24 +73,31 @@ static void* mgt_main(void* arg)
       }
 
       needunblock = 0;
-      switch (mgmtrequest.opcode) {
-         case KM_MGMT_REQ_SNAPSHOT:
-            if ((mgmtreply.request_status = km_snapshot_block(NULL)) == 0) {
-               mgmtreply.request_status =
-                   km_snapshot_create(NULL,
-                                      mgmtrequest.requests.snapshot_req.label,
-                                      mgmtrequest.requests.snapshot_req.description,
-                                      mgmtrequest.requests.snapshot_req.snapshot_path);
-               if (mgmtreply.request_status == 0 && mgmtrequest.requests.snapshot_req.live == 0) {
-                  machine.exit_group = 1;
+      if (km_vcpus_are_started != 0) {
+         switch (mgmtrequest.opcode) {
+            case KM_MGMT_REQ_SNAPSHOT:
+               if ((mgmtreply.request_status = km_snapshot_block(NULL)) == 0) {
+                  mgmtreply.request_status =
+                      km_snapshot_create(NULL,
+                                         mgmtrequest.requests.snapshot_req.label,
+                                         mgmtrequest.requests.snapshot_req.description,
+                                         mgmtrequest.requests.snapshot_req.snapshot_path);
+                  if (mgmtreply.request_status == 0 && mgmtrequest.requests.snapshot_req.live == 0) {
+                     machine.exit_group = 1;
+                  }
+                  needunblock = 1;
                }
-               needunblock = 1;
-            }
-            break;
-         default:
-            km_warnx("Unknown mgmt request %d, length %d", mgmtrequest.opcode, mgmtrequest.length);
-            mgmtreply.request_status = EINVAL;
-            break;
+               break;
+            default:
+               km_warnx("Unknown mgmt request %d, length %d", mgmtrequest.opcode, mgmtrequest.length);
+               mgmtreply.request_status = EINVAL;
+               break;
+         }
+      } else {
+         // The payload has not started, can't do the request.
+	 // This probably should be on a per request type basis, not all requests.
+         mgmtreply.request_status = EAGAIN;
+         km_warnx("Payload not running, failing management request %d", mgmtrequest.opcode);
       }
 
       // let them know what happened.

--- a/km/km_management.c
+++ b/km/km_management.c
@@ -95,7 +95,7 @@ static void* mgt_main(void* arg)
          }
       } else {
          // The payload has not started, can't do the request.
-	 // This probably should be on a per request type basis, not all requests.
+         // This probably should be on a per request type basis, not all requests.
          mgmtreply.request_status = EAGAIN;
          km_warnx("Payload not running, failing management request %d", mgmtrequest.opcode);
       }

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Kontain Inc
+ * Copyright 2021-2022 Kontain Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@
 int vcpu_dump = 0;
 int km_collect_hc_stats = 0;
 int kill_unimpl_hcall = 0;
+// Prevent snapshotting until the payload is running.
+int km_vcpus_are_started = 0;
 
 #define fx "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx "
 
@@ -893,4 +895,5 @@ void km_start_vcpus()
    }
 
    km_start_all_vcpus();
+   km_vcpus_are_started = 1;
 }


### PR DESCRIPTION
The cloud can leave km threads preempted for a long time.  We have seen cases where the mgmt thread is running before the payload is started, allowing snapshot requests when km is not ready to perform them. This change prevents attempting snapshots until after the payload is started.