### PR TITLE
Add snapshot support for contexts created by io_setup().

### DIFF
--- a/km/Makefile
+++ b/km/Makefile
@@ -22,7 +22,7 @@ SOURCES := load_elf.c km_cpu_init.c km_main.c km_vcpu_run.c km_hcalls.c km_mem.c
 		km_gdb_stub.c gdb_kvm_x86_64.c km_signal.c km_init_guest.c km_intr.c km_coredump.c \
 		km_filesys.c km_hc_name.c km_trace.c km_musl_related.c km_decode.c km_proc.c \
 		km_guest_asmcode.s km_snapshot.c km_exec.c km_fork.c km_management.c \
-		km_kkm.c km_vmdriver.c km_exec_fd_save_recover.c
+		km_kkm.c km_vmdriver.c km_exec_fd_save_recover.c km_iocontext.c
 VERSION_SRC := km_main.c # it has branch/version info, so rebuild it if git info changes
 INCLUDES := ${TOP}/include ${TOP}/lib/libkontain
 EXEC := km

--- a/km/km_coredump.h
+++ b/km/km_coredump.h
@@ -251,6 +251,19 @@ typedef struct km_nt_sighand {
 } km_nt_sighand_t;
 #define NT_KM_SIGHAND 0x4b4d5348   // "KMSH" no null term
 
+// Elf note for storing io contexts created with io_setup() in a snapshot file.
+typedef struct km_nt_iocontext {
+   Elf64_Word nr_events;    // max number of events for this context
+   Elf64_Xword iocontext;   // the io context id the payload knows
+} km_nt_iocontext_t;
+typedef struct km_nt_iocontexts {
+   Elf64_Word size;          // size of this note
+   Elf64_Word nr_contexts;   // number of contexts in context[]
+   Elf64_Xword piocontext;   // the next payload io context id to hand out
+   km_nt_iocontext_t contexts[0];
+} km_nt_iocontexts_t;
+#define NT_KM_IOCONTEXTS 0x4b4d4358   // "KMCX"
+
 // Core dump guest.
 typedef enum { KM_DO_CORE, KM_DO_SNAP } km_coredump_type_t;
 int km_dump_core(char* filename,

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -44,6 +44,7 @@
 #include <sys/uio.h>
 #include <sys/un.h>
 #include <arpa/inet.h>
+#include <linux/aio_abi.h>
 #include <netinet/in.h>
 
 #include "bsd_queue.h"
@@ -52,6 +53,7 @@
 #include "km_exec.h"
 #include "km_filesys.h"
 #include "km_filesys_private.h"
+#include "km_iocontext.h"
 #include "km_mem.h"
 #include "km_signal.h"
 #include "km_snapshot.h"
@@ -4056,6 +4058,9 @@ int km_fs_recover(char* notebuf, size_t notesize)
    }
    if (km_snapshot_notes_apply(notebuf, notesize, NT_KM_EPOLLFD, km_fs_recover_epollfd) < 0) {
       km_errx(2, "recover open epollfd's failed");
+   }
+   if (km_snapshot_notes_apply(notebuf, notesize, NT_KM_IOCONTEXTS, km_fs_recover_iocontexts) < 0) {
+      km_errx(2, "recover iocontexts failed");
    }
    return 0;
 }

--- a/km/km_iocontext.c
+++ b/km/km_iocontext.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2023 Kontain Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * To be able to use asynchronous i/o with snapshots km keeps its own asynch io context
+ * id space and passes thoses id's to the payload.  Payload asynch i/o calls use the
+ * km io context id's to the io_*() hypercalls.  When an io_setup() call is made into km,
+ * km will call lilnux's io_setup() to get a context id from the kernel, and then put the
+ * kernel and km context id's into an entry that maps between km /payload context id's and
+ * kernel context id's.  And will then pass the km io context id to the payload.
+ * Why is this done?
+ * Basically to allow resumed km payload snapshots to work with asynch i/o.
+ * The snapshoted payload's io context id's are created in the non-snapshot run of the payload
+ * but must work in the resumed snapshot so we can't let the payload have the kernel io context id's.
+ *
+ * When a snapshot is taken the map between kernel and payload context id's is stored in a
+ * NT_KM_IOCONTEXTS elf note.  The resumed snapshot recovers the map from that same note.
+ * The note also contains the km io context id counter so the resumed snapshot should not
+ * resuse an existing id.
+ */
+
+#include <errno.h>
+#include <sys/syscall.h>
+#include <linux/aio_abi.h>
+
+#include "bsd_queue.h"
+#include "km.h"
+#include "km_coredump.h"
+
+struct km_iocontext {
+   unsigned int kioc_maxevents;
+   aio_context_t kioc_kcontext;
+   aio_context_t kioc_pcontext;
+};
+typedef struct km_iocontext km_iocontext_t;
+
+pthread_mutex_t km_iocmutex = PTHREAD_MUTEX_INITIALIZER;
+size_t km_iocn;            // number of entries in the table km_iocp points to
+km_iocontext_t* km_iocp;   // map of kernel context id's and payload context id's
+aio_context_t km_piocontext = ((unsigned long)'k' << 56) | ((unsigned long)'m' << 48);
+
+// Called when a payload context is being recovered due to a snapshot resume.
+int km_iocontext_recover(unsigned int nr_events, aio_context_t pcontext)
+{
+   aio_context_t iocontext = 0;
+   int rc = syscall(SYS_io_setup, nr_events, &iocontext);
+   if (rc != 0) {
+      return errno;
+   }
+   km_mutex_lock(&km_iocmutex);
+   km_iocontext_t* t = realloc(km_iocp, (km_iocn + 1) * sizeof(km_iocontext_t));
+   if (t == NULL) {
+      km_mutex_unlock(&km_iocmutex);
+      if (syscall(SYS_io_destroy, iocontext) != 0) {
+         // Can't allocate memory and can't deallocate the iocontext!
+         km_warn("io_destroy() failed, io context 0x%lx orphaned", iocontext);
+      }
+      return ENOMEM;
+   }
+   t[km_iocn].kioc_maxevents = nr_events;
+   t[km_iocn].kioc_kcontext = iocontext;
+   t[km_iocn].kioc_pcontext = pcontext;
+   km_iocp = t;
+   km_iocn++;
+   km_mutex_unlock(&km_iocmutex);
+   return 0;
+}
+
+// Called when a payload is creating a new io context.
+// How to handle kernel reuse of an io context that the payload was using????
+int km_iocontext_add(unsigned int nr_events, aio_context_t* pcontextp)
+{
+   aio_context_t piocontext = __atomic_add_fetch(&km_piocontext, 1, __ATOMIC_SEQ_CST);
+   *pcontextp = piocontext;
+   return km_iocontext_recover(nr_events, piocontext);
+}
+
+// Removed the passed payload iocontext from the xlate table
+// We assume the caller will remove the io context
+int km_iocontext_remove(aio_context_t pcontext)
+{
+   size_t i;
+   km_mutex_lock(&km_iocmutex);
+   for (i = 0; i < km_iocn; i++) {
+      if (km_iocp[i].kioc_pcontext == pcontext) {
+         int rv = syscall(SYS_io_destroy, km_iocp[i].kioc_kcontext);
+         if (rv < 0) {
+            // We know the context id is valid but we can't delete it?
+            km_warn("Can't delete io context id 0x%lx, kernel context id: 0x%lx",
+                    km_iocp[i].kioc_pcontext,
+                    km_iocp[i].kioc_kcontext);
+            return errno;
+         }
+         // We don't shrink the memory area when freeing an io context.
+         memcpy(&km_iocp[i], &km_iocp[i + 1], (km_iocn - i - 1) * sizeof(km_iocontext_t));
+         km_iocn--;
+         km_mutex_unlock(&km_iocmutex);
+         return 0;
+      }
+   }
+   km_mutex_unlock(&km_iocmutex);
+   return EINVAL;
+}
+
+// translate a kernel io context to a payload io context.
+// I don' think we will need this function.
+// km_iocontext_xlate_k2p()
+
+// Translate a payload io context to a kernel io context.
+int km_iocontext_xlate_p2k(aio_context_t pcontext, aio_context_t* kcontext)
+{
+   size_t i;
+   km_mutex_lock(&km_iocmutex);
+   for (i = 0; i < km_iocn; i++) {
+      if (km_iocp[i].kioc_pcontext == pcontext) {
+         *kcontext = km_iocp[i].kioc_kcontext;
+         km_mutex_unlock(&km_iocmutex);
+         return 0;
+      }
+   }
+   km_mutex_unlock(&km_iocmutex);
+   // Unknown payload io context
+   return EINVAL;
+}
+
+// Figure out how much space the io context elf notes will need
+size_t km_fs_iocontext_notes_length(void)
+{
+   return km_note_header_size(KM_NT_NAME) + sizeof(km_nt_iocontexts_t) +
+          (km_iocn * sizeof(km_nt_iocontext_t));
+}
+
+// Write the io context elf note into buf.
+size_t km_fs_iocontext_notes_write(char* buf, size_t length)
+{
+   char* cur = buf;
+   size_t remain = length;
+
+   cur += km_add_note_header(cur,
+                             remain,
+                             KM_NT_NAME,
+                             NT_KM_IOCONTEXTS,
+                             km_fs_iocontext_notes_length() - km_note_header_size(KM_NT_NAME));
+   km_nt_iocontexts_t* iocnote = (km_nt_iocontexts_t*)cur;
+   iocnote->size = sizeof(km_nt_iocontexts_t) + (km_iocn * sizeof(km_nt_iocontext_t));
+   iocnote->nr_contexts = km_iocn;
+   iocnote->piocontext = km_piocontext;
+   cur += sizeof(km_nt_iocontexts_t);
+   for (int i = 0; i < km_iocn; i++) {
+      iocnote->contexts[i].nr_events = km_iocp[i].kioc_maxevents;
+      iocnote->contexts[i].iocontext = km_iocp[i].kioc_pcontext;
+      cur += sizeof(km_nt_iocontext_t);
+   }
+   return cur - buf;
+}
+
+// Recover the io contexts used by the payload
+int km_fs_recover_iocontexts(char* ptr, size_t length)
+{
+   int rc = 0;
+   km_nt_iocontexts_t* iocontexts = (km_nt_iocontexts_t*)ptr;
+   km_piocontext = iocontexts->piocontext;
+   for (int i = 0; i < iocontexts->nr_contexts; i++) {
+      rc = km_iocontext_recover(iocontexts->contexts[i].nr_events, iocontexts->contexts[i].iocontext);
+      if (rc != 0) {
+         rc = -rc;
+         break;
+      }
+   }
+   return rc;
+}
+
+void km_iocontext_init(void)
+{
+   km_iocn = 0;
+   km_iocp = NULL;
+}
+
+void km_iocontext_deinit(void)
+{
+   free(km_iocp);
+   km_iocn = 0;
+}

--- a/km/km_iocontext.c
+++ b/km/km_iocontext.c
@@ -33,6 +33,7 @@
  */
 
 #include <errno.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 #include <linux/aio_abi.h>
 

--- a/km/km_iocontext.h
+++ b/km/km_iocontext.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Kontain Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __KM_IOCONTEXT_H__
+#define __KM_IOCONTEXT_H__
+
+int km_iocontext_recover(unsigned int nr_events, aio_context_t pcontext);
+int km_iocontext_add(unsigned int nr_events, aio_context_t* pcontextp);
+int km_iocontext_remove(aio_context_t pcontext);
+int km_iocontext_xlate_p2k(aio_context_t pcontext, aio_context_t* kcontext);
+size_t km_fs_iocontext_notes_length(void);
+size_t km_fs_iocontext_notes_write(char* buf, size_t length);
+int km_fs_recover_iocontexts(char* ptr, size_t length);
+void km_iocontext_init(void);
+void km_iocontext_deinit(void);
+
+#endif   // !defined(__KM_IOCONTEXT_H__)

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -176,7 +176,17 @@ static inline void km_ss_recover_memory(int fd, km_gva_t tbrk_gva, km_payload_t*
                            fd,
                            phdr->p_offset - extra);
             if (m == MAP_FAILED) {
-               km_err(errno, "snapshot mmap[%d]: vaddr=0x%lx offset=0x%lx", i, phdr->p_vaddr, phdr->p_offset);
+               km_err(errno,
+                      "snapshot mmap[%d]: p_vaddr 0x%lx, extra 0x%lx, addr %p, size %lu, "
+                      "vaddr=0x%lx offset=0x%lx, prot 0x%x",
+                      i,
+                      phdr->p_vaddr,
+                      extra,
+                      addr,
+                      phdr->p_filesz + extra,
+                      phdr->p_vaddr,
+                      phdr->p_offset,
+                      prot_elf_to_mmap(phdr->p_flags));
             }
          }
       }

--- a/tests/aio_test.c
+++ b/tests/aio_test.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Kontain Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
@@ -6,6 +22,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
 #include <linux/aio_abi.h>
@@ -13,21 +30,78 @@
 /*
  * A simple test to exercise the io_*() system calls.
  * Usage:
- *   aio_test number_of_files
+ *   aio_test -f number_of_files -c number_of_iocontexts [-s]
+ *
+ * Env vars:
+ *  AIO_TEST_WORKDIR - the path to an existing directory where the
+ *     test files are created.  In addition, if the -s flag is used
+ *     the waiting/continue files to are expected to be created there.
+ *     Once the program is ready to be snapshotted it will creating
+ *     the file "waiting" and will begin looking for the file "continue".
+ *     Once the "continue" file appears, the program will remove both
+ *     files and continue with the tests.  The "waiting" file is created
+ *     after all test files and io contexts have been created and it is
+ *     safe to request a snapshot.
+ *     NOTE: this is not defining a protocol to be used for generating
+ *     snapshots.  We do this to allow easy testing of a snapshot using
+ *     io contexts.
  */
 
-#define TEST_FILENAME "/tmp/aio_file_%d_%d"
+#define TEST_FILENAME "%s/aio_file_%d_%d"
+#define WAITING_FILENAME "waiting"
+#define CONTINUE_FILENAME "continue"
 
 // We only support up to 222 concurrent io's in this test.
 // Arbitrarily chosen.
 #define MAX_FDS 222
 // We write CHUNKSIZE bytes into each file for this test.
 #define CHUNKSIZE 4096
+// Upper limit on the number of io contexts this program will create
+#define MAX_IOCONTEXTS 100
 char* progname = "noname";
 void usage(void)
 {
-   fprintf(stderr, "Usage: %s number_of_files\n", progname);
-   fprintf(stderr, "       number_of_files can be 1 - %d\n", MAX_FDS);
+   fprintf(stderr, "Usage: %s [-f number_of_files] [-c number_of_contexts] [-s]\n", progname);
+   fprintf(stderr, "       -f - number_of_files can be 1 - %d, default is 100\n", MAX_FDS);
+   fprintf(stderr, "       -c - number_of_contexts is limited to %d, default is 1\n", MAX_IOCONTEXTS);
+   fprintf(stderr, "       -ss - pause to wait for a snapshot request, defaul to no pause\n");
+   fprintf(stderr, "       -sf - pause to wait for a failing snapshot request, defaul to no pause\n");
+}
+
+char* workdir = NULL;
+
+/*
+ * Flag to indicate we should wait for a snapshot to be taken and where
+ * we should pause.
+ * 0 = don't pause for snapshot
+ * 1 = pause for a successful snapshot
+ * 2 = pause at a point where a failing snapshot should happen
+ *     (there is active asynch i/o)
+ */
+int waitforsnap = 0;
+
+// Helper routine to create a file signifying we are pausing for a snapshot
+// to be generated and then we wait to be told to continue.
+void pause_for_snapshot(void)
+{
+   char filename[128];
+   struct stat statb;
+
+   snprintf(filename, sizeof(filename), "%s/continue", workdir);
+   unlink(filename);
+   snprintf(filename, sizeof(filename), "%s/waiting", workdir);
+   if (mknod(filename, S_IFREG | 0755, 0) != 0) {
+      fprintf(stderr, "Unable to create %s file, %s\n", filename, strerror(errno));
+      exit(1);
+   }
+   // wait to be told to continue
+   snprintf(filename, sizeof(filename), "%s/continue", workdir);
+   fprintf(stdout, "Waiting for file %s to exist\n", filename);
+   while (stat(filename, &statb) < 0) {
+      sleep(1);
+   }
+   fprintf(stdout, "Continuing\n");
+   unlink(filename);
 }
 
 int io_submit_sync(aio_context_t iocontext,
@@ -103,6 +177,10 @@ int io_submit_pwrite(aio_context_t iocontext,
       return rc;
    }
    fprintf(stdout, "io_submit started %ld pwrite's\n", rc);
+
+   if (waitforsnap == 2) {
+      pause_for_snapshot();
+   }
 
    // wait for io to complete
    rc = syscall(SYS_io_getevents, iocontext, nf, nf, eventlist, NULL);
@@ -340,56 +418,17 @@ int verify_buffer_contents(long nf, unsigned char* buffer, int chunksize)
    return miscompares;
 }
 
-int main(int argc, char* argv[])
+int do_iocontext_test(aio_context_t iocontext,
+                      int nf,
+                      int* fdlist,
+                      struct iocb** iocblist,
+                      struct io_event* eventlist,
+                      unsigned char* buffer,
+                      int chunksize)
 {
-   int nf;
-   long rc = 0;
-   int chunksize = CHUNKSIZE;
-   unsigned char buffer[MAX_FDS * CHUNKSIZE];
-   int fdlist[MAX_FDS];
-   struct iocb iocb[MAX_FDS];
-   struct iocb* iocblist[MAX_FDS];
-   struct io_event eventlist[MAX_FDS];
-   aio_context_t iocontext;
-   char filename[128];
+   int rc;
 
-   progname = argv[0];
-
-   if (argc != 2) {
-      usage();
-      return 1;
-   }
-   nf = atoi(argv[1]);
-   if (nf <= 0 || nf > MAX_FDS) {
-      usage();
-      return 1;
-   }
-   fprintf(stdout, "Using %d files for this test run\n", nf);
-
-   // create data for test file contents and open test files
-   for (int i = 0; i < nf; i++) {
-      // fill buffer
-      memset(&buffer[i * chunksize], i, chunksize);
-
-      // open files, pid may not be unique in a container
-      snprintf(filename, sizeof(filename), TEST_FILENAME, getpid(), i);
-      fdlist[i] = open(filename, O_CREAT | O_RDWR | O_TRUNC, 0777);
-      if (fdlist[i] < 0) {
-         fprintf(stderr, "Can't create %s, %s\n", filename, strerror(errno));
-         goto done;
-      }
-
-      iocblist[i] = &iocb[i];
-   }
-
-   // create io context.
-   rc = syscall(SYS_io_setup, 2 * nf, &iocontext);
-   if (rc != 0) {
-      rc = errno;
-      fprintf(stderr, "SYS_io_setup failed, %s\n", strerror(errno));
-      goto done;
-   }
-   fprintf(stdout, "IO Context 0x%lx created\n", iocontext);
+   fprintf(stdout, "\n\n**** Begin test with iocontext 0x%lx\n", iocontext);
 
    // Try out IOCB_CMD_PWRITE
    if ((rc = io_submit_pwrite(iocontext, nf, fdlist, iocblist, eventlist, buffer, chunksize)) != 0) {
@@ -406,7 +445,7 @@ int main(int argc, char* argv[])
    }
 
    // Clear our buffer before reading into it.
-   memset(buffer, 0xff, sizeof(buffer));
+   memset(buffer, 0xff, nf * chunksize);
 
    if ((rc = io_submit_pread(iocontext, nf, fdlist, iocblist, eventlist, buffer, chunksize)) != 0) {
       goto done;
@@ -436,7 +475,7 @@ int main(int argc, char* argv[])
    }
 
    // Clear our buffer before reading into it.
-   memset(buffer, 0xff, sizeof(buffer));
+   memset(buffer, 0xff, nf * chunksize);
 
    // Try IOCB_CMD_PREADV
    if ((rc = io_submit_preadv(iocontext, nf, fdlist, iocblist, eventlist, buffer, chunksize)) != 0) {
@@ -466,6 +505,116 @@ int main(int argc, char* argv[])
    }
    fprintf(stdout, "asynch poll returned expected results\n");
 
+   fprintf(stdout, "**** test with iocontext 0x%lx succeeded\n", iocontext);
+done:;
+   return rc;
+}
+
+int main(int argc, char* argv[])
+{
+   int nf = 100;
+   int nc = 1;
+   long rc = 0;
+   int chunksize = CHUNKSIZE;
+   unsigned char buffer[MAX_FDS * CHUNKSIZE];
+   int fdlist[MAX_FDS];
+   struct iocb iocb[MAX_FDS];
+   struct iocb* iocblist[MAX_FDS];
+   struct io_event eventlist[MAX_FDS];
+   aio_context_t iocontext[MAX_IOCONTEXTS];
+   char filename[128];
+   struct stat statb;
+
+   progname = argv[0];
+
+   // Check for a workdir
+   workdir = getenv("AIO_TEST_WORKDIR");
+   if (workdir == NULL) {
+      workdir = "/tmp";
+   }
+
+   for (int i = 1; i < argc; i++) {
+      if (strcmp(argv[i], "-f") == 0) {
+         nf = atoi(argv[i + 1]);
+         if (nf <= 0 || nf > MAX_FDS) {
+            usage();
+            return 1;
+         }
+         i++;
+      } else if (strcmp(argv[i], "-c") == 0) {
+         nc = atoi(argv[i + 1]);
+         if (nc < 0 || nc > MAX_IOCONTEXTS) {
+            usage();
+            return 1;
+         }
+         i++;
+      } else if (strcmp(argv[i], "-ss") == 0) {
+         waitforsnap = 1;
+         snprintf(filename, sizeof(filename), "%s/waiting", workdir);
+         if (stat(filename, &statb) == 0) {
+            fprintf(stderr, "Flag file %s must not exist before the test is started\n", filename);
+            return 1;
+         }
+      } else if (strcmp(argv[i], "-sf") == 0) {
+         waitforsnap = 2;
+         snprintf(filename, sizeof(filename), "%s/waiting", workdir);
+         if (stat(filename, &statb) == 0) {
+            fprintf(stderr, "Flag file %s must not exist before the test is started\n", filename);
+            return 1;
+         }
+      } else {
+         fprintf(stderr, "Unknown command line flag %s\n", argv[i]);
+         usage();
+         return 1;
+      }
+   }
+   fprintf(stdout, "Using %d files and %d io contexts for this test run\n", nf, nc);
+
+   if (stat(workdir, &statb) != 0) {
+      fprintf(stderr, "workdir %s must exist\n", workdir);
+      return 1;
+   }
+   fprintf(stdout, "Using %s as our work directory\n", workdir);
+
+   // create data for test file contents and open test files
+   for (int i = 0; i < nf; i++) {
+      // fill buffer
+      memset(&buffer[i * chunksize], i, chunksize);
+
+      // open files, pid may not be unique in a container
+      snprintf(filename, sizeof(filename), TEST_FILENAME, workdir, getpid(), i);
+      fdlist[i] = open(filename, O_CREAT | O_RDWR | O_TRUNC, 0777);
+      if (fdlist[i] < 0) {
+         fprintf(stderr, "Can't create %s, %s\n", filename, strerror(errno));
+         goto done;
+      }
+
+      iocblist[i] = &iocb[i];
+   }
+
+   // create io contexts.
+   for (int i = 0; i < nc; i++) {
+      rc = syscall(SYS_io_setup, 2 * nf, &iocontext[i]);
+      if (rc != 0) {
+         rc = errno;
+         fprintf(stderr, "SYS_io_setup for context #%d failed, %s\n", i, strerror(errno));
+         goto done;
+      }
+      fprintf(stdout, "IO Context number %d: 0x%lx created\n", i, iocontext[i]);
+   }
+
+   // If requested pause to allow a snapshot to be taken
+   if (waitforsnap == 1) {
+      pause_for_snapshot();
+   }
+
+   for (int i = 0; i < nc; i++) {
+      if (do_iocontext_test(iocontext[i], nf, fdlist, iocblist, eventlist, buffer, chunksize) != 0) {
+         fprintf(stderr, "Test %d for iocontext 0x%lx failed\n", i, iocontext[i]);
+         goto done;
+      }
+   }
+
    // Try io_cancel()  (someday)
    // We need to find a very slow disk type device or swamp a fast one so that
    // requests are delayed long enough for us to cancel them.  One wonders how we
@@ -474,13 +623,15 @@ int main(int argc, char* argv[])
    fprintf(stdout, "***** io_cancel() is not being tested for now *****\n");
 
    // destroy io context
-   rc = syscall(SYS_io_destroy, iocontext);
-   if (rc < 0) {
-      rc = errno;
-      fprintf(stderr, "io_destroy failed, %s\n", strerror(errno));
-      goto done;
+   for (int i = 0; i < nc; i++) {
+      rc = syscall(SYS_io_destroy, iocontext[i]);
+      if (rc < 0) {
+         rc = errno;
+         fprintf(stderr, "io_destroy failed, %s\n", strerror(errno));
+         goto done;
+      }
+      fprintf(stdout, "IO Context %d:  0x%lx destroyed\n", i, iocontext[i]);
    }
-   fprintf(stdout, "IO Context 0x%lx destroyed\n", iocontext);
 
    fprintf(stdout, "Test completed with no errors\n");
 
@@ -492,7 +643,7 @@ done:;
          break;
       }
       close(fdlist[i]);
-      snprintf(filename, sizeof(filename), TEST_FILENAME, getpid(), i);
+      snprintf(filename, sizeof(filename), TEST_FILENAME, workdir, getpid(), i);
       unlink(filename);
    }
 


### PR DESCRIPTION
The io_setup() syscall creates an asynch i/o context and returns it to the caller. The payload has no way to control what value for the context is returned.  For snapshot of asynch io to work we must allow to the payload to continue using the context it received before a snapshot was taken.  To accomplish this km generates its own io contexts and maps them to the ones created by the kernel.  Only km generated io contexts are passed to the payload.  So when a payload uses an io context km translates that value to the kernel value returned with io_setup() before forwarding asynch io requests to the kernel.

These km generated io contexts are saved in a new elf note in snapshot files so that the context can be restored when the snapshot is resumed and then continue to be used by the payload.
Snapshots are only allowed if there are no active i/o requests associated with io contexts.  If there is active asynch io, snapshots requests are faileded.  Once all completed asynch i/o operations are harvested with io_getevents() snapshots are again allowed.

Also added bats tests to verify that snapshoting asynch io contexts works.