### PR TITLE
Improve snapshot messages and uninterpreted opcode message

### DIFF
--- a/km/km_decode.c
+++ b/km/km_decode.c
@@ -820,7 +820,16 @@ static void decode_opcode(km_vcpu_t* vcpu, x86_instruction_t* ins)
       return;
    }
 
-   km_warnx("KM intruction decode: Uninterpreted Opcode=0x%x", opcode);
+   uint64_t pc = vcpu->regs.rip;
+   km_warnx("KM intruction decode: PC 0x%x, Uninterpreted Instruction=%02x %02x %02x %02x %02x "
+            "%02x",
+            pc,
+            *(unsigned char*)km_gva_to_kma(pc),
+            *(unsigned char*)km_gva_to_kma(pc + 1),
+            *(unsigned char*)km_gva_to_kma(pc + 2),
+            *(unsigned char*)km_gva_to_kma(pc + 3),
+            *(unsigned char*)km_gva_to_kma(pc + 4),
+            *(unsigned char*)km_gva_to_kma(pc + 5));
 
    return;
 }

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -650,9 +650,11 @@ int main(int argc, char* argv[])
 
    // snapshot file is type ET_CORE. We check for additional notes in restore
    if (elf->ehdr.e_type == ET_CORE) {
+      km_infox(KM_TRACE_SNAPSHOT, "Snapshot recover started, pid %d, from %s", getpid(), km_payload_name);
       if (km_snapshot_restore(elf) < 0) {
          km_err(1, "failed to restore from snapshot %s", km_payload_name);
       }
+      km_infox(KM_TRACE_SNAPSHOT, "Snapshot recover complete, pid %d", getpid());
       vcpu = machine.vm_vcpus[0];
    } else {
       // if environment wasn't set up copy it from host

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -557,9 +557,12 @@ int km_snapshot_create(km_vcpu_t* vcpu, char* label, char* description, char* du
          dumppath = km_get_snapshot_path();
       }
    }
+   km_infox(KM_TRACE_SNAPSHOT, "Begin snapshot pid %d to %s", getpid(), dumppath);
    int rc = km_dump_core(dumppath, vcpu, NULL, label, description, KM_DO_SNAP);
    if (rc != 0) {
       km_warnx("Cannot create snapshot %s, %s", dumppath, strerror(rc));
+   } else {
+      km_infox(KM_TRACE_SNAPSHOT, "Snapshot complete, pid %d", getpid());
    }
 
    return rc;


### PR DESCRIPTION
Todays CI failure shows a km trace that has both a snapshot generation and snapshot resume all run together.  To help us realize what is happening the next time we see this there are km traces now for begin and end of snapshot generation and resumption.

Plus the message for an uninterpreted opcode has been changed to include both the PC for the instruction and the first 6 bytes of the instruction.