### PR TITLE
Warn instead of error setting environment for snapshot, enable valgrind for snapshot tests

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -445,7 +445,7 @@ int km_shrink_footprint(km_vcpu_t* vcpu)
       rc = errno;
       km_warn("execve() to %s failed", me);
    } else {
-      km_warn("aborted shrink");
+      km_warnx("aborted shrink");
    }
 
    km_vcpu_resume_all();

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -633,7 +633,7 @@ int main(int argc, char* argv[])
    if (elf->ehdr.e_type == ET_CORE) {
       // check for incompatible options
       if (envp != NULL) {
-         km_errx(1, "cannot set new environment when resuming a snapshot");
+         km_warnx("ignoring new environment when resuming a snapshot");
       }
       if (argc_p > 1) {
          km_errx(1, "cannot set payload arguments when resuming a snapshot");

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -72,9 +72,8 @@ todo_alpine_dynamic=$todo_alpine_static
 not_needed_dynamic='linux_exec setup_load mem_slots cli mem_brk mmap_1 km_identity exec_sh'
 todo_dynamic='mem_mmap exception dl_iterate_phdr monitor_maps km_exec_guest_files'
 if [ ! -z "${VALGRIND}" ]; then
-todo_dynamic+=' gdb_sharedlib cpp_throw basic_snapshot futex_snapshot popen files_on_exec '
-todo_alpine_dynamic+=' gdb_sharedlib cpp_throw basic_snapshot futex_snapshot popen files_on_exec'
-todo_glibc_dynamic+=' basic_snapshot futex_snapshot'
+todo_dynamic+=' gdb_sharedlib cpp_throw files_on_exec '
+todo_alpine_dynamic+=' gdb_sharedlib cpp_throw popen files_on_exec'
 fi
 # running .so as executables was useful at some point, but it isn't needed anymore.
 # Simply disable the tests for now. Ultimately we will drop build and test support for them.


### PR DESCRIPTION
This fix allows to set an environment variable for km when running snapshot. For instance, unset LD_PRELOAD whn running valgrind, or KM_VERBOSE.