### PR TITLE
Add facilities to trace memory contents and sockaddr's

### DIFF
--- a/km/km_hc_name.c
+++ b/km/km_hc_name.c
@@ -366,6 +366,12 @@ static const char* const hc_name[KM_MAX_HCALL] = {
    [431] = "fsconfig",
    [432] = "fsmount",
    [433] = "fspick",
+   [434] = "pidfd_open",
+   [435] = "clone3",
+   [436] = "close_range",
+   [437] = "openat2",
+   [438] = "pidfd_getfd",
+   [439] = "faccessat2",
    // reserved to be compatible with earlier-built payloads.
    // TODO: drop before release, we do not need compat with
    // pre-release payloads


### PR DESCRIPTION
The memory trace macro is km_info_mem().
The sockaddr trace macro is km_info_sockaddr().

There is only support for AF_* values I've run into. If km_info_sockaddr() runs into an AF_ value it can't handle it produces a trace like this:
"%s unhandled address family: %d, fixme!"

The km_info_mem() produces a dump like this:
OOOOOO: XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX  *AAAAAAAAAAAAAAAA* 
Where "000000" is the offset in hex from the beginning of the memory area to be dumped.
Where XX is the hex value of a byte.
And "A" is the ascii for a byte.  If the byte is not printable a dot is displayed.

Added a km trace category named "network".
Use the name network with the km -V command line flag. 
Use the symbol KM_TRACE_NETWORK in km_info() macro calls.

Add tracing of the sockaddr's passed to connect(), bind(), and values returned by accept(), getsockaddr(), getpeername().

Added some missing system call names to the table of syscall names.