### PR TITLE
Log payload fd when recovered file has mismatched file mode

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -3266,7 +3266,11 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
       return -1;
    }
    if (st.st_mode != nt_file->mode) {
-      km_warnx("file mode mismatch expect 0%o got 0%o %s, payload fd %d", nt_file->mode, st.st_mode, name, nt_file->fd);
+      km_warnx("file mode mismatch expect 0%o got 0%o %s, payload fd %d",
+               nt_file->mode,
+               st.st_mode,
+               name,
+               nt_file->fd);
       return -1;
    }
 

--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -3266,7 +3266,7 @@ static int km_fs_recover_open_file(char* ptr, size_t length)
       return -1;
    }
    if (st.st_mode != nt_file->mode) {
-      km_warnx("file mode mistmatch expect %o got %o %s", nt_file->mode, st.st_mode, name);
+      km_warnx("file mode mismatch expect 0%o got 0%o %s, payload fd %d", nt_file->mode, st.st_mode, name, nt_file->fd);
       return -1;
    }
 


### PR DESCRIPTION
We occasionally see file mode mismatches when a payload snapshot is resumed.  This causes the snapshot resume to fail. In one case the original file is a regular file, after the snapshot is resumed the file is a char special file.
I'm assuming the fd is one of the stdio fd's.  If so, we can skip this check.
For now, add the fd to the message to see if my guess is correct.