### PR TITLE
Create snapshots with holes where unbacked pages are in the dumped memory

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -475,6 +475,7 @@ static const_string_t KM_MGTPIPE = "KM_MGTPIPE";
 static const_string_t KM_MGTDIR = "KM_MGTDIR";
 static const_string_t KM_KILL_UNIMPL_SCALL = "KM_KILL_UNIMPL_SCALL";
 static const_string_t KM_SNAP_LISTEN_TIMEOUT = "SNAP_LISTEN_TIMEOUT";
+static const_string_t KM_SPARSE_COREFILE = "SPARSE_COREFILE";
 
 /*
  * Trivial trace control - with switch to turn on/off and on and a tag to match.
@@ -499,6 +500,7 @@ extern struct option km_cmd_long_options[];
 extern const_string_t km_cmd_short_options;
 extern int km_vcpus_are_started;
 extern int km_shrunken;
+extern int km_sparse_corefile;
 
 void km_trace_fini(void);
 void km_trace_setup(int argc, char* argv[]);

--- a/tests/multilisten_test.c
+++ b/tests/multilisten_test.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/mman.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -100,6 +101,19 @@ int main(int argc, char* argv[])
          maxfd = listenfd[i];
       }
    }
+
+   // allocate a big chunk of memory with malloc() and then don't touch it.
+   char* chunkmalloc = malloc(100 * 1024 * 1024);
+   fprintf(stdout, "chunkmalloc %p\n", chunkmalloc);
+
+   // allocate another big chunk of memory with mmap() and don't touch that
+   char* chunkmmap =
+       mmap(NULL, 100 * 1024 * 1024, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+   if (chunkmmap == MAP_FAILED) {
+      fprintf(stderr, "mmap() failed, %s\n", strerror(errno));
+      return 1;
+   }
+   fprintf(stdout, "chunkmmap %p\n", chunkmmap);
 
    // Setup select mask to listen for connections
    fd_set readfds;


### PR DESCRIPTION
To create a snapshot with unbacked memory pages put into the core file as holes, define SPARSE_COREFILE in the km environment when starting up km.  Currently we only produce sparse snapshot files.  It is easy to produce sparse corefiles if we think we need to.

This commit is mostly for people to look at the code.  There is no bats test yet.  There is some code added to the multilisten test to allocate 100MB with malloc() and 100MB with mmap().  malloc() creates backed pages, mmap() creates unbacked memory pages.