### PR TITLE
Add the aio io_*() syscalls to km and a simple test program

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -499,6 +499,8 @@ extern struct option km_cmd_long_options[];
 extern const_string_t km_cmd_short_options;
 extern int km_vcpus_are_started;
 extern int km_shrunken;
+extern unsigned int km_io_context_count;
+extern unsigned int km_io_active_count;
 
 void km_trace_fini(void);
 void km_trace_setup(int argc, char* argv[]);

--- a/km/km_coredump.c
+++ b/km/km_coredump.c
@@ -882,6 +882,16 @@ int km_dump_core(char* core_path,
       rc = EINVAL;
       goto out;
    }
+   if (dumptype == KM_DO_SNAP && km_io_context_count > 0) {
+      // io context id's are assigned by the kernel with io_setup().
+      // A resumed snapshot won't get the same id(s) when started up.
+      // So, we need to map io contexts between what the payload is
+      // using and what the kernel handed out.  When we add support
+      // for that we can snapshot payloads using asynch io.
+      km_warnx("Can't take a snapshot, %d active io contexts exist", km_io_context_count);
+      rc = EINVAL;
+      goto out;
+   }
 
    if ((notes_buffer = (char*)calloc(1, notes_length)) == NULL) {
       km_warn("cannot allocate notes buffer, %ld bytes, exiting", notes_length);

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -30,6 +30,7 @@
 #include <sys/utsname.h>
 #include <sys/wait.h>
 #include <asm/prctl.h>
+#include <linux/aio_abi.h>
 #include <linux/futex.h>
 #include <linux/stat.h>
 
@@ -2085,6 +2086,152 @@ static km_hc_ret_t mlock_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
+/*
+ * Count of the number of active io contexts.
+ * Count of the number of active io requests.
+ * Use this to prevent snapshots while io contexts are alive.
+ * The kernel supplies context id's in response to io_setup() calls.
+ * If we are going to snapshot asynch i/o the payload will have previously
+ * issue io contexts which km will need to match to newly created io contexts
+ * when a snapshot is resumed.
+ */
+unsigned int km_io_context_count = 0;   // the number of active io context's
+unsigned int km_io_active_count = 0;    // the number of running iocb's
+
+/*
+ * long io_setup(unsigned int nr_events, aio_context_t *ctx_idp);
+ */
+static km_hc_ret_t io_setup_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   void* ctx_idp = km_gva_to_kma(arg->arg2);
+   if (ctx_idp == NULL) {
+      arg->hc_ret = -EFAULT;
+   } else {
+      int rv = __syscall_2(SYS_io_setup, arg->arg1, (uint64_t)ctx_idp);
+      if (rv == 0) {
+         __atomic_add_fetch(&km_io_context_count, 1, __ATOMIC_SEQ_CST);
+         arg->hc_ret = 0;
+      } else {
+         arg->hc_ret = -errno;
+      }
+   }
+   return HC_CONTINUE;
+}
+
+/*
+ * int io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp);
+ */
+static km_hc_ret_t io_submit_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   struct iocb km_iocb_copy[arg->arg2];
+   struct iocb* km_iocb_list[arg->arg2];
+   struct iocb** local_iocbpp = km_gva_to_kma(arg->arg3);
+   if (local_iocbpp == NULL) {
+      arg->hc_ret = -EFAULT;
+      return HC_CONTINUE;
+   }
+
+   // xlate guest address in the iocb's to km address
+   for (int i = 0; i < arg->arg2; i++) {
+      km_iocb_copy[i] = *local_iocbpp[i];
+      km_iocb_list[i] = &km_iocb_copy[i];
+      km_iocb_copy[i].aio_buf = (uint64_t)km_gva_to_kma(local_iocbpp[i]->aio_buf);
+      if (km_iocb_copy[i].aio_buf == (uint64_t)NULL) {
+         arg->hc_ret = -EFAULT;
+         return HC_CONTINUE;
+      }
+   }
+   int reqs_submitted = __syscall_3(SYS_io_submit, arg->arg1, arg->arg2, (uint64_t)&km_iocb_list);
+   if (reqs_submitted >= 0) {
+      __atomic_add_fetch(&km_io_active_count, reqs_submitted, __ATOMIC_SEQ_CST);
+      arg->hc_ret = reqs_submitted;
+   } else {
+      arg->hc_ret = -errno;
+   }
+
+   // Give back kernel supplied values.
+   for (int i = 0; i < arg->arg2; i++) {
+      local_iocbpp[i]->aio_key = km_iocb_copy[i].aio_key;
+   }
+
+   return HC_CONTINUE;
+}
+
+/*
+ * int syscall(SYS_io_cancel, aio_context_t ctx_id, struct iocb *iocb,
+ *             struct io_event *result);
+ */
+static km_hc_ret_t io_cancel_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   struct iocb* local_iocbp = km_gva_to_kma(arg->arg2);
+   struct io_event* local_resultp = km_gva_to_kma(arg->arg3);
+   if (local_iocbp == NULL || local_resultp == NULL) {
+      arg->hc_ret = -EFAULT;
+      return HC_CONTINUE;
+   }
+   km_infox(KM_TRACE_HC, "io context 0x%lx, iocb %p, io_event %p", arg->arg1, local_iocbp, local_resultp);
+   int rv = __syscall_3(SYS_io_cancel, arg->arg1, (uint64_t)local_iocbp, (uint64_t)local_resultp);
+   if (rv >= 0) {
+      arg->hc_ret = 0;
+      __atomic_sub_fetch(&km_io_active_count, 1, __ATOMIC_SEQ_CST);
+   } else {
+      arg->hc_ret = -errno;
+   }
+   return HC_CONTINUE;
+}
+
+/*
+ * int syscall(SYS_io_destroy, aio_context_t ctx_id);
+ */
+static km_hc_ret_t io_destroy_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   int rv = __syscall_1(SYS_io_destroy, arg->arg1);
+   if (rv == 0) {
+      km_assert(__atomic_load_n(&km_io_context_count, __ATOMIC_SEQ_CST) > 0);
+      __atomic_sub_fetch(&km_io_context_count, 1, __ATOMIC_SEQ_CST);
+      arg->hc_ret = 0;
+   } else {
+      arg->hc_ret = -errno;
+   }
+   return HC_CONTINUE;
+}
+
+/*
+ * int syscall(SYS_io_getevents, aio_context_t ctx_id,
+ *             long min_nr, long nr, struct io_event *events,
+ *             struct timespec *timeout);
+ */
+static km_hc_ret_t io_getevents_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   struct events* local_eventsp = km_gva_to_kma(arg->arg4);
+   struct timeout* local_timeoutp = NULL;
+   if (local_eventsp == NULL) {
+      arg->hc_ret = -EFAULT;
+      return HC_CONTINUE;
+   }
+   if (arg->arg5 != 0) {
+      local_timeoutp = km_gva_to_kma(arg->arg5);
+      if (local_timeoutp == NULL) {
+         arg->hc_ret = -EFAULT;
+         return HC_CONTINUE;
+      }
+   }
+
+   int rv = __syscall_5(SYS_io_getevents,
+                        arg->arg1,
+                        arg->arg2,
+                        arg->arg3,
+                        (uint64_t)local_eventsp,
+                        (uint64_t)local_timeoutp);
+   if (rv >= 0) {
+      __atomic_sub_fetch(&km_io_active_count, rv, __ATOMIC_SEQ_CST);
+      arg->hc_ret = rv;
+   } else {
+      arg->hc_ret = -errno;
+   }
+   return HC_CONTINUE;
+}
+
 km_hc_stats_t* km_hcalls_stats;
 const km_hcall_fn_t km_hcalls_table[KM_MAX_HCALL] = {
     [SYS_arch_prctl] = arch_prctl_hcall,
@@ -2265,6 +2412,12 @@ const km_hcall_fn_t km_hcalls_table[KM_MAX_HCALL] = {
     [SYS_inotify_init] = inotify_init_hcall,
     [SYS_inotify_init1] = inotify_init1_hcall,
     [SYS_mlock] = mlock_hcall,
+
+    [SYS_io_setup] = io_setup_hcall,
+    [SYS_io_submit] = io_submit_hcall,
+    [SYS_io_cancel] = io_cancel_hcall,
+    [SYS_io_getevents] = io_getevents_hcall,
+    [SYS_io_destroy] = io_destroy_hcall,
 
     [HC_guest_interrupt] = guest_interrupt_hcall,
     [HC_unmapself] = unmapself_hcall,

--- a/tests/aio_test.c
+++ b/tests/aio_test.c
@@ -1,11 +1,13 @@
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <sys/uio.h>
 #include <linux/aio_abi.h>
 
 /*
@@ -28,10 +30,319 @@ void usage(void)
    fprintf(stderr, "       number_of_files can be 1 - %d\n", MAX_FDS);
 }
 
+int io_submit_sync(aio_context_t iocontext,
+                   int fdsync,
+                   long nf,
+                   int fdlist[],
+                   struct iocb** iocblist,
+                   struct io_event* eventlist)
+{
+   // Try out IOCB_CMD_FSYNC and IOCB_CMD_FDSYNC
+   int rc;
+   char* synctype = (fdsync != 0) ? "IOCB_CMD_FDSYNC" : "IOCB_CMD_FSYNC";
+   for (int i = 0; i < nf; i++) {
+      struct iocb* iocbp = iocblist[i];
+      iocbp->aio_data = i;
+      iocbp->aio_key = 0;
+      iocbp->aio_rw_flags = 0;
+      iocbp->aio_lio_opcode = (fdsync != 0) ? IOCB_CMD_FDSYNC : IOCB_CMD_FSYNC;
+      iocbp->aio_reqprio = 0;
+      iocbp->aio_fildes = fdlist[i];
+      iocbp->aio_buf = 0;
+      iocbp->aio_nbytes = 0;
+      iocbp->aio_offset = 0;
+      iocbp->aio_flags = 0;
+      iocbp->aio_resfd = -1;
+      iocbp->aio_reserved2 = 0;
+   }
+   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
+   if (rc < 0) {
+      fprintf(stderr, "SYS_io_submit for %s failed, %s\n", synctype, strerror(errno));
+      return errno;
+   }
+   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
+   if (rc < 0) {
+      fprintf(stderr, "SYS_io_getevents %s failed, %s\n", synctype, strerror(errno));
+      return errno;
+   }
+   fprintf(stdout, "io_getevents returned %d %s events\n", rc, synctype);
+   return 0;
+}
+
+int io_submit_pwrite(aio_context_t iocontext,
+                     long nf,
+                     int fdlist[],
+                     struct iocb** iocblist,
+                     struct io_event* eventlist,
+                     unsigned char* buffer,
+                     int chunksize)
+{
+   long rc;
+
+   // fill in write iocb's
+   for (int i = 0; i < nf; i++) {
+      struct iocb* iocbp = iocblist[i];
+      iocbp->aio_data = i;
+      iocbp->aio_rw_flags = 0;
+      iocbp->aio_lio_opcode = IOCB_CMD_PWRITE;
+      iocbp->aio_reqprio = 0;
+      iocbp->aio_fildes = fdlist[i];
+      iocbp->aio_buf = (__u64)&buffer[i * chunksize];
+      iocbp->aio_nbytes = chunksize;
+      iocbp->aio_offset = i * chunksize;
+      iocbp->aio_flags = 0;
+      iocbp->aio_resfd = -1;
+      iocbp->aio_reserved2 = 0;
+   }
+
+   // start the i/o
+   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "SYS_io_submit for pwrite's failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "io_submit started %ld pwrite's\n", rc);
+
+   // wait for io to complete
+   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "SYS_io_getevents failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "io_getevents returned %ld pwrite's events\n", rc);
+   return 0;
+}
+
+int io_submit_pwritev(aio_context_t iocontext,
+                      long nf,
+                      int fdlist[],
+                      struct iocb** iocblist,
+                      struct io_event* eventlist,
+                      unsigned char* buffer,
+                      int chunksize)
+{
+   long rc;
+   struct iovec iovec[MAX_FDS];
+
+   // fill in write iocb's
+   for (int i = 0; i < nf; i++) {
+      struct iovec* iovecp = &iovec[i];
+      iovecp->iov_base = &buffer[i * chunksize];
+      iovecp->iov_len = chunksize;
+
+      struct iocb* iocbp = iocblist[i];
+      iocbp->aio_data = i;
+      iocbp->aio_rw_flags = 0;
+      iocbp->aio_lio_opcode = IOCB_CMD_PWRITEV;
+      iocbp->aio_reqprio = 0;
+      iocbp->aio_fildes = fdlist[i];
+      iocbp->aio_buf = (__u64)iovecp;
+      iocbp->aio_nbytes = 1;
+      iocbp->aio_offset = i * chunksize;
+      iocbp->aio_flags = 0;
+      iocbp->aio_resfd = -1;
+      iocbp->aio_reserved2 = 0;
+   }
+
+   // start the i/o
+   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "SYS_io_submit for pwritev's failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "io_submit started %ld pwritev's io's\n", rc);
+
+   // wait for io to complete
+   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "SYS_io_getevents failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "io_getevents returned %ld pwritev events\n", rc);
+   return 0;
+}
+
+int io_submit_pread(aio_context_t iocontext,
+                    long nf,
+                    int fdlist[],
+                    struct iocb** iocblist,
+                    struct io_event* eventlist,
+                    unsigned char* buffer,
+                    int chunksize)
+{
+   long rc;
+
+   // setup iocb's to read data back into buffer
+   for (int i = 0; i < nf; i++) {
+      struct iocb* iocbp = iocblist[i];
+      iocbp->aio_data = i;
+      iocbp->aio_rw_flags = 0;
+      iocbp->aio_lio_opcode = IOCB_CMD_PREAD;
+      iocbp->aio_reqprio = 0;
+      iocbp->aio_fildes = fdlist[i];
+      iocbp->aio_buf = (__u64)&buffer[i * chunksize];
+      iocbp->aio_nbytes = chunksize;
+      iocbp->aio_offset = i * chunksize;
+      iocbp->aio_flags = 0;
+      iocbp->aio_resfd = -1;
+      iocbp->aio_reserved2 = 0;
+   }
+
+   // start i/o to read data
+   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "io_submit for pread's failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "io_submit started %ld pread's\n", rc);
+
+   // wait for reads to complete
+   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "io_getevent looking for active reads failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "%ld of %ld pread's have completed\n", rc, nf);
+   return 0;
+}
+
+int io_submit_preadv(aio_context_t iocontext,
+                     long nf,
+                     int fdlist[],
+                     struct iocb** iocblist,
+                     struct io_event* eventlist,
+                     unsigned char* buffer,
+                     int chunksize)
+{
+   long rc;
+   struct iovec iovec[MAX_FDS];
+
+   // setup iocb's to read data back into buffer
+   for (int i = 0; i < nf; i++) {
+      struct iovec* iovecp = &iovec[i];
+      iovecp->iov_base = &buffer[i * chunksize];
+      iovecp->iov_len = chunksize;
+
+      struct iocb* iocbp = iocblist[i];
+      iocbp->aio_data = i;
+      iocbp->aio_rw_flags = 0;
+      iocbp->aio_lio_opcode = IOCB_CMD_PREADV;
+      iocbp->aio_reqprio = 0;
+      iocbp->aio_fildes = fdlist[i];
+      iocbp->aio_buf = (__u64)iovecp;
+      iocbp->aio_nbytes = 1;
+      iocbp->aio_offset = i * chunksize;
+      iocbp->aio_flags = 0;
+      iocbp->aio_resfd = -1;
+      iocbp->aio_reserved2 = 0;
+   }
+
+   // start i/o to read data
+   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "io_submit for preadv's failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "io_submit started %ld preadv's\n", rc);
+
+   // wait for reads to complete
+   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "io_getevent looking for active preadv's failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "%ld of %ld preadv's have completed\n", rc, nf);
+   return 0;
+}
+
+void print_io_events(long nf, struct io_event* eventlist)
+{
+   for (int i = 0; i < nf; i++) {
+      fprintf(stdout,
+              "io_event[%d]: data %llu, obj 0x%llx, res 0x%llx, res2 0x%llx\n",
+              i,
+              eventlist[i].data,
+              eventlist[i].obj,
+              eventlist[i].res,
+              eventlist[i].res2);
+   }
+}
+
+int io_submit_poll(aio_context_t iocontext,
+                   long nf,
+                   int* fdlist,
+                   struct iocb** iocblist,
+                   struct io_event* eventlist,
+                   int pollflags)
+{
+   long rc;
+
+   // setup iocb's to poll for fd readiness
+   for (int i = 0; i < nf; i++) {
+      struct iocb* iocbp = iocblist[i];
+      iocbp->aio_data = i;
+      iocbp->aio_rw_flags = 0;
+      iocbp->aio_lio_opcode = IOCB_CMD_POLL;
+      iocbp->aio_reqprio = 0;
+      iocbp->aio_fildes = fdlist[i];
+      iocbp->aio_buf = (__u64)pollflags;
+      iocbp->aio_nbytes = 0;
+      iocbp->aio_offset = 0;
+      iocbp->aio_flags = 0;
+      iocbp->aio_resfd = -1;
+      iocbp->aio_reserved2 = 0;
+   }
+   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
+   if (rc < 0) {
+      rc = errno;
+      return rc;
+   }
+   fprintf(stdout, "io_submit started %ld poll's\n", rc);
+
+   // wait for polls to complete
+   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
+   if (rc < 0) {
+      rc = errno;
+      fprintf(stderr, "io_getevent looking for active poll's failed, %s\n", strerror(errno));
+      return rc;
+   }
+   fprintf(stdout, "%ld of %ld poll's have completed\n", rc, nf);
+   return 0;
+}
+
+int verify_buffer_contents(long nf, unsigned char* buffer, int chunksize)
+{
+   int miscompares = 0;
+   // verify buffer contents
+   fprintf(stdout, "Verify %ld buffer contents\n", nf);
+   for (int i = 0; i < nf; i++) {
+      for (int j = 0; j < chunksize; j++) {
+         if (buffer[i * chunksize + j] != (unsigned char)i) {
+            fprintf(stderr,
+                    "fd %d, offset %d, should contain %d but contains %u\n",
+                    i,
+                    j,
+                    i,
+                    buffer[i * chunksize + j]);
+            miscompares++;
+         }
+      }
+   }
+   fprintf(stdout, "Found %d miscompares\n", miscompares);
+   return miscompares;
+}
+
 int main(int argc, char* argv[])
 {
    int nf;
-   int cancelcount;
    long rc = 0;
    int chunksize = CHUNKSIZE;
    unsigned char buffer[MAX_FDS * CHUNKSIZE];
@@ -56,7 +367,6 @@ int main(int argc, char* argv[])
    fprintf(stdout, "Using %d files for this test run\n", nf);
 
    // create data for test file contents and open test files
-   // and setup async io control blocks.
    for (int i = 0; i < nf; i++) {
       // fill buffer
       memset(&buffer[i * chunksize], i, chunksize);
@@ -69,159 +379,104 @@ int main(int argc, char* argv[])
          goto done;
       }
 
-      // fill in iocb
-      iocb[i].aio_data = i;
-      iocb[i].aio_rw_flags = 0;
-      iocb[i].aio_lio_opcode = IOCB_CMD_PWRITE;
-      iocb[i].aio_reqprio = 0;
-      iocb[i].aio_fildes = fdlist[i];
-      iocb[i].aio_buf = (__u64)&buffer[i * chunksize];
-      iocb[i].aio_nbytes = chunksize;
-      iocb[i].aio_offset = i * chunksize;
-      iocb[i].aio_flags = 0;
-      iocb[i].aio_resfd = -1;
-      iocb[i].aio_reserved2 = 0;
       iocblist[i] = &iocb[i];
    }
 
    // create io context.
    rc = syscall(SYS_io_setup, 2 * nf, &iocontext);
    if (rc != 0) {
+      rc = errno;
       fprintf(stderr, "SYS_io_setup failed, %s\n", strerror(errno));
       goto done;
    }
    fprintf(stdout, "IO Context 0x%lx created\n", iocontext);
 
-   // start the i/o
-   rc = syscall(SYS_io_submit, iocontext, nf, &iocblist);
-   if (rc < 0) {
-      fprintf(stderr, "SYS_io_submit for writes failed, %s\n", strerror(errno));
+   // Try out IOCB_CMD_PWRITE
+   if ((rc = io_submit_pwrite(iocontext, nf, fdlist, iocblist, eventlist, buffer, chunksize)) != 0) {
       goto done;
    }
-   fprintf(stdout, "io_submit started %ld write io's\n", rc);
 
-   // wait for io to complete
-   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
-   if (rc < 0) {
-      fprintf(stderr, "SYS_io_getevents failed, %s\n", strerror(errno));
+   // Try out IOCB_CMD_FDSYNC
+   if ((rc = io_submit_sync(iocontext, 1, nf, fdlist, iocblist, eventlist)) != 0) {
       goto done;
    }
-   fprintf(stdout, "io_getevents returned %ld write events\n", rc);
+   // Try out IOCB_CMD_FSYNC
+   if ((rc = io_submit_sync(iocontext, 0, nf, fdlist, iocblist, eventlist)) != 0) {
+      goto done;
+   }
 
    // Clear our buffer before reading into it.
    memset(buffer, 0xff, sizeof(buffer));
 
-   // setup iocb to read data back into buffer
-   // I think we only need to set aio_lio_opcode here.
-   for (int i = 0; i < nf; i++) {
-      iocb[i].aio_fildes = fdlist[i];
-      iocb[i].aio_buf = (__u64)&buffer[i * chunksize];
-      iocb[i].aio_lio_opcode = IOCB_CMD_PREAD;
-      iocb[i].aio_nbytes = chunksize;
-      iocb[i].aio_offset = i * chunksize;
-      iocb[i].aio_reserved2 = 0;
-   }
-
-   // start i/o to read data
-   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
-   if (rc < 0) {
-      fprintf(stderr, "io_submit for reads failed, %s\n", strerror(errno));
+   if ((rc = io_submit_pread(iocontext, nf, fdlist, iocblist, eventlist, buffer, chunksize)) != 0) {
       goto done;
    }
-   fprintf(stdout, "io_submit started %ld reads\n", rc);
-   cancelcount = 0;
-
-   // Find out if any reads are still active.
-   struct timespec ts = {0, 0};
-   rc = syscall(SYS_io_getevents, iocontext, 0, nf, &eventlist, &ts);
-   if (rc < 0) {
-      fprintf(stderr, "io_getevent looking for active reads failed, %s\n", strerror(errno));
+   // Verify buffer contents
+   if (verify_buffer_contents(nf, buffer, chunksize) != 0) {
+      rc = EINVAL;
       goto done;
    }
-   fprintf(stdout, "%ld of %d reads have completed\n", rc, nf);
-   for (int i = 0; i < nf; i++) {
-      fprintf(stderr,
-              "io_event@%p: data 0x%llx, obj 0x%llx, res %lld, res2 %lld\n",
-              &eventlist[i],
-              eventlist[i].data,
-              eventlist[i].obj,
-              eventlist[i].res,
-              eventlist[i].res2);
-   }
-   // If some reads are pending, try canceling one of them
-   if (rc < nf) {
-      // Find a still running read
-      char doneread[MAX_FDS] = {0};
-      for (int i = 0; i < rc; i++) {
-         doneread[eventlist[i].obj] = 1;
-      }
-      int found = -1;
-      for (int i = 0; i < nf; i++) {
-         if (doneread[i] == 0) {
-            found = i;
-            break;
-         }
-      }
-      fprintf(stdout, "read for iocb[%d] is still active, trying to cancel\n", found);
-      memset(&eventlist[found], 0, sizeof(struct io_event));
-      rc = syscall(SYS_io_cancel, iocontext, iocblist[found], &eventlist[found]);
-      if (rc < 0) {
-         fprintf(stderr,
-                 "io_cancel for read iocb %d, with context id 0x%lx failed, %s\n",
-                 found,
-                 iocontext,
-                 strerror(errno));
-         if (errno != EINVAL) {
-            goto done;
-         }
-         // io_cancel() seems to fail with EINVAL even when the iocontext is valid.
-         // I assume this means the io was not canceled.
-         fprintf(stdout, "The read seems to have completed before we could cancel it\n");
-      } else {
-         fprintf(stdout, "io_cancel iocb[%d] success\n", found);
-         cancelcount++;
-      }
 
-      // wait for any remaining io to complete
-      rc = syscall(SYS_io_getevents, iocontext, 0, nf, &eventlist, NULL);
-      if (rc < 0) {
-         fprintf(stderr, "io_getevent for reads failed, %s\n", strerror(errno));
+   // Truncate the test files.
+   fprintf(stdout, "Truncate test files before writing\n");
+   for (int i = 0; i < nf; i++) {
+      if (ftruncate(fdlist[i], 0) < 0) {
+         rc = errno;
+         fprintf(stderr, "Couldn't truncate fd %d, %s\n", fdlist[i], strerror(errno));
          goto done;
       }
-      fprintf(stdout, "%ld read io's completed\n", rc);
-      for (int i = 0; i < rc; i++) {
-         fprintf(stdout,
-                 "io_event[%d]: data 0x%llx, obj 0x%llx, res %lld, res2 %lld\n",
-                 i,
-                 eventlist[i].data,
-                 eventlist[i].obj,
-                 eventlist[i].res,
-                 eventlist[i].res2);
-      }
-   } else {
-      fprintf(stdout, "No outstanding reads, will not test io_cancel()\n");
    }
 
-   // verify buffer contents
-   // Since we may cancel the last io operation, we don't know if the io completed
-   // or not.  So, we don't always verify its buffer contents.
-   fprintf(stdout, "Verify %d buffer contents after read\n", nf - cancelcount);
-   for (int i = 0; i < nf - cancelcount; i++) {
-      for (int j = 0; j < chunksize; j++) {
-         if (buffer[i * chunksize + j] != (unsigned char)i) {
-            fprintf(stderr,
-                    "fd %d, offset %d, should contain %d but contains %u\n",
-                    i,
-                    j,
-                    i,
-                    buffer[i * chunksize + j]);
-         }
+   // We don't reinitialize the buffer, we do depend on the values read in the preceding
+   // part of the test.  If you rearrange this code you may need to reinit the buffers.
+
+   // Try IOCB_CMD_PWRITEV
+   if ((rc = io_submit_pwritev(iocontext, nf, fdlist, iocblist, eventlist, buffer, chunksize)) != 0) {
+      goto done;
+   }
+
+   // Clear our buffer before reading into it.
+   memset(buffer, 0xff, sizeof(buffer));
+
+   // Try IOCB_CMD_PREADV
+   if ((rc = io_submit_preadv(iocontext, nf, fdlist, iocblist, eventlist, buffer, chunksize)) != 0) {
+      goto done;
+   }
+   // Verify buffer contents
+   if (verify_buffer_contents(nf, buffer, chunksize) != 0) {
+      rc = EINVAL;
+      goto done;
+   }
+
+   // Try IOCB_CMD_POLL
+   int pollflags = POLLIN | POLLOUT;
+   if ((rc = io_submit_poll(iocontext, nf, fdlist, iocblist, eventlist, pollflags)) != 0) {
+      goto done;
+   }
+   print_io_events(nf, eventlist);
+   for (int i = 0; i < nf; i++) {
+      if (eventlist[i].res != pollflags) {
+         fprintf(stderr,
+                 "Unexpected poll event flags for file %d, got 0x%llx, expected 0x%x\n",
+                 i,
+                 eventlist[i].res,
+                 pollflags);
+         goto done;
       }
    }
+   fprintf(stdout, "asynch poll returned expected results\n");
+
+   // Try io_cancel()  (someday)
+   // We need to find a very slow disk type device or swamp a fast one so that
+   // requests are delayed long enough for us to cancel them.  One wonders how we
+   // will be able to test this in ci running in the cloud where latency is all
+   // over the map.
+   fprintf(stdout, "***** io_cancel() is not being tested for now *****\n");
 
    // destroy io context
    rc = syscall(SYS_io_destroy, iocontext);
    if (rc < 0) {
+      rc = errno;
       fprintf(stderr, "io_destroy failed, %s\n", strerror(errno));
       goto done;
    }
@@ -233,7 +488,7 @@ done:;
    // close and delete test files
    for (int i = 0; i < nf; i++) {
       if (fdlist[i] < 0) {
-         // If we didn't even finish opening files, stop where we stopped.
+         // If we didn't even finish opening files, stop where we failed.
          break;
       }
       close(fdlist[i]);

--- a/tests/aio_test.c
+++ b/tests/aio_test.c
@@ -1,0 +1,245 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/aio_abi.h>
+
+/*
+ * A simple test to exercise the io_*() system calls.
+ * Usage:
+ *   aio_test number_of_files
+ */
+
+#define TEST_FILENAME "/tmp/aio_file_%d_%d"
+
+// We only support up to 222 concurrent io's in this test.
+// Arbitrarily chosen.
+#define MAX_FDS 222
+// We write CHUNKSIZE bytes into each file for this test.
+#define CHUNKSIZE 4096
+char* progname = "noname";
+void usage(void)
+{
+   fprintf(stderr, "Usage: %s number_of_files\n", progname);
+   fprintf(stderr, "       number_of_files can be 1 - %d\n", MAX_FDS);
+}
+
+int main(int argc, char* argv[])
+{
+   int nf;
+   int cancelcount;
+   long rc = 0;
+   int chunksize = CHUNKSIZE;
+   unsigned char buffer[MAX_FDS * CHUNKSIZE];
+   int fdlist[MAX_FDS];
+   struct iocb iocb[MAX_FDS];
+   struct iocb* iocblist[MAX_FDS];
+   struct io_event eventlist[MAX_FDS];
+   aio_context_t iocontext;
+   char filename[128];
+
+   progname = argv[0];
+
+   if (argc != 2) {
+      usage();
+      return 1;
+   }
+   nf = atoi(argv[1]);
+   if (nf <= 0 || nf > MAX_FDS) {
+      usage();
+      return 1;
+   }
+   fprintf(stdout, "Using %d files for this test run\n", nf);
+
+   // create data for test file contents and open test files
+   // and setup async io control blocks.
+   for (int i = 0; i < nf; i++) {
+      // fill buffer
+      memset(&buffer[i * chunksize], i, chunksize);
+
+      // open files, pid may not be unique in a container
+      snprintf(filename, sizeof(filename), TEST_FILENAME, getpid(), i);
+      fdlist[i] = open(filename, O_CREAT | O_RDWR | O_TRUNC, 0777);
+      if (fdlist[i] < 0) {
+         fprintf(stderr, "Can't create %s, %s\n", filename, strerror(errno));
+         goto done;
+      }
+
+      // fill in iocb
+      iocb[i].aio_data = i;
+      iocb[i].aio_rw_flags = 0;
+      iocb[i].aio_lio_opcode = IOCB_CMD_PWRITE;
+      iocb[i].aio_reqprio = 0;
+      iocb[i].aio_fildes = fdlist[i];
+      iocb[i].aio_buf = (__u64)&buffer[i * chunksize];
+      iocb[i].aio_nbytes = chunksize;
+      iocb[i].aio_offset = i * chunksize;
+      iocb[i].aio_flags = 0;
+      iocb[i].aio_resfd = -1;
+      iocb[i].aio_reserved2 = 0;
+      iocblist[i] = &iocb[i];
+   }
+
+   // create io context.
+   rc = syscall(SYS_io_setup, 2 * nf, &iocontext);
+   if (rc != 0) {
+      fprintf(stderr, "SYS_io_setup failed, %s\n", strerror(errno));
+      goto done;
+   }
+   fprintf(stdout, "IO Context 0x%lx created\n", iocontext);
+
+   // start the i/o
+   rc = syscall(SYS_io_submit, iocontext, nf, &iocblist);
+   if (rc < 0) {
+      fprintf(stderr, "SYS_io_submit for writes failed, %s\n", strerror(errno));
+      goto done;
+   }
+   fprintf(stdout, "io_submit started %ld write io's\n", rc);
+
+   // wait for io to complete
+   rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
+   if (rc < 0) {
+      fprintf(stderr, "SYS_io_getevents failed, %s\n", strerror(errno));
+      goto done;
+   }
+   fprintf(stdout, "io_getevents returned %ld write events\n", rc);
+
+   // Clear our buffer before reading into it.
+   memset(buffer, 0xff, sizeof(buffer));
+
+   // setup iocb to read data back into buffer
+   // I think we only need to set aio_lio_opcode here.
+   for (int i = 0; i < nf; i++) {
+      iocb[i].aio_fildes = fdlist[i];
+      iocb[i].aio_buf = (__u64)&buffer[i * chunksize];
+      iocb[i].aio_lio_opcode = IOCB_CMD_PREAD;
+      iocb[i].aio_nbytes = chunksize;
+      iocb[i].aio_offset = i * chunksize;
+      iocb[i].aio_reserved2 = 0;
+   }
+
+   // start i/o to read data
+   rc = syscall(SYS_io_submit, iocontext, nf, iocblist);
+   if (rc < 0) {
+      fprintf(stderr, "io_submit for reads failed, %s\n", strerror(errno));
+      goto done;
+   }
+   fprintf(stdout, "io_submit started %ld reads\n", rc);
+   cancelcount = 0;
+
+   // Find out if any reads are still active.
+   struct timespec ts = {0, 0};
+   rc = syscall(SYS_io_getevents, iocontext, 0, nf, &eventlist, &ts);
+   if (rc < 0) {
+      fprintf(stderr, "io_getevent looking for active reads failed, %s\n", strerror(errno));
+      goto done;
+   }
+   fprintf(stdout, "%ld of %d reads have completed\n", rc, nf);
+   for (int i = 0; i < nf; i++) {
+      fprintf(stderr,
+              "io_event@%p: data 0x%llx, obj 0x%llx, res %lld, res2 %lld\n",
+              &eventlist[i],
+              eventlist[i].data,
+              eventlist[i].obj,
+              eventlist[i].res,
+              eventlist[i].res2);
+   }
+   // If some reads are pending, try canceling one of them
+   if (rc < nf) {
+      // Find a still running read
+      char doneread[MAX_FDS] = {0};
+      for (int i = 0; i < rc; i++) {
+         doneread[eventlist[i].obj] = 1;
+      }
+      int found = -1;
+      for (int i = 0; i < nf; i++) {
+         if (doneread[i] == 0) {
+            found = i;
+            break;
+         }
+      }
+      fprintf(stdout, "read for iocb[%d] is still active, trying to cancel\n", found);
+      memset(&eventlist[found], 0, sizeof(struct io_event));
+      rc = syscall(SYS_io_cancel, iocontext, iocblist[found], &eventlist[found]);
+      if (rc < 0) {
+         fprintf(stderr,
+                 "io_cancel for read iocb %d, with context id 0x%lx failed, %s\n",
+                 found,
+                 iocontext,
+                 strerror(errno));
+         if (errno != EINVAL) {
+            goto done;
+         }
+         // io_cancel() seems to fail with EINVAL even when the iocontext is valid.
+         // I assume this means the io was not canceled.
+         fprintf(stdout, "The read seems to have completed before we could cancel it\n");
+      } else {
+         fprintf(stdout, "io_cancel iocb[%d] success\n", found);
+         cancelcount++;
+      }
+
+      // wait for any remaining io to complete
+      rc = syscall(SYS_io_getevents, iocontext, 0, nf, &eventlist, NULL);
+      if (rc < 0) {
+         fprintf(stderr, "io_getevent for reads failed, %s\n", strerror(errno));
+         goto done;
+      }
+      fprintf(stdout, "%ld read io's completed\n", rc);
+      for (int i = 0; i < rc; i++) {
+         fprintf(stdout,
+                 "io_event[%d]: data 0x%llx, obj 0x%llx, res %lld, res2 %lld\n",
+                 i,
+                 eventlist[i].data,
+                 eventlist[i].obj,
+                 eventlist[i].res,
+                 eventlist[i].res2);
+      }
+   } else {
+      fprintf(stdout, "No outstanding reads, will not test io_cancel()\n");
+   }
+
+   // verify buffer contents
+   // Since we may cancel the last io operation, we don't know if the io completed
+   // or not.  So, we don't always verify its buffer contents.
+   fprintf(stdout, "Verify %d buffer contents after read\n", nf - cancelcount);
+   for (int i = 0; i < nf - cancelcount; i++) {
+      for (int j = 0; j < chunksize; j++) {
+         if (buffer[i * chunksize + j] != (unsigned char)i) {
+            fprintf(stderr,
+                    "fd %d, offset %d, should contain %d but contains %u\n",
+                    i,
+                    j,
+                    i,
+                    buffer[i * chunksize + j]);
+         }
+      }
+   }
+
+   // destroy io context
+   rc = syscall(SYS_io_destroy, iocontext);
+   if (rc < 0) {
+      fprintf(stderr, "io_destroy failed, %s\n", strerror(errno));
+      goto done;
+   }
+   fprintf(stdout, "IO Context 0x%lx destroyed\n", iocontext);
+
+   fprintf(stdout, "Test completed with no errors\n");
+
+done:;
+   // close and delete test files
+   for (int i = 0; i < nf; i++) {
+      if (fdlist[i] < 0) {
+         // If we didn't even finish opening files, stop where we stopped.
+         break;
+      }
+      close(fdlist[i]);
+      snprintf(filename, sizeof(filename), TEST_FILENAME, getpid(), i);
+      unlink(filename);
+   }
+
+   return rc;
+}

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1775,3 +1775,8 @@ EOF
    # cleanup mgtdir
    rm -fr $MGTDIR $NPDATA
 }
+
+@test "aio($test_type): exercise io_*() syscalls (aio_test$ext)" {
+   km_with_timeout aio_test$ext 13
+   assert_success
+}


### PR DESCRIPTION
The io_setup(), io_submit(), io_getevents(), io_cancel(), and io_destroy() hypercalls are added to km with this change. The bats aio_test program is added to exercise the hypercalls. I can't figure out how to make io_cancel() work.  It seems like the io request being canceled must be active.  If the io has completed, I assume it is nolonger cancelable and it returns an error code that doesn't tell me the io request has completed.

Putting this out for people to look at and comment on.