### PR TITLE
fix gdb backtrace with glibc

### DIFF
--- a/km/Makefile
+++ b/km/Makefile
@@ -46,3 +46,5 @@ include ${TOP}/make/actions.mk
 
 coverage: all
 
+all:
+	cp ${KM_BLDDIR}/km_guest_asmcode.o ${KM_OPT_BIN_PATH}

--- a/km/km_guest_asmcode.s
+++ b/km/km_guest_asmcode.s
@@ -45,8 +45,11 @@ __km_handle_interrupt:
     .global __km_handle_interrupt
     .cfi_startproc
     push %rdx
+    .cfi_def_cfa rsp, 8
     push %rbx
+    .cfi_def_cfa rsp, 16
     push %rax
+    .cfi_def_cfa rsp, 24
     mov $0xdeadbeef, %rbx
     mov %rsp, %gs:0         # KM Setup km_hc_args_t on stack for us to use
     mov $0x81fd, %dx        # HC_guest_interrupt
@@ -161,12 +164,19 @@ __km_syscall_handler:
     .cfi_register %rip, %rcx  # old %rip is in %rcx
     // create a km_hcall_t on the stack.
     push %r9    # arg6
+    .cfi_def_cfa rsp, 8
     push %r8    # arg5
+    .cfi_def_cfa rsp, 16
     push %r10   # arg4
+    .cfi_def_cfa rsp, 24
     push %rdx   # arg3
+    .cfi_def_cfa rsp, 32
     push %rsi   # arg2
+    .cfi_def_cfa rsp, 40
     push %rdi   # arg1
+    .cfi_def_cfa rsp, 48
     push %rax   # hc_ret - don't care about value. %rax is convienent.
+    .cfi_def_cfa rsp, 56
     mov %rsp,%gs:0  # set this thread's hcargs pointer
 
     mov %ax, %dx     # Do the KM HCall
@@ -176,10 +186,13 @@ __km_syscall_handler:
     mov hc_arg3(%rsp), %rdx  # restore rdx
     mov hc_ret(%rsp), %rax   # Get return code into RAX
     add $HCARG_SIZE, %rsp    # Restore stack
+    .cfi_def_cfa rsp, 8
 
     andq $0x3C7FD7, %r11    # restore the flag register
     push %r11
+    .cfi_def_cfa rsp, 8
     popfq
+    .cfi_def_cfa rsp, 0
 
     /*
      * SYSCALL saved address of the next instruction in %rcx.

--- a/km/km_hcalls.c
+++ b/km/km_hcalls.c
@@ -2384,6 +2384,12 @@ static km_hc_ret_t io_destroy_hcall(void* vcpu, int hc, km_hc_args_t* arg)
    return HC_CONTINUE;
 }
 
+static km_hc_ret_t rseq_hcall(void* vcpu, int hc, km_hc_args_t* arg)
+{
+   arg->hc_ret = -ENOSYS;
+   return HC_CONTINUE;
+}
+
 /*
  * int syscall(SYS_io_getevents, aio_context_t ctx_id,
  *             long min_nr, long nr, struct io_event *events,
@@ -2614,6 +2620,8 @@ const km_hcall_fn_t km_hcalls_table[KM_MAX_HCALL] = {
     [SYS_io_cancel] = io_cancel_hcall,
     [SYS_io_getevents] = io_getevents_hcall,
     [SYS_io_destroy] = io_destroy_hcall,
+
+    [SYS_rseq] = rseq_hcall,
 
     [HC_guest_interrupt] = guest_interrupt_hcall,
     [HC_unmapself] = unmapself_hcall,

--- a/make/images.mk
+++ b/make/images.mk
@@ -102,6 +102,7 @@ define testenv_prep =
 			build/opt/kontain/runtime/libpthread.so \
 			build/opt/kontain/bin/km \
 			build/opt/kontain/bin/km_cli \
+			build/opt/kontain/bin/km_guest_asmcode.o \
 			km \
 			include \
 
@@ -128,6 +129,7 @@ define coverage_testenv_prep =
 			build/opt/kontain/runtime/libpthread.so \
 			build/opt/kontain/coverage/bin/km \
 			build/opt/kontain/coverage/bin/km_cli \
+			build/opt/kontain/bin/km_guest_asmcode.o \
 			build/km/coverage \
 			km \
 			include \
@@ -155,6 +157,7 @@ define valgrind_testenv_prep =
 			build/opt/kontain/runtime/libpthread.so \
 			build/opt/kontain/valgrind/bin/km \
 			build/opt/kontain/valgrind/bin/km_cli \
+			build/opt/kontain/bin/km_guest_asmcode.o \
 			build/km/valgrind \
 			km \
 			include \
@@ -363,7 +366,7 @@ test-all-withdocker: ## a special helper to run more node.km tests.
 	${DOCKER_RUN_TEST} ${TEST_IMG_TAGGED} ${CONTAINER_TEST_ALL_CMD}
 
 test-valgrind-withdocker:
-	${DOCKER_RUN_TEST} --ulimit nofile=262144:262144 ${VALGRIND_TEST_IMG_TAGGED} ${CONTAINER_VARGRIND_TEST_CMD}
+	${DOCKER_RUN_TEST} ${VALGRIND_TEST_IMG_TAGGED} ${CONTAINER_VARGRIND_TEST_CMD}
 
 test-coverage-withdocker: ## Run tests in local Docker. IMAGE_VERSION (i.e. tag) needs to be passed in
 	mkdir -p ${COVERAGE_KM_BLDDIR}

--- a/make/locations.mk
+++ b/make/locations.mk
@@ -115,7 +115,7 @@ DOCKER_INTERACTIVE ?= -it
 
 RUNTIME ?= krun
 DOCKER_KRUN_RUNTIME = --runtime ${RUNTIME}
-DOCKER_RUN := docker run --sysctl net.ipv4.ip_unprivileged_port_start=1024 ${DOCKER_RUN_CLEANUP}
+DOCKER_RUN := docker run --sysctl net.ipv4.ip_unprivileged_port_start=1024 --ulimit nofile=262144:262144 ${DOCKER_RUN_CLEANUP}
 # DOCKER_RUN_BUILD are used for building and other operations that requires
 # output of files to volumes. When we need to write files to the volumes mapped
 # in, we need to map the current used into the container, since containers are


### PR DESCRIPTION
Added cfi directives, enabled tests in bats.

In order for this to work need to do

> --ex="add-symbol-file ../build/km/km_guest_asmcode.o -o 0x8000008000"