### PR TITLE
Fix km to allow gdb to use the symbols in the vdso pages

### DIFF
--- a/km/km_mem.c
+++ b/km/km_mem.c
@@ -348,15 +348,21 @@ static void km_add_vvar_vdso_to_guest_address_space(void)
       }
    }
 
+   /*
+    * Do not supply a filename arg to km_monitor_pages_in_guest() here.
+    * Adding a filename prevents gdb from discovering that these addresses
+    * belong to the vdso area and hence getting symbols from the vdso
+    * area which is in reality an elf format object file.
+    */
    rc = km_monitor_pages_in_guest(km_vvar_vdso_base[0],
                                   vvar_vdso_regions[0].end_addr - vvar_vdso_regions[0].begin_addr,
                                   PROT_READ,
-                                  "[vvar]");
+                                  NULL);
    km_assert(rc == 0);
    rc = km_monitor_pages_in_guest(km_vvar_vdso_base[1],
                                   vvar_vdso_regions[1].end_addr - vvar_vdso_regions[1].begin_addr,
                                   PROT_EXEC,
-                                  "[vdso]");
+                                  NULL);
    km_assert(rc == 0);
 }
 


### PR DESCRIPTION
Don't assign a filename to the vvar and vdso regions in the km memory busy map. km was assigning the non-filenames [vvar] and [vdso] to the vdso regions which apparently prevented gdb from checking to see if they were the vdso area.

A quick way to test is run gdb on a payload coredump and then run the "disassem gettimeofday" command.
You will see symbols like __vdso_gettimeofday in the output which tells you gdb was able to access the symbols stored in the vdso pages.