### PR TITLE
Fix faults caused by large reductions in the break size

### DIFF
--- a/km/km_mem.c
+++ b/km/km_mem.c
@@ -606,24 +606,28 @@ static inline void fixup_bottom_page_tables(km_gva_t old_brk, km_gva_t new_brk)
                new_1g_slot);
       if (old_1g_slot > 0 && new_1g_slot > 0) {
          // Handle brk() call where old break and new break are both in the 1g page region.
-         new_1g_slot = PDPTE_SLOT_ROUNDUP(new_brk);     // leave a partial page in the page table
-	 for (int i = old_1g_slot; i >= new_1g_slot; i--) {
+         new_1g_slot = PDPTE_SLOT_ROUNDUP(new_brk);   // leave a partial page in the page table
+         for (int i = old_1g_slot; i >= new_1g_slot; i--) {
             pdpe[i].p = 0;
          }
       } else if (old_1g_slot == 0 && new_1g_slot == 0) {
          // Handle brk() call where old break and new break are both in the 2m page region
-	 new_2m_slot = PDE_SLOT_ROUNDUP(new_brk);
-	 for (int i = old_2m_slot; i >= new_2m_slot; i--) {
+         new_2m_slot = PDE_SLOT_ROUNDUP(new_brk);
+         for (int i = old_2m_slot; i >= new_2m_slot; i--) {
             pde[i].p = 0;
          }
       } else {
          // Handle brk() call where old break is in the 1g page region and new brk is in 2m page region.
-	 for (int i = old_1g_slot; i >= 1; i--) {
+         for (int i = old_1g_slot; i >= 1; i--) {
             pdpe[i].p = 0;
          }
-	 new_2m_slot = PDE_SLOT_ROUNDUP(new_brk);
-	 km_infox(KM_TRACE_MEM, "pde %p, updating pde slots from %d down to %d", pde, PT_ENTRIES-1, new_2m_slot);
-	 for (int i = PT_ENTRIES - 1; i >= new_2m_slot; i--) {
+         new_2m_slot = PDE_SLOT_ROUNDUP(new_brk);
+         km_infox(KM_TRACE_MEM,
+                  "pde %p, updating pde slots from %d down to %d",
+                  pde,
+                  PT_ENTRIES - 1,
+                  new_2m_slot);
+         for (int i = PT_ENTRIES - 1; i >= new_2m_slot; i--) {
             pde[i].p = 0;
          }
       }

--- a/km/km_mem.c
+++ b/km/km_mem.c
@@ -609,14 +609,13 @@ static inline void fixup_bottom_page_tables(km_gva_t old_brk, km_gva_t new_brk)
                new_2m_slot,
                new_1g_slot);
       if (old_1g_slot > 0) {
-         int start = (new_1g_slot == 0) ? 1 : new_1g_slot + 1;
-         for (int i = start; i < old_1g_slot; i++) {
+         for (int i = new_1g_slot + 1; i <= old_1g_slot; i++) {
             pdpe[i].p = 0;
          }
       }
       if (new_1g_slot == 0) {
          // new_brk is below 1GB, need to change 2MB pages
-         // Check if old_brk ws below 1GB or not - operate on some 2MB or all of the from the top
+         // Check if old_brk is below 1GB or not - operate on some 2MB or all of them from the top
          int limit = (old_1g_slot == 0) ? old_2m_slot : MAX_PDE_SLOT;
          for (int i = new_2m_slot + 1; i <= limit; i++) {
             pde[i].p = 0;

--- a/tests/brk_test.c
+++ b/tests/brk_test.c
@@ -19,13 +19,13 @@
  */
 #include <assert.h>
 #include <errno.h>
+#include <setjmp.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <signal.h>
-#include <setjmp.h>
 
 #include "greatest/greatest.h"
 #include "syscall.h"
@@ -237,7 +237,7 @@ int setbrk_checkaccess(void* brkaddr)
  */
 TEST brk_shrink()
 {
-   void *ptr;
+   void* ptr;
    struct sigaction sa;
    void* brkaddr;
 
@@ -250,35 +250,35 @@ TEST brk_shrink()
    ptr = (void*)(((unsigned long)ptr + 4095) & ~4095);
 
    // Set brk in the 1g page region of the page table
-   brkaddr = (void*)(8*GIB);
+   brkaddr = (void*)(8 * GIB);
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Drop down to the next lower 1g boundary.
-   brkaddr -= 1*GIB;
+   brkaddr -= 1 * GIB;
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Drop down to inside the 1g page
-   brkaddr -= 128*MIB;
+   brkaddr -= 128 * MIB;
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Drop down to 1g
-   brkaddr = (void*)(1*GIB);
+   brkaddr = (void*)(1 * GIB);
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Drop down into the 2m page region of the page table
-   brkaddr = (void*)(512*MIB);
+   brkaddr = (void*)(512 * MIB);
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Drop to an address not on a 2m boundary
-   brkaddr -= 1*MIB;
+   brkaddr -= 1 * MIB;
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Move back into the 1g page region of the page table
-   brkaddr = (void*)(1*GIB + 16*MIB);
+   brkaddr = (void*)(1 * GIB + 16 * MIB);
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Drop down into the 2m page region of the page table
-   brkaddr = (void*)(1*GIB - 128*KIB);
+   brkaddr = (void*)(1 * GIB - 128 * KIB);
    ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
 
    // Put the break back to where it was

--- a/tests/brk_test.c
+++ b/tests/brk_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Kontain Inc
+ * Copyright 2021,2023 Kontain Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,15 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#include <signal.h>
+#include <setjmp.h>
 
 #include "greatest/greatest.h"
 #include "syscall.h"
 
 #define GIB (1ul << 30)
 #define MIB (1ul << 20)
+#define KIB (1ul << 10)
 
 void* SYS_break(void const* addr)
 {
@@ -177,11 +180,125 @@ TEST brk_not_too_greedy()
    PASS();
 }
 
+jmp_buf jbuf;
+void access_fault(int signal)
+{
+   siglongjmp(jbuf, 1);
+}
+
+/*
+ * Set the break to brkaddr then verify that we can write
+ * below the break and can't write above the break.
+ * Returns:
+ *   0 - success
+ *   1 - memory access failed
+ *   2 - brk() call failed
+ * We expect the brkaddr arg to be on a page boundary.
+ */
+int setbrk_checkaccess(void* brkaddr)
+{
+   int sjrc;
+   char* pokehere;
+
+   if (SYS_break(brkaddr) != brkaddr) {
+      printf("Set break to %p failed\n", brkaddr);
+      return 2;
+   }
+   pokehere = brkaddr;
+   if ((sjrc = sigsetjmp(jbuf, 1)) == 0) {
+      *(pokehere - 1) = 99;
+   }
+   if (sjrc != 0) {
+      // Can't write below the break
+      printf("Can't write below the break at %p\n", pokehere - 1);
+      return 1;
+   }
+   if ((sjrc = sigsetjmp(jbuf, 1)) == 0) {
+      *(pokehere + 1) = 88;
+   }
+   if (sjrc != 1) {
+      // We can write above the break, really?
+      printf("Can write above the break at %p\n", pokehere + 1);
+      return 1;
+   }
+   return 0;
+}
+
+/*
+ * Test brk() which shrinks the brk region of memory.
+ * We try things like brk() completely within in the 1g page region,
+ * brk() completely within the 2m page region and brk from the 1g
+ * page region into the 2m page region.
+ * We verify that memory below the new brk is still accessible and memory above
+ * the new break is not accessible.
+ * And, we also test brk() to pdpe and pde boundaries and brk() to
+ * non-pdpe and non-pde boundaries and verify that the memory we expect to be
+ * accessible is accessible.
+ */
+TEST brk_shrink()
+{
+   void *ptr;
+   struct sigaction sa;
+   void* brkaddr;
+
+   sa.sa_handler = access_fault;
+   sigemptyset(&sa.sa_mask);
+   sa.sa_flags = 0;
+   ASSERT_EQ(sigaction(SIGSEGV, &sa, NULL), 0);
+
+   printf("initial break is %p\n", ptr = SYS_break(NULL));
+   ptr = (void*)(((unsigned long)ptr + 4095) & ~4095);
+
+   // Set brk in the 1g page region of the page table
+   brkaddr = (void*)(8*GIB);
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Drop down to the next lower 1g boundary.
+   brkaddr -= 1*GIB;
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Drop down to inside the 1g page
+   brkaddr -= 128*MIB;
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Drop down to 1g
+   brkaddr = (void*)(1*GIB);
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Drop down into the 2m page region of the page table
+   brkaddr = (void*)(512*MIB);
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Drop to an address not on a 2m boundary
+   brkaddr -= 1*MIB;
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Move back into the 1g page region of the page table
+   brkaddr = (void*)(1*GIB + 16*MIB);
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Drop down into the 2m page region of the page table
+   brkaddr = (void*)(1*GIB - 128*KIB);
+   ASSERT_EQ(setbrk_checkaccess(brkaddr), 0);
+
+   // Put the break back to where it was
+   SYS_break((void*)ptr);
+   ASSERT_EQ(ptr, SYS_break(NULL));
+
+   // Turn off signal handler
+   sa.sa_handler = SIG_DFL;
+   ASSERT_EQ(sigaction(SIGSEGV, &sa, NULL), 0);
+
+   PASS();
+}
+
 GREATEST_MAIN_DEFS();
 int main(int argc, char** argv)
 {
    GREATEST_MAIN_BEGIN();
    greatest_set_verbosity(1);
+
+   RUN_TEST(brk_shrink);
 
    RUN_TEST(brk_2gib);
    RUN_TEST(brk_test);


### PR DESCRIPTION
We found problems when shrinking the break (brk() system call) from 1.5gig down to .5gig.
It looks like the page tables were not being updated properly when this happened.
This change hopefully fixes this problem and adds some tests to verify that memory is or is not accessible after the break is shrunk.