### PR TITLE
Srini/add lmid

### DIFF
--- a/km/km.h
+++ b/km/km.h
@@ -777,7 +777,10 @@ static inline void km_signal_unlock(void)
 #define KM_TRACE_SHRINK "shrink"
 
 // Helper function to visit entries in the dynamically loaded modules list.
-typedef int(link_map_visit_function_t)(struct link_map* kma, struct link_map* gva, void* visitargp);
+typedef int(link_map_visit_function_t)(struct link_map* kma,
+                                       struct link_map* gva,
+                                       void* visitargp,
+                                       long int ns);
 
 int km_link_map_walk(link_map_visit_function_t* callme, void* visitargp);
 

--- a/km/km_gdb_stub.c
+++ b/km/km_gdb_stub.c
@@ -1436,7 +1436,7 @@ typedef struct gdb_linkmap_arg {
  * Visitor function for traversing the list of dynamically loaded libraries.
  * This function is called once for each library.
  */
-static int km_gdb_linkmap_visit(struct link_map* kmap, struct link_map* gvap, void* argp)
+static int km_gdb_linkmap_visit(struct link_map* kmap, struct link_map* gvap, void* argp, long int ns)
 {
    gdb_linkmap_arg_t* lmargp = (gdb_linkmap_arg_t*)argp;
    int worked;
@@ -1450,11 +1450,12 @@ static int km_gdb_linkmap_visit(struct link_map* kmap, struct link_map* gvap, vo
    } else {
       snprintf(temp,
                sizeof(temp),
-               "  <library name=\"%s\" lm=\"%p\" l_addr=\"0x%lx\" l_ld=\"%p\"/>\n",
+               "  <library name=\"%s\" lm=\"%p\" l_addr=\"0x%lx\" l_ld=\"%p\" lmid=\"0x%lx\"/>\n",
                libname,
                gvap,
                kmap->l_addr,
-               kmap->l_ld);
+               kmap->l_ld,
+               ns);
    }
    worked = string_append(lmargp->bufp, lmargp->bufl, temp);
    if (worked == false) {

--- a/km/km_musl_related.c
+++ b/km/km_musl_related.c
@@ -127,7 +127,7 @@ int km_link_map_walk_musl(link_map_visit_function_t* callme, void* visitargp)
    while (lmp_gva != NULL) {
       km_infox(KM_TRACE_KVM, "Examining link map entry at %p", lmp_gva);
       lmp_kma = (struct link_map*)km_gva_to_kma((km_gva_t)lmp_gva);
-      rc = (*callme)(lmp_kma, lmp_gva, visitargp);
+      rc = (*callme)(lmp_kma, lmp_gva, visitargp, 0);
       if (rc != 0) {
          break;
       }
@@ -150,8 +150,10 @@ int km_link_map_walk_glibc(link_map_visit_function_t* callme, void* visitargp)
 
       while (lmp_gva != NULL) {
          struct link_map* lmp_kma = (struct link_map*)km_gva_to_kma((km_gva_t)lmp_gva);
-         km_infox(KM_TRACE_KVM, "namespace %d gva %p kma_ns %p\n", ns, lmp_gva, lmp_kma);
-         rc = (*callme)(lmp_kma, lmp_gva, visitargp);
+         long int lib_ns =
+             ((uint64_t*)lmp_kma)[6];   // use the value maintained by glibc instead of loop index
+         km_infox(KM_TRACE_KVM, "namespace %d gva %p kma_ns %p lib_ns %llx\n", ns, lmp_gva, lmp_kma, lib_ns);
+         rc = (*callme)(lmp_kma, lmp_gva, visitargp, lib_ns);
          if (rc != 0) {
             return rc;
          }


### PR DESCRIPTION

warning message appears for  both musl and glibc, so sending the same message.