### PR TITLE
Fix poll() and ppoll() hypercalls to detect snapshot'ed network socket errors

### DIFF
--- a/km/km_filesys.h
+++ b/km/km_filesys.h
@@ -290,6 +290,14 @@ uint64_t km_fs_select(km_vcpu_t* vcpu,
                       struct timeval* timeout);
 // int poll(struct pollfd *fds, nfds_t nfds, int timeout);
 uint64_t km_fs_poll(km_vcpu_t* vcpu, struct pollfd* fds, nfds_t nfds, int timeout);
+// int syscall(SYS_ppoll, struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const
+// sigset_t *sigmask, size_t sigsetsize);
+uint64_t km_fs_ppoll(km_vcpu_t* vcpu,
+                     struct pollfd* fds,
+                     nfds_t nfds,
+                     struct timespec* tmo_p,
+                     sigset_t* sigmask,
+                     size_t sigsetsize);
 // int epoll_create1(int flags);
 uint64_t km_fs_epoll_create1(km_vcpu_t* vcpu, int flags);
 // int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event);

--- a/tests/ppoll_test.c
+++ b/tests/ppoll_test.c
@@ -1,0 +1,50 @@
+#include <errno.h>
+#include <poll.h>   // _GNU_SOURCE must be defined to get ppoll()
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+enum pipedir { readside = 0, writeside = 1 };
+
+int main(int argc, char* argv[])
+{
+   int pipefd[2];
+
+   if (pipe(pipefd) < 0) {
+      fprintf(stderr, "pipe() failed, %s\n", strerror(errno));
+      return 1;
+   }
+
+   struct timespec ts = {0, 1000};   // 1 microsecond
+   struct pollfd fdlist[] = {{pipefd[readside], POLLIN, 0}};
+   int rc;
+
+   // ppoll() when the pipe is empty, should timeout
+   if ((rc = ppoll(fdlist, 1, &ts, NULL)) != 0) {
+      fprintf(stderr, "ppoll() with empty pipe should timeout and return 0, got %d\n", rc);
+      return 1;
+   }
+
+   // put something in the pipe
+   char buf[32];
+   memset(buf, 22, sizeof(buf));
+   ssize_t bw = write(pipefd[writeside], buf, sizeof(buf));
+   if (bw != sizeof(buf)) {
+      fprintf(stderr, "write to pipe should have returned %lu, actually returned %ld\n", sizeof(buf), bw);
+      return 1;
+   }
+
+   // ppoll() on pipe with something in it should return 1 for this test.
+   if ((rc = ppoll(fdlist, 1, &ts, NULL)) != 1) {
+      fprintf(stderr, "ppoll() on pipe with data should return 1, got %d\n", rc);
+      return 1;
+   }
+
+   fprintf(stdout, "simple test of ppoll() passed\n");
+
+   close(pipefd[writeside]);
+   close(pipefd[readside]);
+
+   return 0;
+}


### PR DESCRIPTION

km_fs_poll() was using the incorrect value for the fd when checking for disconnected connections in a resumed snapshot().  This would cause an incorrect error to be returned.

Also added a fix to ppoll() where a NULL fds pointer should be allowed under some conditions.  This change is from some arm work Srini is doing.

This also adds the ppoll() hypercall to km and a simple ppoll test program.

We don't necessarily need to merge this.  The goal is to avoid losing this change which was fixed in another repository derived from the open source repository.