### PR TITLE
remove obsolete snap_getdata/snap_putdata hypercalls

### DIFF
--- a/include/km_hcalls.h
+++ b/include/km_hcalls.h
@@ -80,8 +80,8 @@ enum km_internal_hypercalls {
    HC_shrink    = KM_MAX_HCALL - 4,
    HC_unmapself = KM_MAX_HCALL - 6,
    HC_snapshot = KM_MAX_HCALL - 7,
-   HC_snapshot_getdata = KM_MAX_HCALL - 8,
-   HC_snapshot_putdata = KM_MAX_HCALL - 9,
+   HC_reserved4 = KM_MAX_HCALL - 8,
+   HC_reserved5 = KM_MAX_HCALL - 9,
    HC_start = KM_MAX_HCALL - 10,   // must be last in list
 };
 

--- a/km/km_hc_name.c
+++ b/km/km_hc_name.c
@@ -376,8 +376,6 @@ static const char* const hc_name[KM_MAX_HCALL] = {
    [HC_shrink]    = "shrink",
    [HC_unmapself] = "unmapself",
    [HC_snapshot] = "snapshot",
-   [HC_snapshot_getdata] = "snapshot_getdata",
-   [HC_snapshot_putdata] = "snapshot_putdata",
    [HC_start] = "start",
 };
 // clang-format on

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -2039,18 +2039,6 @@ static km_hc_ret_t snapshot_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_ALLSTOP;
 }
 
-static km_hc_ret_t snapshot_getdata_hcall(void* vcpu, int hc, km_hc_args_t* arg)
-{
-   arg->hc_ret = km_snapshot_getdata(vcpu, km_gva_to_kma(arg->arg1), arg->arg2);
-   return HC_CONTINUE;
-}
-
-static km_hc_ret_t snapshot_putdata_hcall(void* vcpu, int hc, km_hc_args_t* arg)
-{
-   arg->hc_ret = km_snapshot_putdata(vcpu, km_gva_to_kma(arg->arg1), arg->arg2);
-   return HC_CONTINUE;
-}
-
 static km_hc_ret_t shrink_payload_hcall(void* vcpu, int hc, km_hc_args_t* arg)
 {
    arg->hc_ret = -km_shrink_footprint(vcpu);
@@ -2495,8 +2483,6 @@ const km_hcall_fn_t km_hcalls_table[KM_MAX_HCALL] = {
     [HC_guest_interrupt] = guest_interrupt_hcall,
     [HC_unmapself] = unmapself_hcall,
     [HC_snapshot] = snapshot_hcall,
-    [HC_snapshot_getdata] = snapshot_getdata_hcall,
-    [HC_snapshot_putdata] = snapshot_putdata_hcall,
     [HC_shrink] = shrink_payload_hcall,
 };
 

--- a/km/km_main.c
+++ b/km/km_main.c
@@ -100,8 +100,6 @@ static inline void usage()
 "\t--enable-1g-pages                   - Force enable 1G pages support (default). Assumes hardware support\n"
 "\t--disable-1g-pages                  - Force disable 1G pages support\n"
 "\t--virt-device=<file-name>  (-Ffile) - Use provided file-name for virtualization device\n"
-"\t--input-data=<file-name>            - File with data for HC_snapshot_getdata\n"
-"\t--output-data=<file-name>           - File with data from HC_snapshot_putdata\n"
 "\t--mgtpipe <path>                    - Name for management pipe.\n");
    // clang-format on
 }
@@ -176,8 +174,6 @@ struct option km_cmd_long_options[] = {
     {"hcall-stats", no_argument, 0, 'S'},
     {"virt-device", required_argument, 0, 'F'},
     {"snapshot", required_argument, 0, 's'},
-    {"input-data", required_argument, 0, 'I'},
-    {"output-data", required_argument, 0, 'O'},
     {"mgtpipe", required_argument, 0, 'm'},
     {"kill-unimpl-scall", no_argument, &(kill_unimpl_hcall), KM_FLAG_FORCE_ENABLE},
 
@@ -489,12 +485,6 @@ km_parse_args(int argc, char* argv[], int* argc_p, char** argv_p[], int* envc_p,
          case 'S':
             km_collect_hc_stats = 1;
             break;
-         case 'I':
-            km_set_snapshot_input_path(optarg);
-            break;
-         case 'O':
-            km_set_snapshot_output_path(optarg);
-            break;
          case 'm':
             if (km_mgtdir != NULL) {
                km_errx(1,
@@ -751,7 +741,6 @@ int main(int argc, char* argv[])
    } while (km_dofork(NULL) != 0);
 
    km_machine_fini();
-   km_snapshot_io_path_fini();
    km_mgt_fini();
    km_trace_fini();
    exit(machine.exit_status);

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -43,9 +43,6 @@
 // TODO: Need to figure out where the snapshot default should go.
 static char* snapshot_path = "./kmsnap";
 
-static char* snapshot_input_path = NULL;
-static char* snapshot_output_path = NULL;
-
 void km_set_snapshot_path(char* path)
 {
    km_infox(KM_TRACE_SNAPSHOT, "Setting snapshot path to %s", path);
@@ -57,78 +54,6 @@ void km_set_snapshot_path(char* path)
 char* km_get_snapshot_path()
 {
    return snapshot_path;
-}
-
-void km_snapshot_io_path_fini()
-{
-   if (snapshot_input_path != NULL) {
-      free(snapshot_input_path);
-   }
-   if (snapshot_output_path != NULL) {
-      free(snapshot_output_path);
-   }
-}
-
-void km_set_snapshot_input_path(char* path)
-{
-   km_infox(KM_TRACE_SNAPSHOT, "Setting snapshot input to %s", path);
-   if ((snapshot_input_path = strdup(path)) == NULL) {
-      km_err(1, "Failed to alloc memory for snapshot input");
-   }
-}
-
-void km_set_snapshot_output_path(char* path)
-{
-   km_infox(KM_TRACE_SNAPSHOT, "Setting snapshot output to %s", path);
-   if ((snapshot_output_path = strdup(path)) == NULL) {
-      km_err(1, "Failed to alloc memory for snapshot output");
-   }
-}
-
-int km_snapshot_getdata(km_vcpu_t* vcpu, char* buf, int buflen)
-{
-   if (buf == NULL) {
-      km_infox(KM_TRACE_SNAPSHOT, "bad buffer");
-      return -EFAULT;
-   }
-   if (snapshot_input_path == NULL) {
-      return 0;
-   }
-   int fd = km_internal_open(snapshot_input_path, O_RDONLY, 0);
-   if (fd < 0) {
-      km_info(KM_TRACE_SNAPSHOT, "open failure");
-      return -errno;
-   }
-   int rc = read(fd, buf, buflen);
-   if (rc < 0) {
-      km_info(KM_TRACE_SNAPSHOT, "read failure");
-      rc = -errno;
-   }
-   close(fd);
-   return rc;
-}
-
-int km_snapshot_putdata(km_vcpu_t* vcpu, char* buf, int buflen)
-{
-   if (buf == NULL) {
-      km_infox(KM_TRACE_SNAPSHOT, "bad buffer");
-      return -EFAULT;
-   }
-   if (snapshot_output_path == NULL) {
-      return 0;
-   }
-   int fd = km_internal_open(snapshot_output_path, O_RDWR | O_CREAT | O_TRUNC, 0666);
-   if (fd < 0) {
-      km_info(KM_TRACE_SNAPSHOT, "open failure");
-      return -errno;
-   }
-   int rc = write(fd, buf, buflen);
-   if (rc < 0) {
-      km_info(KM_TRACE_SNAPSHOT, "write failure");
-      rc = -errno;
-   }
-   close(fd);
-   return rc;
 }
 
 static inline void km_ss_recover_memory(int fd, km_gva_t tbrk_gva, km_payload_t* payload)

--- a/km/km_snapshot.h
+++ b/km/km_snapshot.h
@@ -32,14 +32,7 @@ int km_snapshot_create(km_vcpu_t* vcpu, char* label, char* description, char* pa
 int km_snapshot_restore(km_elf_t* elf);
 char* km_snapshot_read_notes(int fd, size_t* notesize, km_payload_t* payload);
 int km_snapshot_notes_apply(char* notebuf, size_t notesize, int type, int (*func)(char*, size_t));
-void km_snapshot_io_path_fini();
 void km_snapshot_fill_km_payload(km_elf_t* e, km_payload_t* p);
-
-void km_set_snapshot_input_path(char* path);
-void km_set_snapshot_output_path(char* path);
-
-int km_snapshot_getdata(km_vcpu_t* vcpu, char* buf, int buflen);
-int km_snapshot_putdata(km_vcpu_t* vcpu, char* buf, int buflen);
 
 void light_snap_listen(km_elf_t* e);
 

--- a/lib/libkontain/libkontain.c
+++ b/lib/libkontain/libkontain.c
@@ -30,19 +30,3 @@ int snapshot(char* label, char* application_name, int snapshot_live)
 
    return snapshot_args.hc_ret;
 }
-
-size_t snapshot_getdata(void* buffer, size_t count)
-{
-   km_hc_args_t snapshot_getdata_args = {.arg1 = (uint64_t)buffer, .arg2 = (uint64_t)count};
-   km_hcall(HC_snapshot_getdata, &snapshot_getdata_args);
-
-   return (size_t)snapshot_getdata_args.hc_ret;
-}
-
-size_t snapshot_putdata(void* buffer, size_t count)
-{
-   km_hc_args_t snapshot_putdata_args = {.arg1 = (uint64_t)buffer, .arg2 = (uint64_t)count};
-   km_hcall(HC_snapshot_putdata, &snapshot_putdata_args);
-
-   return (size_t)snapshot_putdata_args.hc_ret;
-}

--- a/lib/libkontain/libkontain.h
+++ b/lib/libkontain/libkontain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Kontain Inc
+ * Copyright 2023 Kontain Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,5 @@
 #define __LIBKONTAIN_H__
 
 int snapshot(char* label, char* application_name, int snapshot_live);
-size_t snapshot_getdata(void* buffer, size_t count);
-size_t snapshot_putdata(void* buffer, size_t count);
 
 #endif /* #ifndef __LIBKONTAIN_H__ */

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1084,8 +1084,6 @@ fi
    SNAP=/tmp/snap.$$
    CORE=/tmp/core.$$
    KMLOG=/tmp/kmlog.$$
-   SNAP_INPUT=/tmp/snap_input.$$
-   SNAP_OUTPUT=/tmp/snap_output.$$
    MGMTPIPE=/tmp/mgmtpipe.$$
    SNAPDIR=/tmp/snapdir.$$
    MGTDIR=/tmp/mgtdir.$$
@@ -1150,8 +1148,6 @@ fi
    local -a tmp=($(echo ${MGTDIR}/kmsnap.hello_html_test$ext.[0-9]*))
    assert [ -f ${tmp[0]} ]
    rm -fr ${MGTDIR}
-
-   echo "This is test data" > ${SNAP_INPUT}
 
    # Verify that certain conditions cause the snapshot operation to fail
    run km_with_timeout --snapshot=${SNAP} snapshot_fail_test$ext -e
@@ -1237,16 +1233,14 @@ fi
       assert [ -f ${SNAP} ]
       assert [ ! -f ${CORE} ]
       check_kmcore ${SNAP}
-      run km_with_timeout --km-log-to=${KMLOG} --input-data=${SNAP_INPUT} --output-data=${SNAP_OUTPUT} ${SNAP}
+      run km_with_timeout --km-log-to=${KMLOG} ${SNAP}
       assert_success
       assert_output --partial "Hello from thread"
       refute_line --partial "state restoration error"
       assert [ ! -f ${CORE} ]
-      assert [ -f ${SNAP_OUTPUT} ]
-      run diff ${SNAP_INPUT} ${SNAP_OUTPUT}
       assert_success
       [ $status -ne 0 ] && break
-      rm -f ${SNAP} ${KMLOG} ${SNAP_OUTPUT}
+      rm -f ${SNAP} ${KMLOG}
 
       # snapshot with closed stdio
       run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -c $snapshot_test_port
@@ -1262,7 +1256,7 @@ fi
       refute_line --partial "state restoration error"
       assert [ ! -f ${CORE} ]
       [ $status -ne 0 ] && break
-      rm -f ${SNAP} ${KMLOG} ${SNAP_OUTPUT}
+      rm -f ${SNAP} ${KMLOG}
 
       # snapshot resume that core dumps
       run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -a $snapshot_test_port
@@ -1277,7 +1271,7 @@ fi
       if [ "$test_type" = ".km.so" ]; then
          gdb --ex=bt --ex=q snapshot_test$ext ${CORE} | grep -F 'abort ('
       fi
-      rm -f ${SNAP} ${CORE} ${KMLOG} ${SNAP_OUTPUT}
+      rm -f ${SNAP} ${CORE} ${KMLOG}
 
       # 'live' snapshot
       run km_with_timeout --coredump=${CORE} --snapshot=${SNAP} snapshot_test$ext -l $snapshot_test_port
@@ -1291,9 +1285,9 @@ fi
       refute_line --partial "state restoration error"
       assert [ ! -f ${CORE} ]
       [ $status -ne 0 ] && break
-      rm -f ${SNAP} ${KMLOG} ${SNAP_OUTPUT}
+      rm -f ${SNAP} ${KMLOG}
    done
-   [ $status -eq 0 ] && rm -f ${SNAP} ${KMLOG} ${SNAP_OUTPUT} ${SNAP_INPUT}
+   [ $status -eq 0 ] && rm -f ${SNAP} ${KMLOG}
 }
 
 @test "futex_snapshot($test_type): futex_snapshot and resume (futex_test$ext)" {

--- a/tests/snapshot_test.c
+++ b/tests/snapshot_test.c
@@ -452,15 +452,6 @@ int main(int argc, char* argv[])
    }
    pthread_mutex_unlock(&signal_lock);
 
-   char buf[1024];
-   km_hc_args_t getdata_args = {.arg1 = (uintptr_t)buf, .arg2 = sizeof(buf)};
-   km_hcall(HC_snapshot_getdata, &getdata_args);
-   fprintf(stderr, "getdata rc=%ld\n", getdata_args.hc_ret);
-
-   km_hc_args_t putdata_args = {.arg1 = (uintptr_t)buf, .arg2 = getdata_args.hc_ret};
-   km_hcall(HC_snapshot_putdata, &putdata_args);
-   fprintf(stderr, "putdata rc=%ld\n", putdata_args.hc_ret);
-
    void* rval;
    if ((c = pthread_join(thr, &rval)) != 0) {
       fprintf(stderr, "pthread_join %s:%d, %s\n", __FILE__, __LINE__, strerror(c));


### PR DESCRIPTION
These calls were used by a prototype FAAS I did a few years ago. They are no longer needed.

I did these changes while waiting for paul to deliver his nvidia changes for snapshot/restore.