### PR TITLE
Change bats sendmsg test to stop using --putenv

### DIFF
--- a/tests/km_core_tests.bats
+++ b/tests/km_core_tests.bats
@@ -1870,7 +1870,7 @@ EOF
    # This test uses 2 ports, so the next free port would be 35.
    local port_id=33
    local socket_port=$(($port_range_start + $port_id))
-   km_with_timeout --putenv=PORT=$socket_port sendmsg_test$ext
+   km_with_timeout sendmsg_test$ext $socket_port
    assert_success
 }
 

--- a/tests/sendmsg_test.c
+++ b/tests/sendmsg_test.c
@@ -105,7 +105,7 @@ int main(int argc, char* argv[])
 {
    struct addrinfo* ar;
    int err;
-   char* port = getenv("PORT");
+   char* port = (argc >= 2) ? argv[1] : NULL;
    int portn = 7777;
    if (port != NULL) {
       portn = atoi(port);


### PR DESCRIPTION
Valgrind doesn't let us use the --putenv argument to km which the fix to sendmsg test was using.
Changed the sendmsg test to pass the port number in as the first argument.