### PR TITLE
relax check for fork on snapshot

### DIFF
--- a/km/km_filesys.c
+++ b/km/km_filesys.c
@@ -2477,6 +2477,36 @@ size_t km_fs_core_notes_length(void)
    return ret;
 }
 
+/*
+ * check if there are reading ends of pipes with data
+ */
+
+int km_pipes(void)
+{
+   ssize_t queuedbytes = 0;
+
+   for (int i = 0; i < km_fs()->nfdmap; i++) {
+      km_file_t* file = &km_fs()->guest_files[i];
+      if (file->sockinfo == NULL) {
+         if (file->how == KM_FILE_HOW_PIPE_0) {
+            // We are looking at the read end of a pipe, find out how much data is queued
+            queuedbytes = ioctlfionread(i);
+            if (queuedbytes != 0) {
+               return 1;
+            }
+         }
+      } else {
+         if (file->how == KM_FILE_HOW_SOCKETPAIR0 || file->how == KM_FILE_HOW_SOCKETPAIR1) {
+            queuedbytes = ioctlfionread(i);
+            if (queuedbytes != 0) {
+               return 1;
+            }
+         }
+      }
+   }
+   return 0;
+}
+
 // Helper function to ensure we read all the bytes requested.
 // We abort after 50 tries.
 static inline int do_full_read(int fd, char* bufp, size_t bufl)

--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -310,6 +310,7 @@ uint64_t km_fs_timerfd_create(km_vcpu_t* vcpu, int clockid, int flags);
 size_t km_fs_dup_notes_length(void);
 size_t km_fs_core_dup_write(char* buf, size_t length);
 size_t km_fs_core_notes_length(void);
+int km_pipes(void);
 int km_fs_core_notes_write(char* cur, size_t remain, size_t* sizep);
 
 void km_redirect_msgs(const char* name);

--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -33,7 +33,6 @@
 #include "km_coredump.h"
 #include "km_elf.h"
 #include "km_filesys.h"
-#include "km_fork.h"
 #include "km_gdb.h"
 #include "km_guest.h"
 #include "km_mem.h"
@@ -526,11 +525,6 @@ int km_snapshot_create(km_vcpu_t* vcpu, char* label, char* description, char* du
       km_warnx("Cannot create snapshot with GDB running");
       return -EBUSY;
    }
-   if (km_have_forked() != 0) {
-      km_warnx("Cannot create snapshot after forking");
-      return -EBUSY;
-   }
-
    if (dumppath == NULL || dumppath[0] == 0) {
       if (km_mgtdir != NULL) {
          snprintf(dumpfile,

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -8,3 +8,6 @@ gdb.txt
 km_*.log
 vgcore.*
 !shebang*
+netpipe.data.*
+tracefile.*
+aio_file_*

--- a/tests/snapshot_fail_test.c
+++ b/tests/snapshot_fail_test.c
@@ -278,7 +278,7 @@ int main(int argc, char* argv[])
       // Fork then snapshot.  This should fail.
       // snapshotting pipe and socketpair buffered data is not possible if another
       // process was forked.
-      case 'f':
+      case 'f': {
          int pipefd[2];
          pipe(pipefd);
          pid = fork();
@@ -316,7 +316,7 @@ int main(int argc, char* argv[])
             exit(0);
          }
          break;
-
+      }
       // Snapshot when a pipe has queued data
       case 'p':;
          pipetest(0);

--- a/tests/snapshot_fail_test.c
+++ b/tests/snapshot_fail_test.c
@@ -279,8 +279,11 @@ int main(int argc, char* argv[])
       // snapshotting pipe and socketpair buffered data is not possible if another
       // process was forked.
       case 'f':
+         int pipefd[2];
+         pipe(pipefd);
          pid = fork();
          if (pid > 0) {
+            sleep(1);   // allow child to write into pipe
             // we are the parent process. attempt a snapshot which should fail.
             snapshotargs = (km_hc_args_t){.arg1 = (uint64_t) "snaptest_label",
                                           .arg2 = (uint64_t) "Snapshot after fork",
@@ -308,6 +311,7 @@ int main(int argc, char* argv[])
             fprintf(stderr, "fork failed, %s\n", strerror(errno));
             exit(110);
          } else {
+            write(pipefd[1], "hello", sizeof("hello"));
             // We are the child.  Do nothing just exit.
             exit(0);
          }


### PR DESCRIPTION
pytorch demo https://github.com/kontainapp/km-demo/pull/8 does fork two short lived children. Which disables snapshot, but in fact there is no reason. This change relaxes the check a little bit.

Changed bats test to allow this too.