### PR TITLE
Add error checking to code that writes snapshot conf file

### DIFF
--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -1001,7 +1001,13 @@ int km_dump_core(char* core_path,
                         break;
                   }
                   strcat(buf, "\n");
-                  write(cfd, buf, strlen(buf));
+                  ssize_t byteswritten = write(cfd, buf, strlen(buf));
+                  if (byteswritten < 0) {
+                     rc = errno;
+                     km_warn("Write snapshot config file failed:");
+                     break;
+                  }
+                  km_assert(byteswritten == strlen(buf));
                }
             }
          }

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1214,6 +1214,7 @@ fi
    assert_success
    wait $pid
    local -a snapname=($(echo ${MGTDIR}/kmsnap.prelisten_test$ext.[0-9]*))
+   assert test -s ${MGTDIR}/kmsnap.*.conf
    SNAP_LISTEN_PORT=$(cat ${MGTDIR}/kmsnap.*.conf) km_with_timeout ${snapname[0]} &
    pid=$!
    run curl -4 -s -S --retry-connrefused  --retry 3 --retry-delay 1 localhost:$snapshot_test_port


### PR DESCRIPTION
And add test in bats that verifies the kmsnap.*.conf file exists and is non-zero length.

This change is to help narrow down the problem we see once in a while when the bats tests are run with valgrind.