### PR TITLE
Use restored machine.brk value during snapshot restore

### DIFF
--- a/km/km_snapshot.c
+++ b/km/km_snapshot.c
@@ -65,7 +65,7 @@ static inline void km_ss_recover_memory(int fd, km_gva_t tbrk_gva, km_payload_t*
          if (km_vdso_gva(phdr->p_vaddr) != 0 || km_guestmem_gva(phdr->p_vaddr) != 0) {
             continue;
          }
-         if (phdr->p_vaddr >= 256 * GIB) {   // TODO: HACK to tell upper VA from lower
+         if (phdr->p_vaddr >= km_mem_brk(0)) {
             // upper: Skip addresses loaded by machine initialization.
             if (phdr->p_vaddr + phdr->p_filesz <= tbrk_gva) {
                int prot = prot_elf_to_mmap(phdr->p_flags);
@@ -252,7 +252,7 @@ static int km_ss_recover_file_maps(char* ptr, size_t length)
    for (uint64_t i = 0; i < nfile; i++) {
       km_gva_t base = current[0];
       km_gva_t limit = current[1];
-      if (limit >= 256 * GIB) {   // TODO: HACK to tell upper VA from lower
+      if (limit >= km_mem_brk(0)) {
          /*
           * There are NT_FILE records for all mappings, including the one
           * in low virtual memory create by load_elf. We want to skip those


### PR DESCRIPTION
Some code in snapshot restore uses the hardcoded value 256 * GIB to decide if it is dealing with memory allocated with the brk() system call or memory allocated with mmap().
It turns out machine.brk is saved in the coredump/snapshot and is restored when a snapshot is recovered, so we can use that value to make decisions rather than the hardcoded 256gb value during the remainder of snapshot restore.