### PR TITLE
Don't run the bats multilisten-snapshot test with valgrind

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -72,9 +72,9 @@ todo_alpine_dynamic=$todo_alpine_static
 not_needed_dynamic='linux_exec setup_load mem_slots cli mem_brk mmap_1 km_identity exec_sh'
 todo_dynamic='mem_mmap exception dl_iterate_phdr monitor_maps km_exec_guest_files'
 if [ ! -z "${VALGRIND}" ]; then
-todo_dynamic+=' gdb_sharedlib cpp_throw basic_snapshot futex_snapshot popen files_on_exec '
-todo_alpine_dynamic+=' gdb_sharedlib cpp_throw basic_snapshot futex_snapshot popen files_on_exec'
-todo_glibc_dynamic+=' basic_snapshot futex_snapshot'
+todo_dynamic+=' gdb_sharedlib cpp_throw basic_snapshot futex_snapshot popen files_on_exec multilisten-snapshot'
+todo_alpine_dynamic+=' gdb_sharedlib cpp_throw basic_snapshot futex_snapshot popen files_on_exec multilisten-snapshot'
+todo_glibc_dynamic+=' basic_snapshot futex_snapshot multilisten-snapshot'
 fi
 # running .so as executables was useful at some point, but it isn't needed anymore.
 # Simply disable the tests for now. Ultimately we will drop build and test support for them.


### PR DESCRIPTION
valgrind needs the use of the km --putenv= parameter and snapshots do not allow adding variables to the payload's environment so the multilisten test was failing with this error:

09:15:39.636920 main                 636  memchec cannot set new environment when resuming a snapshot