### PR TITLE
bats aio_test needs to run km_with_timeout in subshell with valgrind

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1781,13 +1781,13 @@ EOF
    mkdir -p $WORKDIR
    assert_success
 
-   AIO_TEST_WORKDIR=$WORKDIR km_with_timeout aio_test$ext -f 13 -c 1
+   AIO_TEST_WORKDIR=$WORKDIR run km_with_timeout aio_test$ext -f 13 -c 1
    assert_success
 
    # Now try snapshotting and resuming a payload with io contexts
    # This snapshot should succeed because there will be no active asynch
    # i/o requests
-   KM_MGTDIR=$WORKDIR  AIO_TEST_WORKDIR=$WORKDIR  km_with_timeout aio_test$ext -f 13 -c 1 -ss &
+   KM_MGTDIR=$WORKDIR  AIO_TEST_WORKDIR=$WORKDIR  run km_with_timeout aio_test$ext -f 13 -c 1 -ss &
    tries=10
    while [ $tries -gt 0 ]; do
       if [ -e $WORKDIR/waiting ]; then
@@ -1807,7 +1807,7 @@ EOF
    assert_success
 
    # start the snapshot and tell it to get going
-   km_with_timeout $snapfile &
+   run km_with_timeout $snapfile &
    local pid=$!
    run touch $WORKDIR/continue
    assert_success
@@ -1818,7 +1818,7 @@ EOF
    # Now try to take a snapshot when async i/o is active.
    # This snapshot should fail.
    rm -f $WORKDIR/*
-   KM_MGTDIR=$WORKDIR  AIO_TEST_WORKDIR=$WORKDIR  km_with_timeout aio_test$ext -f 13 -c 1 -sf &
+   KM_MGTDIR=$WORKDIR  AIO_TEST_WORKDIR=$WORKDIR  run km_with_timeout aio_test$ext -f 13 -c 1 -sf &
    tries=10
    while [ $tries -gt 0 ]; do
       if [ -e $WORKDIR/waiting ]; then


### PR DESCRIPTION
The km_with_timeout() shell function keeps adding things to the KM_ARGS shell variable if we don't run each instance in a subshell with the bats run command.  When running bats with valgrind this will add "--copyenv=LD_PRELOAD" to KM_ARGS each time km_with_timeout is run in the main shell which will cause km to fail complaining about multiple instances of the --copyenv flag.

I'm not sure if this is a bug in tests/test_helper.bash (which is where km_with_timeout lives) or a bug in tests/km_core_tests.bats since we don't consistently use run with km_with_timeout.