### PR TITLE
don't count accepted pre-snapshot sockets

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -579,7 +579,8 @@ static inline void del_guest_fd(km_vcpu_t* vcpu, int fd)
    km_assert(fd >= 0 && fd < km_fs()->nfdmap);
    km_file_t* file = &km_fs()->guest_files[fd];
    km_assert(km_is_file_used(file) != 0);
-   if (light_snap_accept_timeout != 0 && file->how == KM_FILE_HOW_ACCEPT) {
+   // file->error != 0 means socket was connected when snapshot was taken. We do not want to count that
+   if (light_snap_accept_timeout != 0 && file->how == KM_FILE_HOW_ACCEPT && file->error == 0) {
       km_set_inactive_accept();   // account for accepted socket closing
    }
 


### PR DESCRIPTION
When we restarting from snapshot we treat previously connected socket as error, simply telling the app ECONNRESET. That socket was not accepted in the snapshot, it was accepted before snapshot was taken. Hence we should not count it as real close for the purposes of tracking active connected sockets.

The condition is rare hence we haven't seen it before. Payload (like springboot app) is done with the request, response is sent, **but** the socket is not closed yet. Then after snapshot restart the close comes, and our accepted socket counting is wrong. So now we check for that state when count active accepted sockets.