### PR TITLE
Allow a gdb to attach to a snapshot just before the snapshot is started

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -475,6 +475,7 @@ static const_string_t KM_MGTPIPE = "KM_MGTPIPE";
 static const_string_t KM_MGTDIR = "KM_MGTDIR";
 static const_string_t KM_KILL_UNIMPL_SCALL = "KM_KILL_UNIMPL_SCALL";
 static const_string_t KM_SNAP_LISTEN_TIMEOUT = "SNAP_LISTEN_TIMEOUT";
+static const_string_t KM_GDB_WAIT_BEFORE_SNAP_RESUME = "KM_GDB_WAIT_BEFORE_SNAP_RESUME";
 
 /*
  * Trivial trace control - with switch to turn on/off and on and a tag to match.

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -119,7 +119,7 @@ typedef struct km_nt_guest {
 typedef struct km_nt_guestv {
    Elf64_Word version;
    Elf64_Addr load_adjust;
-   Elf64_Addr dlopen;		// to get back to the list of loaded shared libraries
+   Elf64_Addr dlopen;   // to get back to the list of loaded shared libraries
    Elf64_Ehdr ehdr;
    // Followed by PHDR list and filename
 } km_nt_guestv_t;

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -112,6 +112,21 @@ typedef struct km_nt_guest {
 #define NT_KM_DYNLINKER 0x4b4d444c   // "KMDL" no null term
 
 /*
+ * New versioned km_nt_guest_t to allow us to add more fields
+ * when needed by adding a new version number
+ */
+#define KM_NT_GUESTV_VERSION 1
+typedef struct km_nt_guestv {
+   Elf64_Word version;
+   Elf64_Addr load_adjust;
+   Elf64_Addr dlopen;		// to get back to the list of loaded shared libraries
+   Elf64_Ehdr ehdr;
+   // Followed by PHDR list and filename
+} km_nt_guestv_t;
+#define NT_KM_GUESTV 0x4b4d4756       // "KMGV" no null term
+#define NT_KM_DYNLINKERV 0x4b4d4456   // "KMDV" no null term
+
+/*
  * Elf note for dup data
  */
 

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -378,8 +378,9 @@ void light_snap_listen(km_elf_t* e)
       }
    } while (snap_conn_sock < 0);
 
-   // reuse gdb socket numbers here, gdb setup is later when we done
-   km_snap_listening_state_p[i].accept_fd = km_internal_fd(snap_conn_sock, KM_GDB_ACCEPT);
+   // reuse mgmt socket fd number here, resumed snapshots currently don't have
+   // a mgmmt thread.
+   km_snap_listening_state_p[i].accept_fd = km_internal_fd(snap_conn_sock, KM_MGM_ACCEPT);
 }
 
 /*

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -3003,7 +3003,10 @@ void km_gdb_main_loop(km_vcpu_t* main_vcpu)
    km_wait_on_eventfd(machine.intr_fd);   // Wait for km_start_vcpus to be called
 
    km_assert(gdbstub.wait_for_attach != GDB_WAIT_FOR_ATTACH_UNSPECIFIED);
-   if (km_dynlinker.km_filename != NULL && gdbstub.wait_for_attach == GDB_WAIT_FOR_ATTACH_AT_START) {
+   // Resumed snapshots have dynamic linker info but we won't run the liner for a resumed snapshot,
+   // so don't wait for it in that case.
+   if (km_dynlinker.km_filename != NULL && km_snapshot_name == NULL &&
+       gdbstub.wait_for_attach == GDB_WAIT_FOR_ATTACH_AT_START) {
       km_gdb_wait_for_dynlink_to_finish();
    }
 

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -657,6 +657,10 @@ int main(int argc, char* argv[])
       }
       km_infox(KM_TRACE_SNAPSHOT, "Snapshot recover complete, pid %d", getpid());
       vcpu = machine.vm_vcpus[0];
+      if (getenv(KM_GDB_WAIT_BEFORE_SNAP_RESUME) != NULL) {
+         gdbstub.wait_for_attach = GDB_WAIT_FOR_ATTACH_AT_START;
+         km_gdb_enable(1);
+      }
    } else {
       // if environment wasn't set up copy it from host
       if (envp == NULL) {

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -364,7 +364,8 @@ static inline int km_ss_recover_payload(char* ptr, size_t length, km_payload_t* 
 static inline int km_ss_recover_guest(char* ptr, size_t length)
 {
    if (km_payload_guest != 0) {
-      km_warnx("Ignoring elf note NT_KM_GUEST in snapshot because another note has already been encountered");
+      km_warnx("Ignoring elf note NT_KM_GUEST in snapshot because another note has already been "
+               "encountered");
       return 0;
    }
    km_payload_guest = NT_KM_GUEST;
@@ -398,7 +399,8 @@ static inline int km_ss_recover_payloadv(char* ptr, size_t length, km_payload_t*
 static inline int km_ss_recover_guestv(char* ptr, size_t length)
 {
    if (km_payload_guest != 0) {
-      km_warnx("Ignoring elf note NT_KM_GUESTV in snapshot because another note has already been encountered");
+      km_warnx("Ignoring elf note NT_KM_GUESTV in snapshot because another note has already been "
+               "encountered");
       return 0;
    }
    km_payload_guest = NT_KM_GUESTV;


### PR DESCRIPTION
If a new km environment variable called KM_GDB_WAIT_BEFORE_SNAP_RESUME is supplied to the instance of km that is resuming a snapshot, km will pause to wait for gdb to attach before starting the snapshot.