### PR TITLE
gdb in tests in batch mode

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -200,7 +200,7 @@ fi
 # this is how we invoke gdb - with timeout
 function gdb_with_timeout () {
    timeout --foreground $timeout \
-      gdb "$@"
+      gdb --batch "$@"
    s=$?; if [ $s -eq 124 ] ; then echo "\nTimed out in $timeout" ; fi ; return $s
 }
 


### PR DESCRIPTION
Fixed https://github.com/kontainapp/km/issues/1223

Turns out when bats run in parallel mode the stdin into tests is redirected from `/dev/null` and interactive commands gets EOF right way. But in singly threaded mode stdin reads from tty. When quitting gdb it asks:

```A debugging session is active.

	Inferior 1 [Remote target] will be detached.

Quit anyway? (y or n)
```

and hangs in that, causing the timeout.

Put `--batch` in gdb command line to stop that.
