### PR TITLE
Change sendmsg_test to use assigned port numbers

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1867,7 +1867,10 @@ EOF
 }
 
 @test "sendmsg_test($test_type): test sendmsg like syscalls (sendmsg_test$ext)" {
-   km_with_timeout sendmsg_test$ext
+   # This test uses 2 ports, so the next free port would be 35.
+   local port_id=33
+   local socket_port=$(($port_range_start + $port_id))
+   km_with_timeout --putenv=PORT=$socket_port sendmsg_test$ext
    assert_success
 }
 

--- a/tests/sendmsg_test.c
+++ b/tests/sendmsg_test.c
@@ -105,9 +105,21 @@ int main(int argc, char* argv[])
 {
    struct addrinfo* ar;
    int err;
+   char* port = getenv("PORT");
+   int portn = 7777;
+   if (port != NULL) {
+      portn = atoi(port);
+      printf("Using port %d from the PORT environment variable\n", portn);
+   } else {
+      printf("Using default port %d\n", portn);
+   }
+   char port1[16];
+   char port2[16];
+   snprintf(port1, sizeof(port1), "%d", portn);
+   snprintf(port2, sizeof(port1), "%d", portn + 1);
 
-   if ((err = getaddrinfo("127.0.0.1", "7777", NULL, &ar)) != 0) {
-      fprintf(stderr, "ERROR: getaddrinfo 127.0.0.1:7777 failed:%s\n", gai_strerror(err));
+   if ((err = getaddrinfo("127.0.0.1", port1, NULL, &ar)) != 0) {
+      fprintf(stderr, "ERROR: getaddrinfo 127.0.0.1:%s failed:%s\n", port1, gai_strerror(err));
       if (err == EAI_SYSTEM) {
          perror("getaddrinfo");
       }
@@ -117,8 +129,8 @@ int main(int argc, char* argv[])
    sendaddrlen = ar[0].ai_addrlen;
    freeaddrinfo(ar);
 
-   if ((err = getaddrinfo("127.0.0.1", "7778", NULL, &ar)) != 0) {
-      fprintf(stderr, "ERROR: getaddrinfo 127.0.0.1:7778 failed:%s\n", gai_strerror(err));
+   if ((err = getaddrinfo("127.0.0.1", port2, NULL, &ar)) != 0) {
+      fprintf(stderr, "ERROR: getaddrinfo 127.0.0.1:%s failed:%s\n", port2, gai_strerror(err));
       if (err == EAI_SYSTEM) {
          perror("getaddrinfo");
       }


### PR DESCRIPTION
It is currently using 2 fixed port numbers which can cause EADDRINUSE errors sometimes.
Chnaged sendmsg_test to use port numbers assigned it by the bats test script.