### PR TITLE
Add support for timerfd syscalls, fix sendmsg() logging.

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1800,25 +1800,37 @@ uint64_t km_fs_sendrecvmsg(km_vcpu_t* vcpu, int scall, int sockfd, struct msghdr
    }
    if (scall == SYS_sendmsg) {
       // translate sent file descriptors if any
-      for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
-         if (cmsg->cmsg_type == SCM_RIGHTS) {
-            int guest_fd = *(int*)CMSG_DATA(cmsg);
-            int host_fd = km_fs_g2h_fd(guest_fd, NULL);
-            *(int*)CMSG_DATA(cmsg) = host_fd;
-            km_infox(KM_TRACE_FILESYS, "send guest fd %d as host %d", guest_fd, host_fd);
+      if (msg->msg_control != NULL) {
+         for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
+            if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+               int fdcount = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
+	       km_infox(KM_TRACE_FILESYS, "sockfd %d: processing SCM_RIGHTS send chunk containing %d fd's", sockfd, fdcount);
+               int* guest_fd = (int*)CMSG_DATA(cmsg);
+	       for (int i = 0; i < fdcount; i++) {
+                  int host_fd = km_fs_g2h_fd(guest_fd[i], NULL);
+                  km_infox(KM_TRACE_FILESYS, "fd[%d] send guest fd %d as host fd %d", i, guest_fd[i], host_fd);
+                  guest_fd[i] = host_fd;
+               }
+            }
          }
       }
    }
    ret = __syscall_3(scall, host_sockfd, (uintptr_t)msg, flag);
-   if (scall == SYS_recvmsg) {
+   if (scall == SYS_recvmsg && ret >= 0) {
       // receive file descriptors if any
-      for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
-         if (cmsg->cmsg_type == SCM_RIGHTS) {
-            int host_fd = *(int*)CMSG_DATA(cmsg);
-            int guest_fd =
-                km_add_guest_fd_internal(vcpu, host_fd, NULL, flag, KM_FILE_HOW_RECVMSG, NULL);
-            *(int*)CMSG_DATA(cmsg) = guest_fd;
-            km_infox(KM_TRACE_FILESYS, "received host fd %d as guest %d", host_fd, guest_fd);
+      if (msg->msg_control != NULL) {
+         for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
+            if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+               int fdcount = (cmsg->cmsg_len  - sizeof(struct cmsghdr)) / sizeof(int);
+	       km_infox(KM_TRACE_FILESYS, "sockfd %d: processing SCM_RIGHTS recv chunk containing %d fd's", sockfd, fdcount);
+               int* host_fd = (int*)CMSG_DATA(cmsg);
+	       for (int i = 0; i < fdcount; i++) {
+                  int guest_fd =
+                      km_add_guest_fd_internal(vcpu, host_fd[i], NULL, flag, KM_FILE_HOW_RECVMSG, NULL);
+                  km_infox(KM_TRACE_FILESYS, "fd[%d]: received host fd %d will be guest fd %d", i, host_fd[i], guest_fd);
+                  host_fd[i] = guest_fd;
+               }
+            }
          }
       }
    }
@@ -2280,6 +2292,15 @@ uint64_t km_fs_epoll_ctl(km_vcpu_t* vcpu, int epfd, int op, int fd, struct epoll
             km_fs_event_del(vcpu, file, fd, event);
             break;
       }
+   }
+   return ret;
+}
+
+uint64_t km_fs_timerfd_create(km_vcpu_t* vcpu, int clockid, int flags)
+{
+   int ret = __syscall_2(SYS_timerfd_create, clockid, flags);
+   if (ret >= 0) {
+      ret = km_add_guest_fd_internal(vcpu, ret, NULL, flags, KM_FILE_HOW_TIMERFD, NULL);
    }
    return ret;
 }
@@ -2886,6 +2907,9 @@ int km_fs_core_notes_write(char* buf, size_t length, size_t* sizep)
             rc = fs_core_write_epollfd(cur, remain, file, i, &sz);
          } else if (file->how == KM_FILE_HOW_EVENTFD) {
             rc = fs_core_write_eventfd(cur, remain, file, i, &sz);
+         } else if (file->how == KM_FILE_HOW_TIMERFD) {
+            rc = EOPNOTSUPP;
+            km_warnx("Can't snapshot timerfd's yet, fd %d", i);
          } else if (file->sockinfo == NULL) {
             rc = fs_core_write_nonsocket(cur, remain, file, i, &sz);
          } else {

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -1804,9 +1804,12 @@ uint64_t km_fs_sendrecvmsg(km_vcpu_t* vcpu, int scall, int sockfd, struct msghdr
          for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
             if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
                int fdcount = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
-	       km_infox(KM_TRACE_FILESYS, "sockfd %d: processing SCM_RIGHTS send chunk containing %d fd's", sockfd, fdcount);
+               km_infox(KM_TRACE_FILESYS,
+                        "sockfd %d: processing SCM_RIGHTS send chunk containing %d fd's",
+                        sockfd,
+                        fdcount);
                int* guest_fd = (int*)CMSG_DATA(cmsg);
-	       for (int i = 0; i < fdcount; i++) {
+               for (int i = 0; i < fdcount; i++) {
                   int host_fd = km_fs_g2h_fd(guest_fd[i], NULL);
                   km_infox(KM_TRACE_FILESYS, "fd[%d] send guest fd %d as host fd %d", i, guest_fd[i], host_fd);
                   guest_fd[i] = host_fd;
@@ -1821,13 +1824,20 @@ uint64_t km_fs_sendrecvmsg(km_vcpu_t* vcpu, int scall, int sockfd, struct msghdr
       if (msg->msg_control != NULL) {
          for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg)) {
             if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
-               int fdcount = (cmsg->cmsg_len  - sizeof(struct cmsghdr)) / sizeof(int);
-	       km_infox(KM_TRACE_FILESYS, "sockfd %d: processing SCM_RIGHTS recv chunk containing %d fd's", sockfd, fdcount);
+               int fdcount = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
+               km_infox(KM_TRACE_FILESYS,
+                        "sockfd %d: processing SCM_RIGHTS recv chunk containing %d fd's",
+                        sockfd,
+                        fdcount);
                int* host_fd = (int*)CMSG_DATA(cmsg);
-	       for (int i = 0; i < fdcount; i++) {
+               for (int i = 0; i < fdcount; i++) {
                   int guest_fd =
                       km_add_guest_fd_internal(vcpu, host_fd[i], NULL, flag, KM_FILE_HOW_RECVMSG, NULL);
-                  km_infox(KM_TRACE_FILESYS, "fd[%d]: received host fd %d will be guest fd %d", i, host_fd[i], guest_fd);
+                  km_infox(KM_TRACE_FILESYS,
+                           "fd[%d]: received host fd %d will be guest fd %d",
+                           i,
+                           host_fd[i],
+                           guest_fd);
                   host_fd[i] = guest_fd;
                }
             }

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -304,6 +304,9 @@ uint64_t km_fs_prlimit64(km_vcpu_t* vcpu,
                          int resource,
                          const struct rlimit* new_limit,
                          struct rlimit* old_limit);
+
+uint64_t km_fs_timerfd_create(km_vcpu_t* vcpu, int clockid, int flags);
+
 size_t km_fs_dup_notes_length(void);
 size_t km_fs_core_dup_write(char* buf, size_t length);
 size_t km_fs_core_notes_length(void);

--- a/km/km_filesys_private.h
+++ b/km/km_filesys_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Kontain Inc
+ * Copyright 2021-2023 Kontain Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ typedef enum km_file_how {
    KM_FILE_HOW_SOCKETPAIR1 = 7,
    KM_FILE_HOW_RECVMSG = 8,
    KM_FILE_HOW_EVENTFD = 9, /* eventfd() */
+   KM_FILE_HOW_TIMERFD = 10
 } km_file_how_t;
 
 // Each file opened by the guest has one of these structures.

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -25,13 +25,13 @@
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>
 #include <sys/time.h>
+#include <sys/timerfd.h>
 #include <sys/times.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
 #include <asm/prctl.h>
 #include <linux/futex.h>
 #include <linux/stat.h>
-#include <sys/timerfd.h>
 
 #include "km.h"
 #include "km_coredump.h"
@@ -1906,12 +1906,12 @@ static km_hc_ret_t timerfd_create_hcall(void* vcpu, int hc, km_hc_args_t* arg)
  */
 static km_hc_ret_t timerfd_settime_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
-   const struct itimerspec *new_value = km_gva_to_kma(arg->arg3);
+   const struct itimerspec* new_value = km_gva_to_kma(arg->arg3);
    if (new_value == NULL) {
       arg->hc_ret = -EFAULT;
       return HC_CONTINUE;
    }
-   struct itimerspec *old_value = NULL;
+   struct itimerspec* old_value = NULL;
    if (arg->arg4 != 0) {
       old_value = km_gva_to_kma(arg->arg4);
       if (old_value == NULL) {
@@ -1928,7 +1928,7 @@ static km_hc_ret_t timerfd_settime_hcall(void* vcpu, int hc, km_hc_args_t* arg)
  */
 static km_hc_ret_t timerfd_gettime_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
-   struct itimerspec *curr_value = km_gva_to_kma(arg->arg2);
+   struct itimerspec* curr_value = km_gva_to_kma(arg->arg2);
    if (curr_value == NULL) {
       arg->hc_ret = -EFAULT;
       return HC_CONTINUE;

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -1937,47 +1937,6 @@ static km_hc_ret_t timerfd_gettime_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
-#if 0
-/*
- * long io_setup(unsigned int nr_events, aio_context_t *ctx_idp);
- */
-static km_hc_ret_t io_setup_hcall(void* vcpu, int hc, km_hc_args_t* arg)
-{
-}
-
-/*
- * int io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp);
- */
-static km_hc_ret_t io_submit_hcall(void* vcpu, int hc, km_hc_args_t* arg)
-{
-}
-
-/*
- * int syscall(SYS_io_cancel, aio_context_t ctx_id, struct iocb *iocb,
- *             struct io_event *result);
- */
-static km_hc_ret_t io_cancel_hcall(void* vcpu, int hc, km_hc_args_t* arg)
-{
-}
-
-/*
- * int syscall(SYS_io_cancel, aio_context_t ctx_id, struct iocb *iocb,
- *             struct io_event *result);
- */
-static km_hc_ret_t io_destroy_hcall(void* vcpu, int hc, km_hc_args_t* arg)
-{
-}
-
-/*
- * int syscall(SYS_io_getevents, aio_context_t ctx_id,
- *             long min_nr, long nr, struct io_event *events,
- *             struct timespec *timeout);
- */
-static km_hc_ret_t io_getevents_hcall(void* vcpu, int hc, km_hc_args_t* arg)
-{
-}
-#endif
-
 static km_hc_ret_t statfs_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
    char* pathname = km_gva_to_kma(arg->arg1);

--- a/tests/env_test.c
+++ b/tests/env_test.c
@@ -18,7 +18,7 @@
  * Simple test of env vars
  */
 #undef _FORTIFY_SOURCE   // TODO : this is needed on Ubuntu; to make right we need to define _
-//#define _GNU_SOURCE
+// #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Add support for setuid()/setgid() syscalls.
Using serge's implementation from another in progress changeset of his.

I looked at a km trace that serge got from running ngnix under km. We saw several things and this changes addresses some of them. We saw trying to add an fd that was already in use.  This seems to come from sendmsg/recvmsg using SCM_RIGHTS to pass fd's between processes.
I also see that nginx tries to use the timerfd_create() family of syscalls, so added those.
nginx also tries to use io_setup() et al syscalls.  I've added the stubbed out functions to support this but implementation is needed.