### PR TITLE
handle ioctl errno

### DIFF
--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -517,7 +517,8 @@ static void km_vcpu_one_kvm_run(km_vcpu_t* vcpu)
               vcpu->regs.rsp,
               vcpu->sregs.cr2);
       vcpu->cpu_run->exit_reason = KVM_EXIT_INTR;
-      switch (ioctl_errno) {
+      errno = ioctl_errno;
+      switch (errno) {
          case EINTR:
             break;
 

--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -41,7 +41,7 @@ int kill_unimpl_hcall = 0;
 // Prevent snapshotting until the payload is running.
 int km_vcpus_are_started = 0;
 
-#define fx "VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx "
+#define fx " VCPU %d RIP 0x%0llx RSP 0x%0llx CR2 0x%llx"
 
 #define __run_err(vcpu, __s, __f, ...)                                                             \
    km_err(__s, __f fx, ##__VA_ARGS__, vcpu->vcpu_id, vcpu->regs.rip, vcpu->regs.rsp, vcpu->sregs.cr2);
@@ -491,6 +491,7 @@ static void km_vcpu_one_kvm_run(km_vcpu_t* vcpu)
    int rc;
 
    vcpu->state = IN_GUEST;
+   errno = 0;
    vcpu->cpu_run->exit_reason = KVM_EXIT_UNKNOWN;   // Clear exit_reason from the preceding ioctl
    vcpu->regs_valid = 0;                            // Invalidate cached registers
    vcpu->sregs_valid = 0;
@@ -509,6 +510,9 @@ static void km_vcpu_one_kvm_run(km_vcpu_t* vcpu)
    }
 
    if (rc != 0) {
+      if (errno == 0) {
+         errno = -rc;
+      }
       km_info(KM_TRACE_KVM,
               "RIP 0x%0llx RSP 0x%0llx CR2 0x%llx",
               vcpu->regs.rip,

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1678,7 +1678,7 @@ fi
          run /bin/kill -0 $pid >& /dev/null
          if test $status -ne 0; then
             # html server is not running, if km_with_timeout timed it out, we give up on this loop and dont fail the test
-            wait kmstatus $pid
+            wait $pid
             if test $? -eq 124; then
                break;
             fi

--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1657,11 +1657,11 @@ fi
       #assert_success
       run ${KM_CLI_BIN} -r -d $SNAPDIR -s $MGTPIPE
       if test "$status" -ne 0; then
-         run /bin/kill -0 $pid
+         run /bin/kill -0 $pid >& /dev/null
          if test $status -ne 0; then
             # html server is not running, if km_with_timeout timed it out, we give up on this loop and dont fail the test
-            wait -p kmstatus $pid
-            if test $kmstatus -eq 124; then
+            wait $pid
+            if test $? -eq 124; then
                break;
             fi
             # km failed for some other reason, get the trace
@@ -1675,11 +1675,11 @@ fi
       #assert_success
       run curl -4 localhost:$socket_port
       if test "$status" -ne 0; then
-         run /bin/kill -0 $pid
+         run /bin/kill -0 $pid >& /dev/null
          if test $status -ne 0; then
             # html server is not running, if km_with_timeout timed it out, we give up on this loop and dont fail the test
-            wait -p kmstatus $pid
-            if test $kmstatus -eq 124; then
+            wait kmstatus $pid
+            if test $? -eq 124; then
                break;
             fi
             # km failed for some other reason, get the trace


### PR DESCRIPTION
Turns out modern KVM `ioctl (KVM_RUN)` _sometimes_ returns -errno and keeps proper errno untouched. According to `man ioctl()` it should return -1 and set `errno` in case of an error. However I observe that ioctl returning -14 (EFAULT) and errno is left untouched.