### PR TITLE
Try to fix the ci failure in the bats gdb_nextstep test

### DIFF
--- a/km/km_vcpu_run.c
+++ b/km/km_vcpu_run.c
@@ -490,15 +490,15 @@ static void km_vcpu_one_kvm_run(km_vcpu_t* vcpu)
 {
    int rc;
 
-   vcpu->state = IN_GUEST;
    vcpu->cpu_run->exit_reason = KVM_EXIT_UNKNOWN;   // Clear exit_reason from the preceding ioctl
    vcpu->regs_valid = 0;                            // Invalidate cached registers
    vcpu->sregs_valid = 0;
    km_infox(KM_TRACE_VCPU, "about to ioctl( KVM_RUN )");
    errno = 0;
+   vcpu->state = IN_GUEST;
    rc = ioctl(vcpu->kvm_vcpu_fd, KVM_RUN, NULL);
-   int ioctl_errno = errno;
    vcpu->state = HYPERCALL;
+   int ioctl_errno = errno;
    km_infox(KM_TRACE_VCPU,
             "ioctl( KVM_RUN ) returned %d KVM_RUN exit %d (%s)",
             rc,


### PR DESCRIPTION
We've been seeing this failure in the gdb_netstep test lately.
# 09:07:59.624655 km_gdb_set_thread_vc 1648 memchec Assertion `vcpu->state != IN_GUEST' failed: No such file or directory

The only recent change "seemingly" related to this was a change where we save the value of errno for use later in km_vcpu_one_kvm_run(). That change shifted the setting of state to IN_GUEST one statement further away from the ioctl( KVM_RUN ) call.

This change is more an experiment to see if it "helps" fix the assertion failure.  If it does "fix" the problem, we will know there is a race here that we've only made less likely but probably not fixed.