### PR TITLE
Change curl command to stop suppressing messages

### DIFF
--- a/payloads/java/test_java.bats
+++ b/payloads/java/test_java.bats
@@ -62,7 +62,7 @@ load "${TESTS_BASE}/bats-assert/load.bash"  # see manual in bats-assert/README.m
 		${JAVA_DIR}/bin/java.kmd -XX:-UseCompressedOops -jar sb.jar &
   pid=$!
   tries=20
-  run curl -4 -s localhost:8080/greeting --retry-connrefused  --retry $tries --retry-delay 1
+  run curl -4 localhost:8080/greeting --retry-connrefused  --retry $tries --retry-delay 1
   assert_success
   assert_output --regexp '"id":1.*Hello, World!'
 


### PR DESCRIPTION
The java payloads ci regularly fails like this:

``` 
not ok 4 Java SpringBoot snapshot
 (from function `assert_success' in file scripts/bats-assert/src/assert.bash, line 114,
  in test file km-bats-8.dynamic, line 66)
   `assert_success' failed with status 7
 07:25:57.299979 km_set_snapshot_path 51   km      Setting snapshot path to kmsnap
 07:25:57.317530 km_mgt_init          161  km      snapshot pipe name is /tmp/xxx.160

   .   ____          _            __ _ _
  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
 ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
   '  |____| .__|_| |_|_| |_\__, | / / / /
  =========|_|==============|___/=/_/_/_/
  :: Spring Boot ::        (v2.2.0.RELEASE)

 2022-12-09 07:26:04.727  INFO 170 --- [           main] c.e.restservice.RestServiceApplication   : Starting RestServiceApplication on a1c9fe0372e0 with PID 170 (/home/appuser/km/payloads/java/sb.jar started by root in /home/appuser/km/payloads/java)
 2022-12-09 07:26:04.755  INFO 170 --- [           main] c.e.restservice.RestServiceApplication   : No active profile set, falling back to default profiles: default
 2022-12-09 07:26:15.480  INFO 170 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
 2022-12-09 07:26:15.522  INFO 170 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
 2022-12-09 07:26:15.522  INFO 170 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.27]
 2022-12-09 07:26:16.048  INFO 170 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
 2022-12-09 07:26:16.048  INFO 170 --- [           main] o.s.web.context.ContextLoader            : Root WebApplicationContext: initialization completed in 10362 ms
 2022-12-09 07:26:17.205  INFO 170 --- [           main] o.s.s.concurrent.ThreadPoolTaskExecutor  : Initializing ExecutorService 'applicationTaskExecutor'

 -- command failed --
 status : 7
 output :
 --

 Error: The action has timed out.
```

Turns out the failure is in curl and exit status 7 is: "Failed to connect to host."

Which is pretty non-specific.  That instance of curl is run with the -s (silent) option so we don't know if there are additional messages.

This change removes the -s flag so we can find out more about what happened.